### PR TITLE
fix(release-tests): clean up leftover volumes between stage-3 legs, not just containers

### DIFF
--- a/backend/tests/unit/test_test_matrix_stage3_sequencing.py
+++ b/backend/tests/unit/test_test_matrix_stage3_sequencing.py
@@ -108,7 +108,10 @@ def _stage3_fixture(tmp_path: Path) -> tuple[Path, Path, Path]:
     # the test can prove test-upgrade.sh's cleanup is what actually clears the state).
     _write_stub(
         fake_repo / "scripts" / "release-tests" / "test-lite-mode.sh",
-        f'if [ "$1" = "--cleanup" ]; then exit 0; fi\ntouch "{marker_dir}/leg3lite.ran"\nexit 0\n',
+        f'if [ "$1" = "--cleanup" ]; then '
+        f'echo "${{OT_RELEASE_TEST_RESET_VOLUMES:-<unset>}}" > "{marker_dir}/lite-mode.reset-volumes"; '
+        f"exit 0; fi\n"
+        f'touch "{marker_dir}/leg3lite.ran"\nexit 0\n',
     )
 
     # Leg "3-pki": scripts/pki/run-pki-e2e-leg.sh --yes
@@ -117,11 +120,21 @@ def _stage3_fixture(tmp_path: Path) -> tuple[Path, Path, Path]:
         f'touch "{marker_dir}/leg3pki.ran"\nexit 0\n',
     )
 
-    # Cleanup-only targets the precondition calls for any leg OTHER than "3".
-    _write_stub(fake_repo / "scripts" / "release-tests" / "test-fresh-install.sh", "exit 0\n")
+    # Cleanup-only targets the precondition calls for any leg OTHER than "3". Each also
+    # records the OT_RELEASE_TEST_RESET_VOLUMES value it was invoked with, so a sibling test
+    # can prove test-matrix.sh actually requests a volume reset on these calls — not just a
+    # container teardown — per the fix in this commit.
+    _write_stub(
+        fake_repo / "scripts" / "release-tests" / "test-fresh-install.sh",
+        f'if [ "$1" = "--cleanup" ]; then '
+        f'echo "${{OT_RELEASE_TEST_RESET_VOLUMES:-<unset>}}" > "{marker_dir}/fresh-install.reset-volumes"; '
+        f"fi\nexit 0\n",
+    )
     _write_stub(
         fake_repo / "scripts" / "release-tests" / "test-upgrade.sh",
-        f'if [ "$1" = "--cleanup" ]; then rm -f "{state_file}"; fi\nexit 0\n',
+        f'if [ "$1" = "--cleanup" ]; then rm -f "{state_file}"; '
+        f'echo "${{OT_RELEASE_TEST_RESET_VOLUMES:-<unset>}}" > "{marker_dir}/upgrade.reset-volumes"; '
+        f"fi\nexit 0\n",
     )
 
     return fake_repo, marker_dir, state_file
@@ -188,6 +201,37 @@ def test_all_three_stage3_legs_run_in_one_invocation(tmp_path: Path) -> None:
     assert not state_file.exists(), (
         "the leftover release-test stack should have been cleared before 3-lite/3-pki ran"
     )
+
+
+@pytest.mark.unit
+def test_inter_leg_cleanup_requests_a_volume_reset(tmp_path: Path) -> None:
+    """The inter-leg cleanup must clear VOLUMES, not just containers (issue: 3-lite/3-pki
+    inherited leg 3's stock-named opentranscribe_* volumes and failed their own fresh-install
+    guardrail with "pre-existing stock volumes found").
+
+    lib/guardrails.sh's gr_cleanup only removes a stale stock volume through the
+    live-marker-verified gr_check_stale_stock_volumes path, and only when the caller sets
+    OT_RELEASE_TEST_RESET_VOLUMES=1 — a plain `--cleanup` a human runs by hand must not
+    suddenly start dying/removing volumes it was never asked to touch. So the fix must be in
+    test-matrix.sh: it has to set that variable on the SPECIFIC inter-leg cleanup calls this
+    precondition makes, not leave it to be set by hand. Each stub script here records the value
+    of OT_RELEASE_TEST_RESET_VOLUMES it was invoked with when called with `--cleanup`, without
+    needing a real `docker volume` — proving the CALLER passed the opt-in, which is all
+    test-matrix.sh is responsible for.
+    """
+    fake_repo, marker_dir, state_file = _stage3_fixture(tmp_path)
+
+    out = _run_stage3(fake_repo, state_file)
+
+    for name in ("fresh-install", "upgrade", "lite-mode"):
+        marker = marker_dir / f"{name}.reset-volumes"
+        assert marker.exists(), (
+            f"{name}.sh --cleanup was never invoked by the inter-leg cleanup pass:\n{out}"
+        )
+        assert marker.read_text().strip() == "1", (
+            f"{name}.sh --cleanup ran without OT_RELEASE_TEST_RESET_VOLUMES=1 — leg 3's "
+            f"stock-named volumes will survive into the next stage-3 leg:\n{out}"
+        )
 
 
 @pytest.mark.unit

--- a/scripts/release-tests/lib/guardrails.sh
+++ b/scripts/release-tests/lib/guardrails.sh
@@ -314,6 +314,22 @@ gr_cleanup() {
     # install silently inherits it (issue #408).
     gr_cleanup_owned_stock_resources
 
+    # 3c. Opt-in reset of stale stock-named volumes left by an EARLIER run this
+    # one does not own (gr_cleanup_owned_stock_resources deliberately leaves
+    # those alone — "leaving $vol alone — it existed before this run" — which is
+    # correct in general but is exactly what let leg "3"'s stock volumes survive
+    # into "3-lite"/"3-pki": those legs' own --cleanup calls could stop leg "3"'s
+    # containers but not remove volumes leg "3" never recorded owning, so the very
+    # next fresh-install's preflight found the previous run's Postgres credentials
+    # still there and refused. This reuses gr_check_stale_stock_volumes — the same
+    # live-marker-verified removal gr_preflight already runs — rather than a raw
+    # `docker volume rm`, and only fires when the caller explicitly opts in via
+    # OT_RELEASE_TEST_RESET_VOLUMES=1 (test-matrix.sh's inter-leg cleanup does this;
+    # a plain `--cleanup` a human runs by hand is unaffected).
+    if [[ "${OT_RELEASE_TEST_RESET_VOLUMES:-}" == "1" ]]; then
+        gr_check_stale_stock_volumes
+    fi
+
     # 4. Remove TEST_ROOT contents — but only if TEST_ROOT is still within the allowed area
     if [[ -n "${TEST_ROOT:-}" && -d "$TEST_ROOT" ]]; then
         local resolved

--- a/scripts/test-matrix.sh
+++ b/scripts/test-matrix.sh
@@ -236,9 +236,18 @@ check_stage3_precondition() {
         # something that might not be this stage's to touch.
         if [[ "$id" != "3" ]]; then
             info "  clearing a leftover release-test stack from an earlier stage-3 leg..."
-            ./scripts/release-tests/test-fresh-install.sh --cleanup --yes >/dev/null 2>&1 || true
-            ./scripts/release-tests/test-upgrade.sh --cleanup --yes >/dev/null 2>&1 || true
-            ./scripts/release-tests/test-lite-mode.sh --cleanup --yes >/dev/null 2>&1 || true
+            # OT_RELEASE_TEST_RESET_VOLUMES=1 makes --cleanup also remove stale
+            # opentranscribe_* stock volumes (lib/guardrails.sh's gr_cleanup, opt-in
+            # step 3c) — not just containers. Without it, leg "3"'s named volumes
+            # (owned by leg "3"'s own run, not this cleanup pass) survive every
+            # --cleanup call here, and the next fresh-install leg ("3-lite"/"3-pki")
+            # inherits leg "3"'s database credentials and fails its own preflight
+            # ("A fresh-install test against these is NOT a fresh install"). This is
+            # the same live-marker-verified removal gr_preflight already runs on a
+            # standalone invocation, never a raw `docker volume rm`.
+            OT_RELEASE_TEST_RESET_VOLUMES=1 ./scripts/release-tests/test-fresh-install.sh --cleanup --yes >/dev/null 2>&1 || true
+            OT_RELEASE_TEST_RESET_VOLUMES=1 ./scripts/release-tests/test-upgrade.sh --cleanup --yes >/dev/null 2>&1 || true
+            OT_RELEASE_TEST_RESET_VOLUMES=1 ./scripts/release-tests/test-lite-mode.sh --cleanup --yes >/dev/null 2>&1 || true
             for _ in $(seq 1 30); do
                 service_reachable localhost 5174 || break
                 sleep 2


### PR DESCRIPTION
## Problem

Commit 0fcc03e6 (merged to `master` in #643) made `test-matrix.sh`'s
`check_stage3_precondition()` clear a leftover release-test stack's
**containers** between stage-3 legs (`test-fresh-install.sh` /
`test-upgrade.sh` / `test-lite-mode.sh --cleanup --yes`), since leg `3`
(Scenario B / `test-upgrade.sh`) deliberately leaves its stack running "for
inspection". That container cleanup works — confirmed on a real
`test-matrix.sh all --yes` run on 2026-08-31 (`✓ no live opentranscribe-*
containers running`) — but the stock-named **volumes**
(`opentranscribe_postgres_data` etc.) survive it and poison the very next
fresh-install leg:

```
[guardrails] ⚠ pre-existing stock volumes found:
           opentranscribe_postgres_data
           opentranscribe_minio_data
           ...
[guardrails] ✗ FATAL: Re-run with OT_RELEASE_TEST_RESET_VOLUMES=1 to remove them ...
```

Root cause: `gr_cleanup()`'s step 3b (`gr_cleanup_owned_stock_resources`)
only removes volumes the CALLING run's own ownership stamp recorded as
newly created — it deliberately leaves any volume that already existed
before that run's own preflight alone. A volume born from leg `3` (or an
earlier manual run) is therefore untouchable by every subsequent
`--cleanup` call, so it survives into `3-lite`, which then correctly
refuses ("A fresh-install test against these is NOT a fresh install").

The guardrail message itself points at the fix
(`OT_RELEASE_TEST_RESET_VOLUMES=1`), but that variable only gated
`gr_check_stale_stock_volumes()`, which is called from `gr_preflight()` (the
start of a normal scenario run) and never from `gr_cleanup()` (the
`--cleanup` path the inter-leg pass actually uses) — so setting it had no
effect there.

## Fix

- `scripts/release-tests/lib/guardrails.sh`: `gr_cleanup()` gains an opt-in
  step 3c that calls the existing, live-marker-verified
  `gr_check_stale_stock_volumes()` — never a raw `docker volume rm` — when
  `OT_RELEASE_TEST_RESET_VOLUMES=1` is set. A plain `--cleanup` a human runs
  by hand is unaffected (the var stays unset, so nothing about standalone
  behavior changed).
- `scripts/test-matrix.sh`: the inter-leg cleanup pass now sets
  `OT_RELEASE_TEST_RESET_VOLUMES=1` on its three `--cleanup --yes` calls, so
  leg 3's stock volumes are actually removed (or, if genuinely
  live-marked, correctly refused) before `3-lite`/`3-pki` start.

## Verification

**Red-then-green (unit test):** extended
`backend/tests/unit/test_test_matrix_stage3_sequencing.py` (added by
0fcc03e6) with `test_inter_leg_cleanup_requests_a_volume_reset`, which
stubs the three leg scripts to record the `OT_RELEASE_TEST_RESET_VOLUMES`
value they were invoked with on `--cleanup`.
- Run against a `git archive HEAD` snapshot of the pre-fix `test-matrix.sh`:
  **fails** — `fresh-install.sh --cleanup ran without
  OT_RELEASE_TEST_RESET_VOLUMES=1`.
- Run against the fix: **passes**, along with the two pre-existing
  sequencing tests (3 passed).

**Manual end-to-end validation** of `gr_check_stale_stock_volumes()` against
disposable `ot-selftest-fakestock_*` volumes (never touching anything named
`opentranscribe_*`/`transcribe-app_*`):
- Without the env var: dies, volumes left alone.
- With `OT_RELEASE_TEST_RESET_VOLUMES=1`: all 5 removed.
- A volume carrying the `.opentranscribe-live-data` marker: refused even
  with the env var set (fail-closed, as designed).
- All disposable test volumes were removed afterward; nothing under the
  live `opentranscribe`/`transcribe-app` namespaces was touched.

**Lint/hooks:** `scripts/safe-precommit.sh run --files <touched paths>` —
all hooks pass (shellcheck, mypy, ruff, audit-tests, bandit, etc).

Not merging — opening for review per repo convention.