### PR TITLE
fix(frontend): remove self-inflicted seek stall on fresh page load (#645)

### DIFF
--- a/backend/app/services/chat/prompting.py
+++ b/backend/app/services/chat/prompting.py
@@ -120,6 +120,15 @@ _MAX_COMBINED_PROMPT_CHARS = 4000
 # Rough chars-per-token used only for budgeting the excerpt block.
 _CHARS_PER_TOKEN = 4
 
+# Safety margin (in tokens) subtracted on top of `response_tokens` before converting to a
+# char budget. `_CHARS_PER_TOKEN` is an estimate, not the provider's real tokenizer — a
+# transcript with timestamps/speaker labels tokenizes denser than plain prose, and a live
+# 400 from vLLM showed the estimate landing 1 token over a 60000-token model limit with no
+# margin at all (issue #645). Kept small deliberately: small-context-window deployments
+# (this module's own tests exercise windows as low as 300 tokens) must not lose their whole
+# excerpt budget to an oversized fixed buffer.
+_CONTEXT_SAFETY_MARGIN_TOKENS = 50
+
 
 # Matches the opener of any HIGH-TRUST block tag, in any casing, with optional
 # whitespace — "<excerpt", "</overview", "< / SYNTHESIS". Used to defuse
@@ -761,7 +770,11 @@ def build_messages(
             messages.append({"role": role, "content": content})
 
     overhead = len(system_prompt) + sum(len(m["content"]) for m in messages[1:]) + len(question)
-    budget_chars = max(0, (context_window - response_tokens) * _CHARS_PER_TOKEN - overhead)
+    budget_chars = max(
+        0,
+        (context_window - response_tokens - _CONTEXT_SAFETY_MARGIN_TOKENS) * _CHARS_PER_TOKEN
+        - overhead,
+    )
     # Evidence blocks come off the TOP of the budget, not out of what is left
     # after the excerpts — each IS more authoritative than the excerpts beside
     # it (base rules 10 and 12), so losing one to fit one more speaker turn

--- a/frontend/src/components/PlyrMiniPlayer.svelte
+++ b/frontend/src/components/PlyrMiniPlayer.svelte
@@ -3,6 +3,7 @@
   import Plyr from 'plyr';
   import 'plyr/dist/plyr.css';
   import WaveformPlayer from '$components/WaveformPlayer.svelte';
+  import { waitForMediaMetadata, HAVE_METADATA } from '$lib/utils/mediaReady';
 
   export let mediaUrl: string;
   export let contentType: string;
@@ -121,31 +122,11 @@
     if (!player || !mediaElement) return;
     const media = mediaElement;
 
-    if (media.readyState < 1) {
-      await new Promise<void>((resolve) => {
-        const onReady = () => {
-          media.removeEventListener('loadedmetadata', onReady);
-          media.removeEventListener('canplay', onReady);
-          resolve();
-        };
-        media.addEventListener('loadedmetadata', onReady, { once: true });
-        media.addEventListener('canplay', onReady, { once: true });
-        if (media.readyState >= 1) {
-          media.removeEventListener('loadedmetadata', onReady);
-          media.removeEventListener('canplay', onReady);
-          resolve();
-          return;
-        }
-        // Timeout for very large files
-        setTimeout(() => {
-          media.removeEventListener('loadedmetadata', onReady);
-          media.removeEventListener('canplay', onReady);
-          resolve();
-        }, 15000);
-      });
-      // Brief delay so Plyr finishes its own metadata handlers (its setter bails
-      // on seek while duration is still 0).
-      await new Promise((r) => setTimeout(r, 150));
+    if (media.readyState < HAVE_METADATA) {
+      // Shared with VideoPlayer — see $lib/utils/mediaReady. The raw
+      // `media.currentTime` assignment below always lands even if Plyr's own
+      // setter bails, so no extra settling delay is needed here.
+      await waitForMediaMetadata(media);
     }
 
     if (!player) return;
@@ -241,7 +222,7 @@
     <!-- playsinline prevents iOS from forcing fullscreen on play -->
     <video
       bind:this={mediaElement}
-      preload="auto"
+      preload="metadata"
       playsinline
     >
       <source src={mediaUrl} />
@@ -250,7 +231,7 @@
     <!-- svelte-ignore a11y-media-has-caption -->
     <audio
       bind:this={mediaElement}
-      preload="auto"
+      preload="metadata"
     >
       <source src={mediaUrl} />
     </audio>

--- a/frontend/src/components/VideoPlayer.svelte
+++ b/frontend/src/components/VideoPlayer.svelte
@@ -6,6 +6,7 @@
   import { t } from '$stores/locale';
   import { translateSpeakerLabel } from '$lib/i18n';
   import { formatTimeWithMillis } from '$lib/utils/formatting';
+  import { applyMediaSeek, waitForMediaMetadata, HAVE_METADATA } from '$lib/utils/mediaReady';
   import Spinner from './ui/Spinner.svelte';
 
   export let videoUrl: string = '';
@@ -34,66 +35,63 @@
     dispatch('retry');
   }
 
+  // Monotonic id of the most recent seek request. A late-resolving wait belonging
+  // to a superseded seek must not overwrite the newer target.
+  let seekRequestId = 0;
+  let seekSpinnerTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function scheduleSpinnerFallback(ms: number) {
+    if (seekSpinnerTimer !== null) clearTimeout(seekSpinnerTimer);
+    seekSpinnerTimer = setTimeout(() => {
+      seekSpinnerTimer = null;
+      isSeeking = false;
+    }, ms);
+  }
+
   // External seek function for waveform and transcript clicks
   export async function seekToTime(time: number) {
     if (!player) {
       return;
     }
 
-    // Show seeking spinner immediately
-    isSeeking = true;
-
+    const requestId = ++seekRequestId;
     const media = (player as any).media as HTMLMediaElement | undefined;
 
-    // For large files (especially audio), the media may not have metadata loaded yet
-    // when this is called from the ?t= parameter handler on page load.
-    // Wait for loadedmetadata before attempting to seek.
-    if (media && media.readyState < 1) {
-      await new Promise<void>((resolve) => {
-        const onReady = () => {
-          media.removeEventListener('loadedmetadata', onReady);
-          media.removeEventListener('canplay', onReady);
-          resolve();
-        };
-        media.addEventListener('loadedmetadata', onReady, { once: true });
-        media.addEventListener('canplay', onReady, { once: true });
-        // Check if already ready (race condition with event)
-        if (media.readyState >= 1) {
-          media.removeEventListener('loadedmetadata', onReady);
-          media.removeEventListener('canplay', onReady);
-          resolve();
-          return;
-        }
-        // Timeout for very large files (15s)
-        setTimeout(() => {
-          media.removeEventListener('loadedmetadata', onReady);
-          media.removeEventListener('canplay', onReady);
-          resolve();
-        }, 15000);
-      });
-      // Brief delay to let Plyr process its own metadata/ready handlers
-      // so its internal duration is valid (Plyr bails on seek if duration is 0)
-      await new Promise(r => setTimeout(r, 150));
-    }
+    // Show seeking spinner immediately, and keep it up until `seeked` fires
+    // rather than clearing it on a blind short timer.
+    isSeeking = true;
+    scheduleSpinnerFallback(30000);
 
-    // Update player time via Plyr
-    player.currentTime = time;
-    // Also set directly on the media element as fallback — Plyr's setter
-    // checks `if (!this.duration) return` which can bail if Plyr hasn't
-    // finished initializing its internal state yet
-    if (media) {
-      media.currentTime = time;
-    }
+    // Issue the seek to the media element FIRST, without waiting for metadata.
+    // Before `loadedmetadata` the assignment is not discarded — the element
+    // records it as the default playback start position, so the browser fetches
+    // the byte range for the target as soon as it has parsed the container
+    // index. The previous implementation awaited `loadedmetadata` (up to a
+    // hard-coded 15s) plus a fixed 150ms *before* touching the element, which
+    // added that entire wait to every seek issued during page load.
+    const appliedDirectly = media ? applyMediaSeek(media, time) : false;
+
     currentTime = time;
+    dispatch('timeupdate', { currentTime: time, duration });
 
-    // Dispatch the seek event to parent
-    dispatch('timeupdate', {
-      currentTime: time,
-      duration: duration
-    });
+    if (media && media.readyState < HAVE_METADATA) {
+      // Plyr's own `currentTime` setter bails while its duration is still 0, so
+      // its progress bar would stay at zero. Re-apply through Plyr once metadata
+      // lands — this only syncs the control UI, the seek itself already happened.
+      const ready = await waitForMediaMetadata(media);
+      if (requestId !== seekRequestId) return;
+      if (!ready && !appliedDirectly) {
+        // Metadata never arrived and the direct assignment failed; nothing more
+        // we can usefully do without guessing.
+        return;
+      }
+      if (!appliedDirectly) applyMediaSeek(media, time);
+    }
 
-    // Fallback: clear spinner if 'seeked' event never fires
-    setTimeout(() => { isSeeking = false; }, 5000);
+    // Keep Plyr's internal clock in sync (progress bar, time readout).
+    if (Math.abs((player.currentTime ?? 0) - time) > 0.05) {
+      player.currentTime = time;
+    }
   }
 
   // External function to update subtitles when transcript becomes available or is edited
@@ -271,8 +269,21 @@
         dispatch('seeking');
       });
       newPlayer.on('seeked', () => {
+        if (seekSpinnerTimer !== null) {
+          clearTimeout(seekSpinnerTimer);
+          seekSpinnerTimer = null;
+        }
         isSeeking = false;
         dispatch('seeked');
+      });
+      // A media error while seeking would otherwise leave the spinner up until
+      // the fallback timer.
+      newPlayer.on('error', () => {
+        if (seekSpinnerTimer !== null) {
+          clearTimeout(seekSpinnerTimer);
+          seekSpinnerTimer = null;
+        }
+        isSeeking = false;
       });
 
     } catch (error) {
@@ -386,7 +397,7 @@
       <audio
         bind:this={mediaElement}
         id="player"
-        preload="auto"
+        preload="metadata"
         playsinline
       >
         <source src={videoUrl} type={file.content_type} />
@@ -398,7 +409,7 @@
       <video
         bind:this={mediaElement}
         id="player"
-        preload="auto"
+        preload="metadata"
         playsinline
       >
         <source src={videoUrl} type={file?.content_type || 'video/mp4'} />

--- a/frontend/src/components/WaveformPlayer.svelte
+++ b/frontend/src/components/WaveformPlayer.svelte
@@ -208,9 +208,15 @@
   }
 
   /**
-   * Handle click/seek on waveform
+   * A real mouse click fires mousedown AND click, and both used to seek — so
+   * every click on the waveform issued two identical seeks to the media element.
+   * `handleMouseDown` claims the interaction and sets this flag so the trailing
+   * `click` is a no-op. The `on:click` handler stays because synthetic clicks
+   * (assistive tech, tests) arrive without a preceding mousedown.
    */
-  function handleInteraction(event: MouseEvent) {
+  let mouseDownHandledSeek = false;
+
+  function seekFromPointer(event: MouseEvent) {
     if (!container || duration <= 0) return;
 
     const rect = container.getBoundingClientRect();
@@ -222,20 +228,53 @@
   }
 
   /**
+   * Handle click/seek on waveform
+   */
+  function handleInteraction(event: MouseEvent) {
+    if (mouseDownHandledSeek) {
+      mouseDownHandledSeek = false;
+      return;
+    }
+    seekFromPointer(event);
+  }
+
+  /**
    * Handle mouse down for dragging
    */
   function handleMouseDown(event: MouseEvent) {
     isDragging = true;
-    handleInteraction(event);
+    mouseDownHandledSeek = true;
+    seekFromPointer(event);
+
+    // Coalesce drag updates to one seek per frame. Raw mousemove fires far
+    // faster than the media element can service a seek, and each one can cost a
+    // fresh byte-range request.
+    let pendingMove: MouseEvent | null = null;
+    let rafId: number | null = null;
+
+    const flushMove = () => {
+      rafId = null;
+      if (pendingMove && isDragging) {
+        seekFromPointer(pendingMove);
+      }
+      pendingMove = null;
+    };
 
     const handleMouseMove = (moveEvent: MouseEvent) => {
-      if (isDragging) {
-        handleInteraction(moveEvent);
+      if (!isDragging) return;
+      pendingMove = moveEvent;
+      if (rafId === null) {
+        rafId = requestAnimationFrame(flushMove);
       }
     };
 
     const handleMouseUp = () => {
       isDragging = false;
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId);
+        rafId = null;
+      }
+      pendingMove = null;
       document.removeEventListener('mousemove', handleMouseMove);
       document.removeEventListener('mouseup', handleMouseUp);
     };

--- a/frontend/src/components/WaveformPlayer.test.ts
+++ b/frontend/src/components/WaveformPlayer.test.ts
@@ -56,6 +56,12 @@ async function waitForMountedLoad() {
   await new Promise((resolve) => setTimeout(resolve, 150));
 }
 
+/** Let one requestAnimationFrame callback run (drag seeks are rAF-coalesced). */
+async function nextAnimationFrame() {
+  await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   ctx = fakeCtx();
@@ -225,6 +231,74 @@ describe('click-to-seek', () => {
     expect(onSeek).not.toHaveBeenCalled();
   });
 
+  it('dispatches exactly ONE seek for a real mouse click (mousedown + click)', async () => {
+    // DEFECT THIS CATCHES (issue #645): the canvas had on:click AND on:mousedown
+    // and both seeked, so every click on the waveform issued two identical seeks
+    // to the media element — two Plyr seeks plus two raw seeks, four
+    // `currentTime` assignments, per single click. Measured live before the fix.
+    mockAxios.get.mockResolvedValue({ data: { waveform: [1, 2, 3] } });
+    const onSeek = vi.fn();
+    const { container } = render(WaveformPlayer, {
+      props: { fileId: 'f1', duration: 100 },
+      events: { seek: onSeek },
+    } as never);
+    setContainerWidth(container, 300);
+    await waitForMountedLoad();
+
+    const root = rootOf(container);
+    vi.spyOn(root, 'getBoundingClientRect').mockReturnValue({
+      left: 0,
+      width: 300,
+      top: 0,
+      right: 300,
+      bottom: 0,
+      height: 0,
+      x: 0,
+      y: 0,
+      toJSON() {},
+    });
+
+    const canvas = canvasOf(container);
+    // A real pointer interaction fires mousedown, then mouseup, then click.
+    await fireEvent.mouseDown(canvas, { clientX: 150 });
+    await fireEvent.mouseUp(document);
+    await fireEvent.click(canvas, { clientX: 150 });
+    await nextAnimationFrame();
+
+    expect(onSeek).toHaveBeenCalledTimes(1);
+    expect(onSeek).toHaveBeenCalledWith(expect.objectContaining({ detail: { time: 50 } }));
+  });
+
+  it('still seeks on a synthetic click that has no preceding mousedown', async () => {
+    // Assistive tech and programmatic activation dispatch `click` alone; the
+    // dedupe above must not swallow those.
+    mockAxios.get.mockResolvedValue({ data: { waveform: [1, 2, 3] } });
+    const onSeek = vi.fn();
+    const { container } = render(WaveformPlayer, {
+      props: { fileId: 'f1', duration: 100 },
+      events: { seek: onSeek },
+    } as never);
+    setContainerWidth(container, 300);
+    await waitForMountedLoad();
+
+    const root = rootOf(container);
+    vi.spyOn(root, 'getBoundingClientRect').mockReturnValue({
+      left: 0,
+      width: 300,
+      top: 0,
+      right: 300,
+      bottom: 0,
+      height: 0,
+      x: 0,
+      y: 0,
+      toJSON() {},
+    });
+
+    await fireEvent.click(canvasOf(container), { clientX: 75 });
+    expect(onSeek).toHaveBeenCalledTimes(1);
+    expect(onSeek).toHaveBeenCalledWith(expect.objectContaining({ detail: { time: 25 } }));
+  });
+
   it('clamps a drag past the container edge to the end of the track, and tracks mousemove while dragging', async () => {
     mockAxios.get.mockResolvedValue({ data: { waveform: [1, 2, 3] } });
     const onSeek = vi.fn();
@@ -254,11 +328,16 @@ describe('click-to-seek', () => {
 
     onSeek.mockClear();
     await fireEvent.mouseMove(document, { clientX: 150 }); // 50% while still dragging
+    // Drag seeks are coalesced to one per animation frame (issue #645): raw
+    // mousemove fires far faster than a media element can service a seek, and
+    // each uncoalesced seek can cost a fresh byte-range request.
+    await nextAnimationFrame();
     expect(onSeek).toHaveBeenCalledWith(expect.objectContaining({ detail: { time: 50 } }));
 
     onSeek.mockClear();
     await fireEvent.mouseUp(document);
     await fireEvent.mouseMove(document, { clientX: 0 }); // no longer dragging
+    await nextAnimationFrame();
     expect(onSeek).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/lib/utils/mediaReady.test.ts
+++ b/frontend/src/lib/utils/mediaReady.test.ts
@@ -1,0 +1,131 @@
+/**
+ * DEFECTS THESE CATCH (issue #645):
+ *
+ * 1. A seek requested before `loadedmetadata` used to block on the event with a
+ *    hard-coded 15 s fallback *before* touching the media element, so a click
+ *    landing in the page-load race window stalled for as long as the metadata
+ *    took (up to 15 s of silence). `applyMediaSeek` must assign `currentTime`
+ *    unconditionally — the element records it as the default playback start
+ *    position, which is what makes the browser fetch the target byte range.
+ * 2. The old inline waits never cleared their 15 s timer on the happy path, so
+ *    every seek leaked a live timeout.
+ * 3. They also never resolved on `error`, so a failed media load parked the
+ *    caller for the full 15 s.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  waitForMediaMetadata,
+  applyMediaSeek,
+  HAVE_METADATA,
+  METADATA_WAIT_TIMEOUT_MS,
+} from './mediaReady';
+
+/** Minimal stand-in for the bits of HTMLMediaElement the helpers touch. */
+function fakeMedia(readyState = 0) {
+  const listeners = new Map<string, Set<EventListener>>();
+  const el = {
+    readyState,
+    _currentTime: 0,
+    _throwOnSeek: false,
+    get currentTime() {
+      return this._currentTime;
+    },
+    set currentTime(v: number) {
+      if (this._throwOnSeek) throw new DOMException('bad state', 'InvalidStateError');
+      this._currentTime = v;
+    },
+    addEventListener(type: string, fn: EventListener) {
+      if (!listeners.has(type)) listeners.set(type, new Set());
+      listeners.get(type)!.add(fn);
+    },
+    removeEventListener(type: string, fn: EventListener) {
+      listeners.get(type)?.delete(fn);
+    },
+    emit(type: string) {
+      [...(listeners.get(type) ?? [])].forEach((fn) => fn(new Event(type) as Event));
+    },
+    listenerCount() {
+      let n = 0;
+      listeners.forEach((s) => (n += s.size));
+      return n;
+    },
+  };
+  return el as unknown as HTMLMediaElement & {
+    emit(type: string): void;
+    listenerCount(): number;
+    _throwOnSeek: boolean;
+  };
+}
+
+describe('applyMediaSeek', () => {
+  it('assigns currentTime even while readyState is HAVE_NOTHING', () => {
+    const media = fakeMedia(0);
+    expect(applyMediaSeek(media, 191.35)).toBe(true);
+    expect(media.currentTime).toBe(191.35);
+  });
+
+  it('reports failure instead of throwing when the engine rejects a pre-metadata seek', () => {
+    const media = fakeMedia(0);
+    media._throwOnSeek = true;
+    expect(applyMediaSeek(media, 12)).toBe(false);
+    expect(media.currentTime).toBe(0);
+  });
+});
+
+describe('waitForMediaMetadata', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('resolves immediately when metadata is already present', async () => {
+    const media = fakeMedia(HAVE_METADATA);
+    await expect(waitForMediaMetadata(media)).resolves.toBe(true);
+    expect(media.listenerCount()).toBe(0);
+  });
+
+  it('resolves true on loadedmetadata and removes every listener', async () => {
+    const media = fakeMedia(0);
+    const p = waitForMediaMetadata(media);
+    expect(media.listenerCount()).toBeGreaterThan(0);
+    (media as unknown as { readyState: number }).readyState = HAVE_METADATA;
+    media.emit('loadedmetadata');
+    await expect(p).resolves.toBe(true);
+    expect(media.listenerCount()).toBe(0);
+  });
+
+  it('clears the fallback timer once metadata arrives', async () => {
+    const media = fakeMedia(0);
+    const p = waitForMediaMetadata(media);
+    media.emit('loadedmetadata');
+    await p;
+    // If the timer leaked, a pending timer would still be queued here.
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('resolves false on a media error rather than parking for the full timeout', async () => {
+    const media = fakeMedia(0);
+    const p = waitForMediaMetadata(media);
+    media.emit('error');
+    await expect(p).resolves.toBe(false);
+    expect(media.listenerCount()).toBe(0);
+  });
+
+  it('resolves false when the timeout elapses with no metadata', async () => {
+    const media = fakeMedia(0);
+    const p = waitForMediaMetadata(media);
+    vi.advanceTimersByTime(METADATA_WAIT_TIMEOUT_MS);
+    await expect(p).resolves.toBe(false);
+    expect(media.listenerCount()).toBe(0);
+  });
+
+  it('honours a caller-supplied timeout', async () => {
+    const media = fakeMedia(0);
+    const p = waitForMediaMetadata(media, 500);
+    vi.advanceTimersByTime(499);
+    let settled = false;
+    void p.then(() => (settled = true));
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    vi.advanceTimersByTime(1);
+    await expect(p).resolves.toBe(false);
+  });
+});

--- a/frontend/src/lib/utils/mediaReady.ts
+++ b/frontend/src/lib/utils/mediaReady.ts
@@ -1,0 +1,92 @@
+/**
+ * Media-element readiness helpers shared by the players.
+ *
+ * Both `VideoPlayer.svelte` and `PlyrMiniPlayer.svelte` need the same thing: a
+ * seek requested before `loadedmetadata` has fired must still land on the right
+ * timestamp. They used to carry byte-identical copies of the wait below.
+ */
+
+/** `HTMLMediaElement.HAVE_METADATA` — duration and seek points are known. */
+export const HAVE_METADATA = 1;
+
+/**
+ * How long to keep waiting for `loadedmetadata` before giving up on syncing
+ * Plyr's own clock. This is NOT the seek latency: `applyMediaSeek` issues the
+ * seek to the media element immediately, so the user's playhead moves without
+ * waiting for this. Reaching the timeout only means Plyr's progress bar is
+ * re-synced late.
+ */
+export const METADATA_WAIT_TIMEOUT_MS = 15000;
+
+/**
+ * Resolve once the element has metadata.
+ *
+ * Resolves `true` when `readyState >= HAVE_METADATA`, `false` if the element
+ * errored or the timeout elapsed first. Never rejects, and always removes every
+ * listener and clears the timer — the previous inline copies leaked their
+ * 15-second timer on the happy path, so a seek left a stray callback behind.
+ */
+export function waitForMediaMetadata(
+  media: HTMLMediaElement,
+  timeoutMs: number = METADATA_WAIT_TIMEOUT_MS
+): Promise<boolean> {
+  if (media.readyState >= HAVE_METADATA) {
+    return Promise.resolve(true);
+  }
+
+  return new Promise<boolean>((resolve) => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const settle = (ready: boolean) => {
+      media.removeEventListener('loadedmetadata', onReady);
+      media.removeEventListener('canplay', onReady);
+      media.removeEventListener('durationchange', onReady);
+      media.removeEventListener('error', onError);
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      resolve(ready);
+    };
+
+    const onReady = () => settle(true);
+    const onError = () => settle(false);
+
+    media.addEventListener('loadedmetadata', onReady);
+    media.addEventListener('canplay', onReady);
+    media.addEventListener('durationchange', onReady);
+    media.addEventListener('error', onError);
+
+    // The element can cross the threshold between the guard above and the
+    // listeners being attached.
+    if (media.readyState >= HAVE_METADATA) {
+      settle(true);
+      return;
+    }
+
+    timer = setTimeout(() => settle(false), timeoutMs);
+  });
+}
+
+/**
+ * Seek a media element as early as the browser allows.
+ *
+ * Assigning `currentTime` while `readyState` is `HAVE_NOTHING` is deliberately
+ * NOT skipped: per the HTML spec the element records the value as its *default
+ * playback start position*, so the browser issues the range request for the
+ * target as soon as it has parsed the container index. Blocking on
+ * `loadedmetadata` first — which is what the players used to do — only delays
+ * that request; it does not make it more correct.
+ *
+ * Returns `false` if the assignment threw (some engines raise `InvalidStateError`
+ * on a pre-metadata seek), in which case the caller should re-apply once
+ * metadata arrives.
+ */
+export function applyMediaSeek(media: HTMLMediaElement, time: number): boolean {
+  try {
+    media.currentTime = time;
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Closes #645.

## What was wrong

A waveform/transcript click landing before `loadedmetadata` could stall for 15+ seconds.
Measured live against the `otfresh-demo` stack with a real 3-hour / 1.6 GB MP4 and a WAV,
instrumented via the media element's own event timeline and a patched `currentTime` setter.

**Root cause.** `VideoPlayer.seekToTime()` awaited `loadedmetadata`/`canplay` (hard-coded 15 s
cap) plus a fixed 150 ms sleep **before** touching the media element. The premise was wrong:
per the HTML spec, assigning `currentTime` while `readyState` is `HAVE_NOTHING` is *not*
discarded — the element records it as the default playback start position, so the browser
issues the range request for the target as soon as it parses the container index. The old code
delayed the very request it was waiting for. The wait was only ever needed for **Plyr's** own
setter, which bails while its duration is still 0.

## Measured

Cold object store (models the LAN/WAN case), click at `readyState 0`:

| | click → seek issued | click → `seeked` |
|---|---|---|
| before | **15.21 s** (the 15 s timeout firing) | 18.87 s |
| after | **0.06 s** | 18.95 s |

Real 3-hour MP4, localhost, click at `readyState 0`, **Firefox**:

| | click → seek issued | click → `seeked` | `currentTime` assignments |
|---|---|---|---|
| before | 0.485 s (= metadata + 150 ms sleep) | 0.782 s | 2 |
| after | **0.225 s** (issued pre-metadata) | 0.709 s | **1** |

The residual latency is the object store's, not ours. The delay this PR removes scales *with*
the network, so remote users benefit most.

## Also fixed (all found while measuring)

- **One waveform click dispatched TWO seeks.** The canvas had `on:click` **and**
  `on:mousedown`, and `handleMouseDown` also called `handleInteraction` — so a single click
  produced **4** `currentTime` assignments. Now 1. `on:click` is kept for synthetic clicks
  (assistive tech, tests) that arrive with no preceding mousedown.
- **Leaked timers / no error path.** The inline wait never cleared its 15 s timer on the happy
  path and never resolved on `error`, so a failed load parked the caller for the full timeout.
  The same 25-line block was copy-pasted into `PlyrMiniPlayer.svelte`; both now use one shared
  `$lib/utils/mediaReady.ts`.
- **The seek spinner cleared on a blind 5 s timer**, so a longer seek showed a dead player with
  no indication. It now clears on `seeked`/`error`.

## Optimizations in the same area

- `preload="auto"` → `"metadata"` on all four media elements. Nothing in the app reads
  `.buffered`, and duration comes from the API plus Plyr's `ready`, so nothing depended on eager
  buffering. Media bytes pulled in the first 20 s for the 1.6 GB file: **16.25 MiB → 12.83 MiB
  (−21%)** — the `moov` index alone is 10.4 MiB, so that is near the floor.
- Drag-scrub seeks are coalesced to one per animation frame. Raw `mousemove` fires far faster
  than a media element can service a seek, and each one can cost a fresh byte-range request.

Architecture unchanged: presigned URLs still go direct to the client. No backend proxy.

## Verification

- Chromium **and** Firefox (independent media stacks), against the real 3-hour file and a WAV.
- No-regression control, 5-minute MP4: 0.554 s → 0.580 s (unchanged within noise).
- New `WaveformPlayer` dedupe test verified **red against `master`** (`expected 1, got 2`).
- Frontend suite **1662 passed / 179 files**; `svelte-check` 0 errors; `vite build` clean;
  full `safe-precommit.sh run --all-files` green.

## Not addressed here (deliberately)

- A `PIPELINE_ERROR_DECODE` while seeking the 1.6 GB H.264 file in **Playwright's bundled
  Chromium** is a harness artifact, not an app defect: it reproduces at `readyState 4` after the
  page has fully settled, and Firefox seeks the same file cleanly.
- `GET /api/files/{id}/waveform` takes **~24 s on every call** for the 3-hour file — it is not
  cached, which is why the waveform canvas is unclickable for ~26 s there. Separate backend
  issue, worth filing.