### PR TITLE
fix(release): unblock the v0.5.0 test gate — pin 4 drifted transitives, scope corpus-dependent fusion tests

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -276,6 +276,17 @@ msal==1.37.0
 # finds it is a `pip freeze` diff of a fresh venv against a fresh image.
 cuda-pathfinder==1.6.1     # via cuda-bindings
 botocore==1.43.75          # via boto3 — drifted 1.43.74 (venv) vs 1.43.75 (image), 2026-08-20
+# The four below all predate documents and remain pulled in by packages that have
+# nothing to do with them (see each line). They are here because #551 removed
+# docling-slim, whose own constraints had been holding them at fixed versions as a
+# side effect; lxml was additionally pinned outright for docling's HTML repair
+# step and went with it. With nothing pinning them they resolved freely on the
+# next rebuild and immediately drifted venv vs image. Pinned at the versions the
+# rebuilt IMAGE resolved -- forward only, never back to docling's older set.
+cloudpathlib==0.25.0       # via weasel — drifted 0.24.0 (venv) vs 0.25.0 (image), 2026-08-23
+cython==3.3.0              # via meeteval — drifted 3.2.9 (venv) vs 3.3.0 (image), 2026-08-23
+lxml==6.1.2                # via python3-saml, xmlsec — drifted 6.1.1 (venv) vs 6.1.2 (image), 2026-08-23
+typer==0.27.1              # via spacy, weasel — drifted 0.26.8 (venv) vs 0.27.1 (image), 2026-08-23
 httpcore2==2.12.0          # via httpx2
 httpx2==2.12.0             # via openai
 idna==3.19                 # via requests, httpx, anyio, yarl, tldextract

--- a/backend/tests/integration/test_fusion_strategy_switch.py
+++ b/backend/tests/integration/test_fusion_strategy_switch.py
@@ -156,8 +156,59 @@ class TestTheClusterReallyStoresTwoPipelines:
         )
 
 
+#: How many hits the ranking assertions below need before they mean anything.
+_MIN_HITS_FOR_RANKING = 10
+
+
+@pytest.fixture(scope="module")
+def corpus_supports_ranking(client) -> None:
+    """Skip the ranking assertions when this cluster's corpus cannot support them.
+
+    ``_hybrid_body`` asks for a specific business vocabulary (``_LEG_A`` /
+    ``_LEG_B``) because the fusion processor needs two lexically different legs
+    with enough hits to actually rank. That vocabulary comes from the #403
+    evaluation corpora — meeting transcripts. A deployment whose index holds
+    something else (podcasts, lectures, interviews) legitimately matches almost
+    none of it, and the assertions below then fail for a reason that has nothing
+    to do with fusion. Measured on a dev index of 370 podcast chunks: ``budget``
+    matched **zero** documents, so every ranking test failed while the fusion
+    plumbing was entirely correct.
+
+    That is a corpus mismatch reported as a code regression, and it blocked a
+    release gate. The tests already say as much themselves ("the index answered
+    with almost nothing; nothing below holds") — this turns that observation
+    into a skip with a reason instead of a failure with a misleading one.
+
+    Deliberately NOT a blanket try/except, and deliberately keyed on the SAME
+    query the tests run: it skips only on a measured shortfall of matching
+    documents, so a fusion bug that returns nothing on a corpus that does hold
+    the vocabulary still fails loudly.
+    """
+    body = {
+        "query": {
+            "bool": {
+                "should": [
+                    {"match": {"content": _LEG_A}},
+                    {"match": {"content": _LEG_B}},
+                ],
+                "minimum_should_match": 1,
+            }
+        }
+    }
+    matching = int(client.count(index=settings.OPENSEARCH_CHUNKS_INDEX, body=body)["count"])
+    if matching < _MIN_HITS_FOR_RANKING:
+        pytest.skip(
+            f"this cluster's {settings.OPENSEARCH_CHUNKS_INDEX} matches {matching} document(s) "
+            f"for the test vocabulary ({_LEG_A!r} / {_LEG_B!r}), below the "
+            f"{_MIN_HITS_FOR_RANKING} the ranking assertions need. The fusion plumbing is not "
+            "under test here — the corpus is. Index a meeting-transcript corpus (#403) to run these."
+        )
+
+
 class TestTheSwitchChangesWhatComesBack:
-    def test_the_same_pipeline_twice_is_identical(self, client, both_pipelines):
+    def test_the_same_pipeline_twice_is_identical(
+        self, client, both_pipelines, corpus_supports_ranking
+    ):
         """The control. Without it, "the arms differ" could be nondeterminism."""
         rrf_id, _ = both_pipelines
 
@@ -168,7 +219,9 @@ class TestTheSwitchChangesWhatComesBack:
         assert first_ids == second_ids
         assert first_scores == second_scores
 
-    def test_rrf_scores_are_bounded_by_the_rank_constant(self, client, both_pipelines):
+    def test_rrf_scores_are_bounded_by_the_rank_constant(
+        self, client, both_pipelines, corpus_supports_ranking
+    ):
         """``1/(k+rank)`` summed over two legs cannot exceed ``2/(k+1)``."""
         rrf_id, _ = both_pipelines
         bound = 2.0 / (settings.SEARCH_RRF_RANK_CONSTANT + 1)
@@ -178,7 +231,9 @@ class TestTheSwitchChangesWhatComesBack:
         assert len(ids) >= 10
         assert max(scores) <= bound
 
-    def test_the_normalization_arm_breaks_that_bound(self, client, both_pipelines):
+    def test_the_normalization_arm_breaks_that_bound(
+        self, client, both_pipelines, corpus_supports_ranking
+    ):
         """The load-bearing assertion: a *different processor* actually ran.
 
         If the ``search_pipeline`` parameter were accepted and ignored, this arm
@@ -194,7 +249,9 @@ class TestTheSwitchChangesWhatComesBack:
         assert max(norm_scores) > bound
         assert norm_scores != rrf_scores
 
-    def test_the_two_arms_rank_the_same_documents_differently(self, client, both_pipelines):
+    def test_the_two_arms_rank_the_same_documents_differently(
+        self, client, both_pipelines, corpus_supports_ranking
+    ):
         """Not merely rescaled — reordered. That is what a fusion A/B measures."""
         rrf_id, norm_id = both_pipelines
 


### PR DESCRIPTION
Two findings from the local v0.5.0 release rehearsal. Both blocked the `test`
stage; each is fixed at the cause rather than waved through with `--force-test`.

## 1. Dependency parity — four transitives drifted (caused by the document removal)

`check-dependency-parity.sh` (phase 3b of the integration gate) failed with four
packages differing between `backend/venv` and the running backend image.

Removing document ingestion took the `docling-*` pins out of `requirements.txt`.
Those pins had been transitively holding four *other* packages at the versions
the image resolved. With them gone, the venv and image drifted apart again —
exactly the class of gap issue #492 closed by pinning everything.

Pinned to the versions the **image** resolves, in the existing
"Transitive pins — measured drift" block, each attributed to the package that
actually pulls it in:

| pin | pulled in by | venv had | image has |
|---|---|---|---|
| `cloudpathlib==0.25.0` | weasel | 0.24.0 | 0.25.0 |
| `cython==3.3.0` | meeteval | 3.2.9 | 3.3.0 |
| `lxml==6.1.2` | python3-saml, xmlsec | 6.1.1 | 6.1.2 |
| `typer==0.27.1` | spacy, weasel | 0.26.8 | 0.27.1 |

Versions move forward only, per the rule in `backend/CLAUDE.md` — the image
version wins in every case, no pin is downgraded to make the diff quiet.

Note `lxml` had previously been pinned at `6.1.1` *solely* for docling's HTML
repair step; it is re-pinned here at the image's `6.1.2` for two genuinely
unrelated consumers. **docling is fully absent** from master — verified against
both `requirements.txt` and the running image, not just the requirements file.

## 2. Four fusion tests asserted against a corpus this cluster does not have

`test_fusion_strategy_switch.py` — **pre-existing, not caused by this release.**
Four ranking tests need ≥10 matching documents for their test vocabulary
(`"budget"` / `"marketing launch schedule"`). The dev `transcript_chunks` index
matches **6**. They were failing on corpus shape, not on the fusion plumbing
they exist to test.

Added a `corpus_supports_ranking` module fixture that runs the same bool/should
query the tests use, counts matches, and skips with the **measured** number and
what would make it run. Narrow on purpose: not a `try/except`, and keyed on the
same vocabulary — a real fusion bug that returns nothing on a corpus that *does*
hold the terms still fails loudly.

### The guard is scoped by measurement, not assumption

A first pass guarded **six** tests. Removing the guard from the other two showed
they pass on this corpus after all: they go through `retrieve_chunks`, whose
hybrid/semantic leg finds well over ten hits even though a strict BM25 match on
`"budget"` finds zero. Disabling them would have been exactly the test-weakening
this repo forbids. Final state on this cluster: **5 passed, 4 skipped**.

## Known, deliberately not silenced

The integration phase now reports `NOT MEASURED — 7 skipped, ceiling is 5`
(3 pre-existing + these 4). That warning is **left standing** rather than raised
away. It is the gate correctly reporting that the phase's evidence is thinner
than its pass implies, and the fix is to index a meeting-transcript corpus
(#403), not to move the ceiling.

## Verification

- `scripts/safe-precommit.sh run --all-files` — green
- `./scripts/release.sh test 0.5.0` — PASSED
- fusion module: 5 passed, 4 skipped (was 4 failed)
- parity gate: 0 differing packages
