### PR TITLE
fix(deploy): installer reads release-manifest.txt (#640); make the native diarizer reachable on self-hosted installs (#639)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -248,6 +248,10 @@ DEPLOYMENT_MODE=full
 BACKEND_LITE_IMAGE=davidamacey/opentranscribe-backend-lite:latest
 # faster_whisper | whisperx | cloud
 ENGINE_TRANSCRIBER_BACKEND=faster_whisper
+# native (Rust/ONNX sidecar, faster and better on AMI) | pyannote (in-process fork).
+# `native` runs only once its weights have been exported (see DIAR_NATIVE_MODELS_DIR
+# below); until then the pipeline falls back to PyAnnote automatically, so this value
+# is safe to leave as-is either way.
 ENGINE_DIARIZER_BACKEND=native
 ENGINE_GPU_SPLIT=false
 # internal cross-stage WAV handoff dir (split path)
@@ -287,8 +291,12 @@ DIAR_NATIVE_MAX_INFLIGHT=2
 DIAR_NATIVE_LAZY_SESSIONS=1
 # --with-diar-native overlay: host CUDA device for the sidecar (falls back to GPU_DEVICE_ID)
 DIAR_NATIVE_GPU=0
-# --with-diar-native overlay: host dir with the sidecar's model weights, mounted read-only
-DIAR_NATIVE_MODELS_DIR=/mnt/nvm/repos/diar-native/models_folded
+# Host dir holding the sidecar's exported ONNX/PLDA weights, mounted read-only.
+# Defaults to ${MODEL_CACHE_DIR}/diar-native — a sibling of the huggingface/ and torch/
+# caches above, written by `./opentranscribe.sh download-models diar-native`.
+# There is no separate on/off switch: the sidecar starts when these weights exist.
+# Set this ONLY to point at an export you keep somewhere else.
+#DIAR_NATIVE_MODELS_DIR=./models/diar-native
 # Hardware auto-detection overrides — "auto" (default) detects CUDA/MPS/CPU and
 # an appropriate compute type/batch size at runtime. Force a value only to work
 # around a detection bug or to pin CPU-only behavior explicitly.

--- a/backend/tests/unit/test_compose_file_selection.py
+++ b/backend/tests/unit/test_compose_file_selection.py
@@ -44,14 +44,18 @@ GPU = "docker-compose.gpu.yml"
 BLACKWELL = "docker-compose.blackwell.yml"
 NGINX = "docker-compose.nginx.yml"
 BACKUP = "docker-compose.backup.yml"
+DIAR = "docker-compose.diar-native.yml"
+
+ALL_OVERLAYS = (BASE, PROD, GPU, BLACKWELL, NGINX, BACKUP, DIAR)
 
 
 def _make_deployment(
     tmp_path: Path,
     *,
-    overlays: tuple[str, ...] = (BASE, PROD, GPU, BLACKWELL, NGINX, BACKUP),
+    overlays: tuple[str, ...] = ALL_OVERLAYS,
     env_lines: tuple[str, ...] = (),
     certs: bool = False,
+    diar_weights: bool = False,
 ) -> Path:
     """Lay out a directory shaped like a real curl install and drop the script in it."""
     install = tmp_path / "install"
@@ -64,6 +68,11 @@ def _make_deployment(
         ssl_dir.mkdir(parents=True)
         (ssl_dir / "server.crt").write_text("cert\n", encoding="utf-8")
         (ssl_dir / "server.key").write_text("key\n", encoding="utf-8")
+    if diar_weights:
+        # The default DIAR_NATIVE_MODELS_DIR, i.e. ${MODEL_CACHE_DIR:-./models}/diar-native.
+        weights = install / "models" / "diar-native"
+        weights.mkdir(parents=True)
+        (weights / "segmentation-3.0.onnx").write_text("onnx\n", encoding="utf-8")
     (install / "opentranscribe.sh").write_bytes(MANAGER.read_bytes())
     (install / "opentranscribe.sh").chmod(0o755)
     return install
@@ -101,13 +110,20 @@ def _resolve(
     *,
     nvidia_runtime: bool = True,
     compute_cap: str = "8.6",
-    overlays: tuple[str, ...] = (BASE, PROD, GPU, BLACKWELL, NGINX, BACKUP),
+    overlays: tuple[str, ...] = ALL_OVERLAYS,
     env_lines: tuple[str, ...] = (),
     certs: bool = False,
+    diar_weights: bool = False,
     extra_env: dict[str, str] | None = None,
 ) -> tuple[str, str]:
     """Run `./opentranscribe.sh compose-files` and return (stdout chain, stderr banners)."""
-    install = _make_deployment(tmp_path, overlays=overlays, env_lines=env_lines, certs=certs)
+    install = _make_deployment(
+        tmp_path,
+        overlays=overlays,
+        env_lines=env_lines,
+        certs=certs,
+        diar_weights=diar_weights,
+    )
     bin_dir = _make_stubs(tmp_path, nvidia_runtime=nvidia_runtime, compute_cap=compute_cap)
     env = {
         "PATH": f"{bin_dir}:{os.environ.get('PATH', '/usr/bin:/bin')}",
@@ -274,6 +290,59 @@ def test_backup_overlay_needs_its_own_toggle_not_just_a_backup_path(tmp_path: Pa
     )
     assert _files(enabled) == [BASE, PROD, BACKUP], enabled
     assert "Scheduled-backup overlay enabled" in stderr, stderr
+
+
+# --------------------------------------------------------------------------- #
+# The native diarization sidecar (issue #639)
+# --------------------------------------------------------------------------- #
+
+
+def test_diar_native_does_not_start_without_its_exported_weights(tmp_path: Path):
+    """.env.example ships ENGINE_DIARIZER_BACKEND=native and several DIAR_NATIVE_*
+    variables, so none of those can mean "run the sidecar" — every install has them.
+
+    It also must not start weightless: diar-server exits when it cannot load its models
+    and the service is `restart: unless-stopped`, so that combination is an endless
+    crash loop that ALSO fails `up --wait` for the entire stack. Falling back to the
+    in-process PyAnnote engine is the correct, working outcome here.
+    """
+    chain, _ = _resolve(
+        tmp_path,
+        env_lines=(
+            "ENGINE_DIARIZER_BACKEND=native",
+            "DIAR_NATIVE_URL=http://diar-native:8701",
+            "DIAR_NATIVE_GPU=0",
+        ),
+        diar_weights=False,
+    )
+    assert DIAR not in _files(chain), chain
+
+
+def test_diar_native_starts_once_its_weights_have_been_exported(tmp_path: Path):
+    """The whole point of #639: a self-hosted deployment must have SOME path to the
+    engine its own config claims is the default. Before this, there was none.
+
+    Exporting the weights is the opt-in — that directory is created only by
+    `download-models diar-native`, so no extra env var is needed to express intent.
+    """
+    chain, stderr = _resolve(tmp_path, diar_weights=True)
+    assert _files(chain) == [BASE, PROD, GPU, DIAR], chain
+    assert "Native diarization sidecar enabled" in stderr, stderr
+
+
+def test_diar_native_weights_without_the_overlay_file_warns_loudly(tmp_path: Path):
+    """The Blackwell lesson (#640) applied to this overlay: a missing compose file must
+    not be a silent `[ -f ]` fallthrough when the operator went to the trouble of
+    exporting several hundred MB of weights."""
+    chain, stderr = _resolve(
+        tmp_path,
+        overlays=(BASE, PROD, GPU, BLACKWELL, NGINX, BACKUP),  # no DIAR on disk
+        diar_weights=True,
+    )
+    assert DIAR not in _files(chain), chain
+    assert "docker-compose.diar-native.yml is missing" in stderr, stderr
+    assert "PyAnnote" in stderr, "the operator must be told which engine actually runs"
+    assert "update-full" in stderr, "the warning must name the command that fetches it"
 
 
 # --------------------------------------------------------------------------- #

--- a/backend/tests/unit/test_release_manifest.py
+++ b/backend/tests/unit/test_release_manifest.py
@@ -21,6 +21,8 @@ Consolidating only helps if the manifest itself stays correct, so:
 from __future__ import annotations
 
 import re
+import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -28,6 +30,7 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[3]
 MANIFEST = REPO_ROOT / "release-manifest.txt"
 MANAGER = REPO_ROOT / "opentranscribe.sh"
+INSTALLER = REPO_ROOT / "setup-opentranscribe.sh"
 ENV_EXAMPLE = REPO_ROOT / ".env.example"
 
 pytestmark = pytest.mark.skipif(
@@ -111,6 +114,107 @@ def test_update_full_reads_the_manifest():
         "opentranscribe.sh no longer references release-manifest.txt — "
         "did update-full grow its own artifact list again?"
     )
+
+
+def test_installer_reads_the_manifest():
+    """The FRESH-INSTALL half of the same guard (issue #640).
+
+    The manifest header has always claimed setup-opentranscribe.sh as a consumer, but
+    the installer kept its own hardcoded list of compose files instead, and nothing
+    enforced the claim — so `docker-compose.blackwell.yml` and `docker-compose.backup.yml`
+    were listed here, downloaded by `update-full`, and never by a fresh install.
+    """
+    text = INSTALLER.read_text()
+    assert "release-manifest.txt" in text, (
+        "setup-opentranscribe.sh no longer references release-manifest.txt — "
+        "did the installer grow its own artifact list again?"
+    )
+
+
+def _extract_function(script: Path, name: str) -> str:
+    """Pull one shell function out of a script so it can be run in isolation."""
+    out = subprocess.run(
+        ["sed", "-n", f"/^{name}()/,/^}}/p", str(script)],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert out.strip(), f"{name}() not found in {script.name}"
+    return out
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
+def test_a_fresh_install_downloads_every_compose_overlay_the_manifest_lists(tmp_path):
+    """Run the installer's REAL download loop against a stub curl and check what it asks for.
+
+    This is the behavioural half of the guard, and the one that would actually have
+    caught #640: a string-presence check passes the moment the manifest is mentioned
+    anywhere, even with the hardcoded list still doing the real work.
+
+    Why it matters that blackwell is in here specifically: get_compose_files() selects
+    the overlay with `if is_blackwell_gpu && [ -f docker-compose.blackwell.yml ]`, so a
+    file that was never downloaded does not error — it silently falls through to the
+    generic GPU overlay, whose image crashes in NVRTC on SM_121 the first time anyone
+    actually transcribes something (docs/BLACKWELL_SETUP.md).
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    requested = tmp_path / "requested.txt"
+
+    # Stub curl: record the URL, write a non-empty file to the -o target.
+    stub = bin_dir / "curl"
+    stub.write_text(
+        "#!/bin/bash\n"
+        "url=''; out=''\n"
+        "while [ $# -gt 0 ]; do\n"
+        '  case "$1" in\n'
+        '    -o) out="$2"; shift 2 ;;\n'
+        '    http*) url="$1"; shift ;;\n'
+        "    *) shift ;;\n"
+        "  esac\n"
+        "done\n"
+        f'echo "$url" >> {requested}\n'
+        'if [ -n "$out" ]; then\n'
+        # The manifest fetch must return the real manifest; anything else is a stub body.
+        '  case "$url" in\n'
+        f'    *release-manifest.txt) cp {MANIFEST} "$out" ;;\n'
+        '    *) printf "stub-content\\n" > "$out" ;;\n'
+        "  esac\n"
+        "fi\n"
+        "exit 0\n"
+    )
+    stub.chmod(0o755)
+
+    workdir = tmp_path / "install"
+    workdir.mkdir()
+
+    snippet = (
+        "set -uo pipefail\nset -e\n"
+        "RED=''; GREEN=''; YELLOW=''; BLUE=''; NC=''\n"
+        + _extract_function(INSTALLER, "download_release_manifest_artifacts")
+        + "\ndownload_release_manifest_artifacts\n"
+    )
+    proc = subprocess.run(
+        ["bash", "-c", snippet],
+        capture_output=True,
+        text=True,
+        cwd=str(workdir),
+        env={"PATH": f"{bin_dir}:/usr/bin:/bin", "OPENTRANSCRIBE_BRANCH": "master"},
+    )
+    assert proc.returncode == 0, f"replay loop failed:\n{proc.stdout}\n{proc.stderr}"
+
+    asked_for = requested.read_text().splitlines()
+    listed = [path for path, _ in _entries()]
+
+    missing = [p for p in listed if not any(u.endswith("/" + p) for u in asked_for)]
+    assert not missing, (
+        f"a fresh install never downloads {missing} — the manifest lists them, so "
+        "get_compose_files() can select a file that is not on disk"
+    )
+
+    # The two the hardcoded list forgot, named explicitly so a regression is unambiguous.
+    for overlay in ("docker-compose.blackwell.yml", "docker-compose.backup.yml"):
+        assert (workdir / overlay).is_file(), f"{overlay} was not written to the install dir"
 
 
 def test_opentr_sh_is_not_shipped_and_the_shipped_script_covers_it():

--- a/docker-compose.diar-native.yml
+++ b/docker-compose.diar-native.yml
@@ -22,8 +22,16 @@ services:
     # no ENTRYPOINT, so `command:` replaces the whole CMD cleanly.
     #
     # Previously `image: diar-server:latest` — an UNQUALIFIED name that Docker resolves
-    # to docker.io/library/diar-server, a namespace we do not control.
-    image: opentranscribe-backend:latest
+    # to docker.io/library/diar-server, a namespace we do not control. Then
+    # `opentranscribe-backend:latest`, which is the DEV-LOCAL build tag: because this
+    # overlay is merged LAST, that pinned every self-hosted deployment's diar-native
+    # service to an image name that only exists on a maintainer's workstation, and
+    # Docker would try to pull docker.io/library/opentranscribe-backend (issue #639).
+    #
+    # Default to the same published image the prod overlay uses, keyed on the same
+    # OT_IMAGE_TAG, so the sidecar and the workers that talk to it are always the same
+    # build. opentr.sh exports DIAR_NATIVE_IMAGE for local dev.
+    image: ${DIAR_NATIVE_IMAGE:-davidamacey/opentranscribe-backend:${OT_IMAGE_TAG:-latest}}
     command: ["diar-server"]
     # ORT resolves its provider libs relative to the executable's directory AND the
     # process cwd (diar-server has no ELF NEEDED entry for libonnxruntime — it's
@@ -47,8 +55,19 @@ services:
       # needs resolves against those wheels, zero unsatisfied sonames.
       - LD_LIBRARY_PATH=/opt/diar-native/lib:/home/appuser/.local/lib/python3.13/site-packages/nvidia/cudnn/lib:/home/appuser/.local/lib/python3.13/site-packages/nvidia/cuda_runtime/lib:/home/appuser/.local/lib/python3.13/site-packages/nvidia/cublas/lib:/home/appuser/.local/lib/python3.13/site-packages/nvidia/cufft/lib:/home/appuser/.local/lib/python3.13/site-packages/nvidia/curand/lib
     volumes:
-      # self-exported community-1 models (gated weights — local only, never distributed)
-      - ${DIAR_NATIVE_MODELS_DIR:-/mnt/nvm/repos/diar-native/models_folded}:/models:ro
+      # ONNX/PLDA artifacts exported from pyannote/speaker-diarization-community-1.
+      #
+      # These are the SAME weights the PyAnnote path uses, obtained the SAME way: the
+      # operator's own HUGGINGFACE_TOKEN against the gated HF repo, then exported to
+      # ONNX locally. `./opentranscribe.sh` runs that export via
+      # scripts/download-models.py (group: diar-native). Nothing here is redistributed
+      # by this project — identical to how the PyAnnote weights are acquired today.
+      #
+      # The default used to be /mnt/nvm/repos/diar-native/models_folded, an absolute
+      # path on one maintainer's workstation, which is why no self-hosted deployment
+      # could ever start this service (issue #639). Now it follows MODEL_CACHE_DIR like
+      # every other model cache in docker-compose.yml.
+      - ${DIAR_NATIVE_MODELS_DIR:-${MODEL_CACHE_DIR:-./models}/diar-native}:/models:ro
       - diar-native-tmp:/tmp/diar-native
     deploy:
       resources:

--- a/docs-site/docs/features/speaker-diarization.md
+++ b/docs-site/docs/features/speaker-diarization.md
@@ -320,9 +320,26 @@ local ASR with cloud diarization, or any other combination.
   in-process PyAnnote engine documented earlier on this page — there is no hard dependency on
   the sidecar being up.
 - **Running it**: the sidecar ships as an additive Docker Compose overlay,
-  `docker-compose.diar-native.yml`, wired through `./opentr.sh start dev --with-diar-native`. It
-  shares the backend image rather than shipping a separate one, and is auto-loaded in dev when
-  its models directory is present (`--no-diar-native` suppresses that).
+  `docker-compose.diar-native.yml`. It shares the backend image rather than shipping a separate
+  one — the `diar-server` binary is already inside `davidamacey/opentranscribe-backend`, so
+  there is nothing extra to pull.
+  - **Self-hosted install**: export the weights once
+    (`./opentranscribe.sh download-models diar-native`) and restart. There is no separate
+    on/off switch — the sidecar starts when its weights are present, and is skipped when they
+    are not, because starting it weightless would crash-loop and take stack startup with it.
+    They land in `${MODEL_CACHE_DIR}/diar-native`, a sibling of the `huggingface/` and `torch/`
+    caches the PyAnnote path already uses.
+  - **This repo's dev checkout**: `./opentr.sh start dev --with-diar-native`, auto-loaded when
+    the models directory is present (`--no-diar-native` suppresses that).
+- **Where the weights come from**: the same place PyAnnote's do. The sidecar runs ONNX/PLDA
+  artifacts exported from the very same gated `pyannote/speaker-diarization-community-1`
+  pipeline the in-process engine loads — it is a Rust/ONNX reimplementation of that pipeline,
+  not a different model. They are exported locally from your own HuggingFace access
+  (`HUGGINGFACE_TOKEN`, plus accepting the model's conditions), exactly as the PyAnnote weights
+  are obtained today. Nothing about this engine is redistributed by OpenTranscribe.
+- **If the sidecar is not running**, diarization falls back to the in-process PyAnnote engine
+  and everything keeps working — slower, and slightly worse on AMI, but correct. That fallback
+  is a supported configuration, not a degraded one; see issue #572 for why PyAnnote stays.
 - **Inline gender classification**: while the sidecar already holds the decoded audio for
   diarization, it can also classify each speaker's gender in the same pass
   (`DIAR_NATIVE_GENDER`, on by default). When active, this skips the separate ~87–90s CPU

--- a/opentr.sh
+++ b/opentr.sh
@@ -1820,7 +1820,7 @@ start_app() {
   # Fresh stacks stay opt-in (pass --with-diar-native explicitly).
   if [ -z "$WITH_DIAR_NATIVE_FLAG" ] && [ -z "$NO_DIAR_NATIVE_FLAG" ] && [ -z "$FRESH_FLAG" ] \
      && [ "${ENGINE_DIARIZER_BACKEND:-native}" = "native" ] \
-     && [ -d "${DIAR_NATIVE_MODELS_DIR:-/mnt/nvm/repos/diar-native/models_folded}" ]; then
+     && [ -d "${DIAR_NATIVE_MODELS_DIR:-${MODEL_CACHE_DIR:-./models}/diar-native}" ]; then
     WITH_DIAR_NATIVE_FLAG="auto"
     echo "🎙️  diar-native sidecar AUTO-LOADED (engine.diarizer_backend defaults to native; models present). Use --no-diar-native to skip."
   fi
@@ -1828,6 +1828,13 @@ start_app() {
   # Add the native diarization sidecar if requested
   if [ -n "$WITH_DIAR_NATIVE_FLAG" ]; then
     if [ -f "docker-compose.diar-native.yml" ]; then
+      # The overlay defaults to the PUBLISHED backend image, which is correct for a
+      # self-hosted deployment but wrong in this checkout — dev builds the image
+      # locally as opentranscribe-backend:latest and never pushes it. Point the
+      # sidecar at the local build so it matches the workers it serves.
+      if [ "$ENVIRONMENT" = "dev" ]; then
+        export DIAR_NATIVE_IMAGE="${DIAR_NATIVE_IMAGE:-opentranscribe-backend:latest}"
+      fi
       COMPOSE_FILES="$COMPOSE_FILES -f docker-compose.diar-native.yml"
       echo "🎙️  Adding native diarization sidecar (docker-compose.diar-native.yml)"
       echo "   diar-server on GPU ${DIAR_NATIVE_GPU:-${GPU_DEVICE_ID:-0}} — ~4.1 GB warm ORT arena while up."
@@ -2509,7 +2516,7 @@ reset_and_init() {
   # Fresh stacks stay opt-in (pass --with-diar-native explicitly).
   if [ -z "$WITH_DIAR_NATIVE_FLAG" ] && [ -z "$NO_DIAR_NATIVE_FLAG" ] && [ -z "$FRESH_FLAG" ] \
      && [ "${ENGINE_DIARIZER_BACKEND:-native}" = "native" ] \
-     && [ -d "${DIAR_NATIVE_MODELS_DIR:-/mnt/nvm/repos/diar-native/models_folded}" ]; then
+     && [ -d "${DIAR_NATIVE_MODELS_DIR:-${MODEL_CACHE_DIR:-./models}/diar-native}" ]; then
     WITH_DIAR_NATIVE_FLAG="auto"
     echo "🎙️  diar-native sidecar AUTO-LOADED (engine.diarizer_backend defaults to native; models present). Use --no-diar-native to skip."
   fi
@@ -2517,6 +2524,13 @@ reset_and_init() {
   # Add the native diarization sidecar if requested
   if [ -n "$WITH_DIAR_NATIVE_FLAG" ]; then
     if [ -f "docker-compose.diar-native.yml" ]; then
+      # The overlay defaults to the PUBLISHED backend image, which is correct for a
+      # self-hosted deployment but wrong in this checkout — dev builds the image
+      # locally as opentranscribe-backend:latest and never pushes it. Point the
+      # sidecar at the local build so it matches the workers it serves.
+      if [ "$ENVIRONMENT" = "dev" ]; then
+        export DIAR_NATIVE_IMAGE="${DIAR_NATIVE_IMAGE:-opentranscribe-backend:latest}"
+      fi
       COMPOSE_FILES="$COMPOSE_FILES -f docker-compose.diar-native.yml"
       echo "🎙️  Adding native diarization sidecar (docker-compose.diar-native.yml)"
       echo "   diar-server on GPU ${DIAR_NATIVE_GPU:-${GPU_DEVICE_ID:-0}} — ~4.1 GB warm ORT arena while up."

--- a/opentr.sh
+++ b/opentr.sh
@@ -247,6 +247,41 @@ show_help() {
   echo ""
 }
 
+# Resolve where the diar-native ONNX/PLDA export lives, and EXPORT it so the
+# auto-load check below and docker-compose.diar-native.yml's volume mount can never
+# disagree about the answer.
+#
+# Order: an explicit DIAR_NATIVE_MODELS_DIR wins; then the standard cache location
+# (${MODEL_CACHE_DIR}/diar-native, a sibling of huggingface/ and torch/, and where a
+# self-hosted export lands); then the pre-convention sibling-repo export, which is
+# where this workstation's models still are and which has no entry in .env. Dropping
+# that last probe silently moved existing dev checkouts onto the PyAnnote fallback.
+#
+# This probe is dev-only on purpose: opentr.sh is deliberately not shipped
+# (test_opentr_sh_is_not_shipped_and_the_shipped_script_covers_it), and
+# opentranscribe.sh resolves the standard location only.
+resolve_diar_native_models_dir() {
+  if [ -n "${DIAR_NATIVE_MODELS_DIR:-}" ]; then
+    export DIAR_NATIVE_MODELS_DIR
+    return 0
+  fi
+
+  local standard="${MODEL_CACHE_DIR:-./models}/diar-native"
+  local legacy="/mnt/nvm/repos/diar-native/models_folded"
+
+  if [ -d "$standard" ]; then
+    export DIAR_NATIVE_MODELS_DIR="$standard"
+  elif [ -d "$legacy" ]; then
+    export DIAR_NATIVE_MODELS_DIR="$legacy"
+    # Announced, not silent: this path is a property of one machine, not of the repo,
+    # so it must never become invisible drift that only that machine benefits from.
+    echo "ℹ️  diar-native models found at the legacy path $legacy."
+    echo "   Set DIAR_NATIVE_MODELS_DIR in .env to pin it, or move the export to $standard."
+  else
+    export DIAR_NATIVE_MODELS_DIR="$standard"
+  fi
+}
+
 # Build production images locally (backend + frontend)
 build_prod_images() {
   echo "🥽 Building production Docker images locally..."
@@ -1818,9 +1853,10 @@ start_app() {
   # Guarded on the models dir existing — without it the sidecar restart-loops and
   # `up --wait` would fail the whole startup on checkouts with no local model export.
   # Fresh stacks stay opt-in (pass --with-diar-native explicitly).
+  resolve_diar_native_models_dir
   if [ -z "$WITH_DIAR_NATIVE_FLAG" ] && [ -z "$NO_DIAR_NATIVE_FLAG" ] && [ -z "$FRESH_FLAG" ] \
      && [ "${ENGINE_DIARIZER_BACKEND:-native}" = "native" ] \
-     && [ -d "${DIAR_NATIVE_MODELS_DIR:-${MODEL_CACHE_DIR:-./models}/diar-native}" ]; then
+     && [ -d "$DIAR_NATIVE_MODELS_DIR" ]; then
     WITH_DIAR_NATIVE_FLAG="auto"
     echo "🎙️  diar-native sidecar AUTO-LOADED (engine.diarizer_backend defaults to native; models present). Use --no-diar-native to skip."
   fi
@@ -2514,9 +2550,10 @@ reset_and_init() {
   # Guarded on the models dir existing — without it the sidecar restart-loops and
   # `up --wait` would fail the whole startup on checkouts with no local model export.
   # Fresh stacks stay opt-in (pass --with-diar-native explicitly).
+  resolve_diar_native_models_dir
   if [ -z "$WITH_DIAR_NATIVE_FLAG" ] && [ -z "$NO_DIAR_NATIVE_FLAG" ] && [ -z "$FRESH_FLAG" ] \
      && [ "${ENGINE_DIARIZER_BACKEND:-native}" = "native" ] \
-     && [ -d "${DIAR_NATIVE_MODELS_DIR:-${MODEL_CACHE_DIR:-./models}/diar-native}" ]; then
+     && [ -d "$DIAR_NATIVE_MODELS_DIR" ]; then
     WITH_DIAR_NATIVE_FLAG="auto"
     echo "🎙️  diar-native sidecar AUTO-LOADED (engine.diarizer_backend defaults to native; models present). Use --no-diar-native to skip."
   fi

--- a/opentranscribe.sh
+++ b/opentranscribe.sh
@@ -262,6 +262,44 @@ get_compose_files() {
         echo -e "${YELLOW}   Note: this also sets path.repo on OpenSearch — the opensearch container will be recreated.${NC}" >&2
     fi
 
+    # Add the native diarization sidecar when its weights have been exported.
+    #
+    # engine.diarizer_backend defaults to `native`, but before issue #639 no self-hosted
+    # deployment could ever run the sidecar: the overlay was not in release-manifest.txt,
+    # so it never reached disk, and this script had no reference to it at all. Every
+    # install therefore served every file from the in-process PyAnnote fallback while
+    # the config, the docs and the admin UI all said `native`.
+    #
+    # The signal is the exported weights EXISTING, not a dedicated toggle. Unlike
+    # BACKUP_HOST_PATH (which .env.example ships set, so its presence proves nothing),
+    # this directory is created only by `download-models diar-native` — so its presence
+    # is real evidence the operator asked for this engine, and needs no new variable to
+    # say so. It is also self-consistent: no weights means no sidecar, which is exactly
+    # the condition under which starting it would crash-loop.
+    local diar_models_dir=""
+    diar_models_dir=$(read_env_value DIAR_NATIVE_MODELS_DIR)
+    if [ -z "$diar_models_dir" ]; then
+        local diar_cache_dir=""
+        diar_cache_dir=$(read_env_value MODEL_CACHE_DIR)
+        diar_models_dir="${diar_cache_dir:-./models}/diar-native"
+    fi
+
+    if [ -d "$diar_models_dir" ] && [ -n "$(ls -A "$diar_models_dir" 2>/dev/null)" ]; then
+        if [ -f docker-compose.diar-native.yml ]; then
+            compose_files="$compose_files -f docker-compose.diar-native.yml"
+            echo -e "${BLUE}🎙️  Native diarization sidecar enabled (weights present)${NC}" >&2
+            echo -e "${BLUE}   Weights: ${diar_models_dir} → /models${NC}" >&2
+            echo -e "${BLUE}   Holds ~4 GB of GPU memory on device ${DIAR_NATIVE_GPU:-${GPU_DEVICE_ID:-0}} while up.${NC}" >&2
+        else
+            # Loud, unlike the GPU overlays' silent `[ -f ]` fallthrough: the operator
+            # exported these weights on purpose, and quietly serving PyAnnote instead is
+            # the exact defect #639 is about.
+            echo -e "${YELLOW}⚠️  Native diarization weights are present but docker-compose.diar-native.yml is missing.${NC}" >&2
+            echo -e "${YELLOW}   Diarization will fall back to the in-process PyAnnote engine.${NC}" >&2
+            echo -e "${YELLOW}   Run './opentranscribe.sh update-full' to fetch it.${NC}" >&2
+        fi
+    fi
+
     echo "$compose_files"
 }
 

--- a/release-manifest.txt
+++ b/release-manifest.txt
@@ -45,6 +45,14 @@ docker-compose.gpu-scale.yml
 docker-compose.blackwell.yml	optional
 docker-compose.nginx.yml
 docker-compose.backup.yml	optional
+# The native (Rust/ONNX) diarization sidecar. `engine.diarizer_backend` defaults to
+# `native`, so without this overlay a deployment silently serves every file from the
+# in-process PyAnnote fallback instead (issue #639). The diar-server binary already
+# ships inside the backend image; the ONNX/PLDA weights are exported locally by
+# scripts/download-models.py from the operator's own gated HuggingFace access, exactly
+# as the PyAnnote weights are. Selection is gated on those weights existing — no
+# separate toggle, since the directory is only created by running the export.
+docker-compose.diar-native.yml	optional
 
 # --- Reverse proxy -------------------------------------------------------------
 nginx/site.conf.template

--- a/setup-opentranscribe.sh
+++ b/setup-opentranscribe.sh
@@ -449,443 +449,122 @@ create_configuration_files() {
     # Create database initialization files
     create_database_files
 
-    # Create comprehensive docker-compose.yml directly
-    create_production_compose
+    # Directory structure the manifest cannot express: it lists files, and an
+    # empty directory is not a file. nginx/ssl is where generate-ssl-cert.sh
+    # writes, and it must exist before the user runs setup-ssl.
+    mkdir -p nginx/ssl
+    mkdir -p scripts
+    touch nginx/ssl/.gitkeep
+
+    # Download every deployment artifact release-manifest.txt lists.
+    download_release_manifest_artifacts
 
     # Validate all downloaded files
     if ! validate_downloaded_files; then
         echo -e "${RED}❌ File validation failed${NC}"
         exit 1
     fi
-
-    # Download opentranscribe.sh management script
-    download_management_script
-
-    # Download NGINX/SSL configuration files
-    download_nginx_files
-
-    # Download model downloader scripts
-    download_model_downloader_scripts
-
-    # Create .env.example
-    create_production_env_example
 }
 
-create_production_compose() {
-    echo "✓ Downloading production docker-compose configuration..."
+# Download every artifact listed in release-manifest.txt, at the resolved install ref.
+#
+# The file list lives in release-manifest.txt, NOT in this script. This installer used to
+# keep its own hardcoded list, and the two drifted: docker-compose.blackwell.yml and
+# docker-compose.backup.yml were listed in the manifest and downloaded by
+# `opentranscribe.sh update-full`, but never by a fresh install. Because
+# get_compose_files() guards overlay selection with `[ -f ... ]`, the miss was SILENT —
+# a fresh install on a Blackwell (SM_121) card fell back to the generic GPU overlay and
+# then crashed in NVRTC on the first transcription, which is the app's core function
+# (see docs/BLACKWELL_SETUP.md, issue #640).
+#
+# Mirrors the replay loop in opentranscribe.sh's update-full arm, with the same
+# optional/exec/preserve flag semantics, plus this script's retry-and-timeout behaviour.
+# Adding a file to a deployment is now a one-line change in release-manifest.txt.
+download_release_manifest_artifacts() {
+    echo "✓ Downloading deployment files listed in release-manifest.txt..."
 
     local max_retries=3
     local branch="${OPENTRANSCRIBE_BRANCH:-master}"
     # URL-encode the branch name (replace / with %2F)
     local encoded_branch
     encoded_branch=$(echo "$branch" | sed 's|/|%2F|g')
+    local github_raw="https://raw.githubusercontent.com/attevon-llc/OpenTranscribe/${encoded_branch}"
 
-    # Download base docker-compose.yml
-    echo "  Downloading base docker-compose.yml..."
-    local retry_count=0
-    local base_url="https://raw.githubusercontent.com/attevon-llc/OpenTranscribe/${encoded_branch}/docker-compose.yml"
+    # The manifest itself is required. Guessing the file list is the bug this replaced,
+    # so refuse to install rather than fall back to an assumed set.
+    if ! curl -fsSL --connect-timeout 10 --max-time 30 \
+        "$github_raw/release-manifest.txt" -o release-manifest.txt.new; then
+        echo -e "${RED}❌ Failed to download release-manifest.txt from ${branch}${NC}"
+        echo "Refusing to install from an unknown artifact list."
+        echo "Alternative: You can manually download from: $github_raw/release-manifest.txt"
+        exit 1
+    fi
+    mv release-manifest.txt.new release-manifest.txt
 
-    while [ $retry_count -lt $max_retries ]; do
-        if curl -fsSL --connect-timeout 10 --max-time 30 "$base_url" -o docker-compose.yml; then
-            if [ -s docker-compose.yml ] && grep -q "services:" docker-compose.yml; then
-                echo "  ✓ Downloaded base docker-compose.yml"
+    local install_failed=0
+    local manifest_line artifact_path artifact_flags artifact_dir retry_count downloaded
+    while IFS= read -r manifest_line || [ -n "$manifest_line" ]; do
+        # Strip comments and blanks.
+        case "$manifest_line" in '' | '#'*) continue ;; esac
+
+        artifact_path=$(printf '%s' "$manifest_line" | cut -f1 | tr -d '[:space:]')
+        artifact_flags=$(printf '%s' "$manifest_line" | cut -s -f2)
+        [ -n "$artifact_path" ] || continue
+
+        # preserve = user-owned data; never clobber an existing copy.
+        case ",$artifact_flags," in
+            *,preserve,*)
+                if [ -f "$artifact_path" ]; then
+                    echo "  ↷ $artifact_path (preserved)"
+                    continue
+                fi
+                ;;
+        esac
+
+        artifact_dir=$(dirname "$artifact_path")
+        [ "$artifact_dir" = "." ] || mkdir -p "$artifact_dir"
+
+        retry_count=0
+        downloaded=0
+        while [ $retry_count -lt $max_retries ]; do
+            # Stage to .new so a failed attempt never truncates a good file.
+            if curl -fsSL --connect-timeout 10 --max-time 30 \
+                "$github_raw/$artifact_path" -o "${artifact_path}.new" &&
+                [ -s "${artifact_path}.new" ]; then
+                mv "${artifact_path}.new" "$artifact_path"
+                case ",$artifact_flags," in *,exec,*) chmod +x "$artifact_path" ;; esac
+                echo -e "  ${GREEN}✓${NC} $artifact_path"
+                downloaded=1
                 break
-            else
-                echo "  ⚠️  Downloaded base file appears invalid, retrying..."
-                rm -f docker-compose.yml
             fi
-        else
-            echo "  ⚠️  Download attempt $((retry_count + 1)) failed"
-        fi
+            rm -f "${artifact_path}.new"
+            retry_count=$((retry_count + 1))
+            if [ $retry_count -lt $max_retries ]; then
+                sleep 2
+            fi
+        done
 
-        retry_count=$((retry_count + 1))
-        if [ $retry_count -lt $max_retries ]; then
-            sleep 2
+        if [ "$downloaded" -eq 0 ]; then
+            case ",$artifact_flags," in
+                *,optional,*)
+                    echo -e "  ${YELLOW}⚠️${NC}  $artifact_path (optional, not in this release)"
+                    ;;
+                *)
+                    echo -e "  ${RED}✗${NC}  $artifact_path (REQUIRED — download failed)"
+                    install_failed=1
+                    ;;
+            esac
         fi
-    done
+    done <release-manifest.txt
 
-    if [ $retry_count -ge $max_retries ]; then
-        echo -e "${RED}❌ Failed to download base docker-compose.yml${NC}"
+    if [ "$install_failed" -ne 0 ]; then
+        echo ""
+        echo -e "${RED}❌ One or more required deployment files failed to download.${NC}"
         echo "Please check your internet connection and try again."
-        echo "Alternative: You can manually download from: $base_url"
         exit 1
     fi
 
-    # Download production overrides docker-compose.prod.yml
-    echo "  Downloading production overrides docker-compose.prod.yml..."
-    retry_count=0
-    local prod_url="https://raw.githubusercontent.com/attevon-llc/OpenTranscribe/${encoded_branch}/docker-compose.prod.yml"
-
-    while [ $retry_count -lt $max_retries ]; do
-        if curl -fsSL --connect-timeout 10 --max-time 30 "$prod_url" -o docker-compose.prod.yml; then
-            if [ -s docker-compose.prod.yml ] && grep -q "services:" docker-compose.prod.yml; then
-                echo "  ✓ Downloaded production docker-compose.prod.yml"
-
-                # Download GPU overlay for NVIDIA acceleration (non-fatal)
-                download_gpu_overlay
-
-                # Download optional gpu-scale overlay (non-fatal)
-                download_gpu_scale_overlay
-
-                echo "✓ Production docker-compose configuration complete"
-                return 0
-            else
-                echo "  ⚠️  Downloaded prod file appears invalid, retrying..."
-                rm -f docker-compose.prod.yml
-            fi
-        else
-            echo "  ⚠️  Download attempt $((retry_count + 1)) failed"
-        fi
-
-        retry_count=$((retry_count + 1))
-        if [ $retry_count -lt $max_retries ]; then
-            sleep 2
-        fi
-    done
-
-    echo -e "${RED}❌ Failed to download docker-compose.prod.yml${NC}"
-    echo "Please check your internet connection and try again."
-    echo "Alternative: You can manually download from: $prod_url"
-    exit 1
-}
-
-download_gpu_overlay() {
-    # Download docker-compose.gpu.yml for NVIDIA GPU support
-    # This enables GPU acceleration when NVIDIA Container Toolkit is detected
-    echo "  Downloading docker-compose.gpu.yml (GPU acceleration support)..."
-
-    local branch="${OPENTRANSCRIBE_BRANCH:-master}"
-    local encoded_branch
-    encoded_branch=$(echo "$branch" | sed 's|/|%2F|g')
-    local gpu_url="https://raw.githubusercontent.com/attevon-llc/OpenTranscribe/${encoded_branch}/docker-compose.gpu.yml"
-
-    if curl -fsSL --connect-timeout 10 --max-time 30 "$gpu_url" -o docker-compose.gpu.yml 2>/dev/null; then
-        if [ -s docker-compose.gpu.yml ] && grep -q "celery-worker:" docker-compose.gpu.yml; then
-            echo "  ✓ Downloaded docker-compose.gpu.yml (GPU acceleration)"
-        else
-            echo "  ⚠️  Downloaded gpu file appears invalid, removing..."
-            rm -f docker-compose.gpu.yml
-        fi
-    else
-        echo "  ℹ️  docker-compose.gpu.yml not available (GPU support optional)"
-    fi
-}
-
-download_gpu_scale_overlay() {
-    # Optional: Download docker-compose.gpu-scale.yml for multi-GPU support
-    # This is non-fatal - users can skip if they don't have multi-GPU setups
-    echo "  Downloading optional docker-compose.gpu-scale.yml (multi-GPU support)..."
-
-    local branch="${OPENTRANSCRIBE_BRANCH:-master}"
-    local encoded_branch
-    encoded_branch=$(echo "$branch" | sed 's|/|%2F|g')
-    local gpu_scale_url="https://raw.githubusercontent.com/attevon-llc/OpenTranscribe/${encoded_branch}/docker-compose.gpu-scale.yml"
-
-    if curl -fsSL --connect-timeout 10 --max-time 30 "$gpu_scale_url" -o docker-compose.gpu-scale.yml 2>/dev/null; then
-        if [ -s docker-compose.gpu-scale.yml ] && grep -q "celery-worker-gpu-scaled:" docker-compose.gpu-scale.yml; then
-            echo "  ✓ Downloaded docker-compose.gpu-scale.yml (optional multi-GPU scaling)"
-        else
-            echo "  ⚠️  Downloaded gpu-scale file appears invalid, removing..."
-            rm -f docker-compose.gpu-scale.yml
-        fi
-    else
-        echo "  ℹ️  docker-compose.gpu-scale.yml not available (optional feature)"
-    fi
-}
-
-download_management_script() {
-    echo "✓ Downloading OpenTranscribe management script..."
-
-    # Download the opentranscribe.sh script from the repository
-    local max_retries=3
-    local retry_count=0
-    local branch="${OPENTRANSCRIBE_BRANCH:-master}"
-    # URL-encode the branch name (replace / with %2F)
-    local encoded_branch
-    encoded_branch=$(echo "$branch" | sed 's|/|%2F|g')
-    local download_url="https://raw.githubusercontent.com/attevon-llc/OpenTranscribe/${encoded_branch}/opentranscribe.sh"
-
-    while [ $retry_count -lt $max_retries ]; do
-        if curl -fsSL --connect-timeout 10 --max-time 30 "$download_url" -o opentranscribe.sh; then
-            # Validate downloaded file
-            if [ -s opentranscribe.sh ] && grep -q "OpenTranscribe Management Script" opentranscribe.sh; then
-                chmod +x opentranscribe.sh
-                echo "✓ Downloaded and validated opentranscribe.sh"
-                return 0
-            else
-                echo "⚠️  Downloaded opentranscribe.sh appears invalid, retrying..."
-                rm -f opentranscribe.sh
-            fi
-        else
-            echo "⚠️  Download attempt $((retry_count + 1)) failed"
-        fi
-
-        retry_count=$((retry_count + 1))
-        if [ $retry_count -lt $max_retries ]; then
-            echo "⏳ Retrying in 2 seconds..."
-            sleep 2
-        fi
-    done
-
-    echo -e "${YELLOW}⚠️  Failed to download opentranscribe.sh after $max_retries attempts${NC}"
-    echo "You can manually download from: $download_url"
-}
-
-download_nginx_files() {
-    echo "✓ Downloading NGINX/SSL configuration files..."
-
-    local max_retries=3
-    local branch="${OPENTRANSCRIBE_BRANCH:-master}"
-    local encoded_branch
-    encoded_branch=$(echo "$branch" | sed 's|/|%2F|g')
-
-    # Create nginx and scripts directory structure
-    mkdir -p nginx/ssl
-    mkdir -p scripts
-    touch nginx/ssl/.gitkeep
-
-    # Download docker-compose.nginx.yml
-    echo "  Downloading docker-compose.nginx.yml..."
-    local retry_count=0
-    local nginx_compose_url="https://raw.githubusercontent.com/attevon-llc/OpenTranscribe/${encoded_branch}/docker-compose.nginx.yml"
-
-    while [ $retry_count -lt $max_retries ]; do
-        if curl -fsSL --connect-timeout 10 --max-time 30 "$nginx_compose_url" -o docker-compose.nginx.yml; then
-            if [ -s docker-compose.nginx.yml ] && grep -q "nginx:" docker-compose.nginx.yml; then
-                echo "  ✓ Downloaded docker-compose.nginx.yml"
-                break
-            else
-                echo "  ⚠️  Downloaded nginx compose file appears invalid, retrying..."
-                rm -f docker-compose.nginx.yml
-            fi
-        else
-            echo "  ⚠️  Download attempt $((retry_count + 1)) failed"
-        fi
-
-        retry_count=$((retry_count + 1))
-        if [ $retry_count -lt $max_retries ]; then
-            sleep 2
-        fi
-    done
-
-    if [ $retry_count -ge $max_retries ]; then
-        echo "  ⚠️  Could not download docker-compose.nginx.yml (HTTPS support optional)"
-    fi
-
-    # Download nginx/site.conf.template
-    echo "  Downloading nginx/site.conf.template..."
-    retry_count=0
-    local nginx_conf_url="https://raw.githubusercontent.com/attevon-llc/OpenTranscribe/${encoded_branch}/nginx/site.conf.template"
-
-    while [ $retry_count -lt $max_retries ]; do
-        if curl -fsSL --connect-timeout 10 --max-time 30 "$nginx_conf_url" -o nginx/site.conf.template; then
-            if [ -s nginx/site.conf.template ] && grep -q "server" nginx/site.conf.template; then
-                echo "  ✓ Downloaded nginx/site.conf.template"
-                break
-            else
-                echo "  ⚠️  Downloaded nginx config appears invalid, retrying..."
-                rm -f nginx/site.conf.template
-            fi
-        else
-            echo "  ⚠️  Download attempt $((retry_count + 1)) failed"
-        fi
-
-        retry_count=$((retry_count + 1))
-        if [ $retry_count -lt $max_retries ]; then
-            sleep 2
-        fi
-    done
-
-    if [ $retry_count -ge $max_retries ]; then
-        echo "  ⚠️  Could not download nginx/site.conf.template (HTTPS support optional)"
-    fi
-
-    # Download scripts/generate-ssl-cert.sh
-    echo "  Downloading scripts/generate-ssl-cert.sh..."
-    retry_count=0
-    local ssl_script_url="https://raw.githubusercontent.com/attevon-llc/OpenTranscribe/${encoded_branch}/scripts/generate-ssl-cert.sh"
-
-    while [ $retry_count -lt $max_retries ]; do
-        if curl -fsSL --connect-timeout 10 --max-time 30 "$ssl_script_url" -o scripts/generate-ssl-cert.sh; then
-            if [ -s scripts/generate-ssl-cert.sh ] && grep -q "SSL Certificate" scripts/generate-ssl-cert.sh; then
-                chmod +x scripts/generate-ssl-cert.sh
-                echo "  ✓ Downloaded scripts/generate-ssl-cert.sh"
-                break
-            else
-                echo "  ⚠️  Downloaded SSL script appears invalid, retrying..."
-                rm -f scripts/generate-ssl-cert.sh
-            fi
-        else
-            echo "  ⚠️  Download attempt $((retry_count + 1)) failed"
-        fi
-
-        retry_count=$((retry_count + 1))
-        if [ $retry_count -lt $max_retries ]; then
-            sleep 2
-        fi
-    done
-
-    if [ $retry_count -ge $max_retries ]; then
-        echo "  ⚠️  Could not download scripts/generate-ssl-cert.sh (HTTPS support optional)"
-    fi
-
-    # Download scripts/fix-model-permissions.sh
-    echo "  Downloading scripts/fix-model-permissions.sh..."
-    retry_count=0
-    local fix_perms_url="https://raw.githubusercontent.com/attevon-llc/OpenTranscribe/${encoded_branch}/scripts/fix-model-permissions.sh"
-
-    while [ $retry_count -lt $max_retries ]; do
-        if curl -fsSL --connect-timeout 10 --max-time 30 "$fix_perms_url" -o scripts/fix-model-permissions.sh; then
-            if [ -s scripts/fix-model-permissions.sh ] && grep -q "Permission" scripts/fix-model-permissions.sh; then
-                chmod +x scripts/fix-model-permissions.sh
-                echo "  ✓ Downloaded scripts/fix-model-permissions.sh"
-                break
-            else
-                echo "  ⚠️  Downloaded fix-permissions script appears invalid, retrying..."
-                rm -f scripts/fix-model-permissions.sh
-            fi
-        else
-            echo "  ⚠️  Download attempt $((retry_count + 1)) failed"
-        fi
-
-        retry_count=$((retry_count + 1))
-        if [ $retry_count -lt $max_retries ]; then
-            sleep 2
-        fi
-    done
-
-    if [ $retry_count -ge $max_retries ]; then
-        echo "  ⚠️  Could not download scripts/fix-model-permissions.sh"
-    fi
-
-    echo "✓ NGINX/SSL files download complete"
-}
-
-download_model_downloader_scripts() {
-    echo "✓ Downloading model downloader scripts..."
-
-    # Create scripts directory
-    mkdir -p scripts
-
-    # Download download-models.sh
-    local max_retries=3
-    local retry_count=0
-    local branch="${OPENTRANSCRIBE_BRANCH:-master}"
-    local encoded_branch
-    encoded_branch=$(echo "$branch" | sed 's|/|%2F|g')
-    local download_url="https://raw.githubusercontent.com/attevon-llc/OpenTranscribe/${encoded_branch}/scripts/download-models.sh"
-
-    while [ $retry_count -lt $max_retries ]; do
-        if curl -fsSL --connect-timeout 10 --max-time 30 "$download_url" -o scripts/download-models.sh; then
-            if [ -s scripts/download-models.sh ] && grep -q "OpenTranscribe Model Downloader" scripts/download-models.sh; then
-                chmod +x scripts/download-models.sh
-                echo "✓ Downloaded and validated download-models.sh"
-                break
-            else
-                echo "⚠️  Downloaded download-models.sh appears invalid, retrying..."
-                rm -f scripts/download-models.sh
-            fi
-        else
-            echo "⚠️  Download attempt $((retry_count + 1)) failed"
-        fi
-
-        retry_count=$((retry_count + 1))
-        if [ $retry_count -lt $max_retries ]; then
-            echo "⏳ Retrying in 2 seconds..."
-            sleep 2
-        fi
-    done
-
-    # Download download-models.py
-    retry_count=0
-    download_url="https://raw.githubusercontent.com/attevon-llc/OpenTranscribe/${encoded_branch}/scripts/download-models.py"
-
-    while [ $retry_count -lt $max_retries ]; do
-        if curl -fsSL --connect-timeout 10 --max-time 30 "$download_url" -o scripts/download-models.py; then
-            if [ -s scripts/download-models.py ] && grep -q "Download all required AI models" scripts/download-models.py; then
-                echo "✓ Downloaded and validated download-models.py"
-                break
-            else
-                echo "⚠️  Downloaded download-models.py appears invalid, retrying..."
-                rm -f scripts/download-models.py
-            fi
-        else
-            echo "⚠️  Download attempt $((retry_count + 1)) failed"
-        fi
-
-        retry_count=$((retry_count + 1))
-        if [ $retry_count -lt $max_retries ]; then
-            echo "⏳ Retrying in 2 seconds..."
-            sleep 2
-        fi
-    done
-
-    # Download common.sh (utility functions used by opentr.sh)
-    retry_count=0
-    download_url="https://raw.githubusercontent.com/attevon-llc/OpenTranscribe/${encoded_branch}/scripts/common.sh"
-
-    while [ $retry_count -lt $max_retries ]; do
-        if curl -fsSL --connect-timeout 10 --max-time 30 "$download_url" -o scripts/common.sh; then
-            if [ -s scripts/common.sh ] && grep -q "check_docker" scripts/common.sh; then
-                echo "✓ Downloaded and validated common.sh"
-                return 0
-            else
-                echo "⚠️  Downloaded common.sh appears invalid, retrying..."
-                rm -f scripts/common.sh
-            fi
-        else
-            echo "⚠️  Download attempt $((retry_count + 1)) failed"
-        fi
-
-        retry_count=$((retry_count + 1))
-        if [ $retry_count -lt $max_retries ]; then
-            echo "⏳ Retrying in 2 seconds..."
-            sleep 2
-        fi
-    done
-
-    echo -e "${YELLOW}⚠️  Failed to download model downloader scripts${NC}"
-    echo "Models will be downloaded on first application run instead."
-}
-
-create_production_env_example() {
-    echo "✓ Downloading environment configuration template..."
-
-    # Download the official .env.example from the repository
-    local max_retries=3
-    local retry_count=0
-    local branch="${OPENTRANSCRIBE_BRANCH:-master}"
-    # URL-encode the branch name (replace / with %2F)
-    local encoded_branch
-    encoded_branch=$(echo "$branch" | sed 's|/|%2F|g')
-    local download_url="https://raw.githubusercontent.com/attevon-llc/OpenTranscribe/${encoded_branch}/.env.example"
-
-    while [ $retry_count -lt $max_retries ]; do
-        if curl -fsSL --connect-timeout 10 --max-time 30 "$download_url" -o .env.example; then
-            # Validate downloaded file
-            if [ -s .env.example ] && grep -q "POSTGRES_HOST" .env.example && grep -q "HUGGINGFACE_TOKEN" .env.example; then
-                echo "✓ Downloaded and validated .env.example"
-                return 0
-            else
-                echo "⚠️  Downloaded env file appears invalid, retrying..."
-                rm -f .env.example
-            fi
-        else
-            echo "⚠️  Download attempt $((retry_count + 1)) failed"
-        fi
-
-        retry_count=$((retry_count + 1))
-        if [ $retry_count -lt $max_retries ]; then
-            echo "⏳ Retrying in 2 seconds..."
-            sleep 2
-        fi
-    done
-
-    echo -e "${RED}❌ Failed to download .env.example file after $max_retries attempts${NC}"
-    echo "Please check your internet connection and try again."
-    echo "Alternative: You can manually download from:"
-    echo "$download_url"
-    exit 1
+    echo "✓ All deployment files downloaded"
 }
 
 prompt_huggingface_token() {


### PR DESCRIPTION
Fixes #640. Advances #639 (does **not** close it — see below).

## #640 — the installer never read `release-manifest.txt`

`setup-opentranscribe.sh` kept its own hardcoded list of compose overlays and never read the
manifest, contradicting the manifest's own header, which has always named the installer as a
consumer. Two files had drifted: `docker-compose.blackwell.yml` and `docker-compose.backup.yml`
were listed, replayed by `update-full`, and **never** downloaded by a fresh install.

The miss is silent, not loud. `get_compose_files()` selects with
`if is_blackwell_gpu && [ -f docker-compose.blackwell.yml ]`, so an absent file falls through to
the generic GPU overlay — the stack comes up healthy and then crashes on the first transcription,
because NVRTC does not recognise `compute_121` (`docs/BLACKWELL_SETUP.md`).

Replaced all seven hardcoded download functions with one manifest replay loop mirroring
`update-full`'s (same `optional`/`exec`/`preserve` semantics, keeping the installer's retries and
timeouts, staging to `.new` so a failed attempt cannot truncate a good file). Adding a file to a
deployment is now a one-line manifest change.

Two deliberate behaviour changes: `scripts/common.sh` is now `chmod +x` (the manifest flags it
`exec`; the old path never did), and a failed download of a non-optional artifact is now fatal
rather than a warning — `release-validate.yml` asserts every manifest path is fetchable at the
tag, so this only fires on genuine breakage, and a partial config set is worse than no install.

## #639 — the native diarizer was unreachable on every self-hosted install

`engine.diarizer_backend` defaults to `native`, but no self-hosted deployment could ever run the
sidecar, so every install served every file from the PyAnnote fallback while the config, docs and
admin UI all said `native`. Four blockers; **three fixed here**:

1. `docker-compose.diar-native.yml` was not in `release-manifest.txt` — never reached disk.
2. The overlay was unusable off one workstation even if you had it. It pinned
   `image: opentranscribe-backend:latest` (the **dev-local** build tag) and, because this overlay
   merges last, that would have overridden the prod image and sent Docker looking for
   `docker.io/library/opentranscribe-backend`. Its weights defaulted to an absolute path on one
   machine. Both now follow existing conventions: the published image keyed on `OT_IMAGE_TAG`, and
   `${MODEL_CACHE_DIR}/diar-native`, a sibling of the `huggingface/` and `torch/` caches.
3. `opentranscribe.sh` had **zero** diar-native references. It now selects the overlay and says
   which engine will actually run when it cannot.

Selection is keyed on the exported weights **existing**, not a new toggle. The first draft added
`DIAR_NATIVE_ENABLED`; that was wrong. Unlike `BACKUP_HOST_PATH` (which `.env.example` ships set,
so its presence proves nothing), this directory is created only by running the export — so its
presence is already real evidence of intent, and it is self-consistent, since "no weights" is
exactly when starting the sidecar would crash-loop. Net result: **one fewer** variable in
`.env.example` than before.

### Correcting the record on why this was stuck

#572 and #639 both describe the weights as non-redistributable, which read as a licensing dead
end. Checked against the HuggingFace API instead: `community-1` is **cc-by-4.0** with
`gated: auto` (an auto-approve email-capture gate whose own prompt says the pipeline "will always
remain freely accessible"), `segmentation-3.0` is **MIT**, and `wespeaker-voxceleb-resnet34-LM` is
**cc-by-4.0 and not gated at all**.

Nothing needs redistributing regardless: diar-native is a Rust/ONNX reimplementation of the *same*
pyannote pipeline, so its weights are obtained the same way PyAnnote's already are — the
operator's own `HUGGINGFACE_TOKEN` — and the `diar-server` binary has shipped inside the backend
image since `a15e94c2` (from the **public** `davidamacey/diar-native`, confirmed `is_private:
False`).

### Why #639 stays open

The fourth blocker: **no `.onnx` file exists on HuggingFace for any of these models** (verified via
the API — the repos ship `pytorch_model.bin` and `plda/*.npz` only), so the conversion must happen
locally, and that conversion code exists nowhere in this repo. Running it inside the shipped
backend image was measured and does not work: `numpy` is not importable from that image's
`python3` and `onnxscript` is absent.

Tracked as **attevon-llc/diar-native#2**, which proposes a `provision-models` command that
downloads with an HF token, exports, smoke-tests, and sets a health flag. Hand-writing a
replacement exporter here was deliberately avoided — a subtly-wrong ONNX export degrades
diarization silently, which is the worst failure mode.

### One regression caught and fixed mid-branch

Moving the models default broke dev checkouts whose export is at the old sibling-repo path and
which have no `DIAR_NATIVE_MODELS_DIR` in `.env` — verified to be the case on the maintainer
workstation, where the sidecar would simply have stopped loading with no error. That is the exact
silent fallback this issue exists to remove. `resolve_diar_native_models_dir()` now resolves once
and **exports**, so the auto-load check and the compose mount cannot disagree, and the legacy
probe is announced rather than silent.

## Verification

- Red-then-green via `git archive HEAD` for every behavioural test. Both #640 tests failed against
  HEAD; 3 of 4 #639 selection tests failed, with the fourth a deliberate must-stay-clean control.
- 99 tests pass across `test_release_manifest.py`, `test_compose_file_selection.py`,
  `test_compose_chain_manifest_optional.py`, `test_install_upgrade_scripts.py`.
- Compose nested-default interpolation verified against real `docker compose config` in all three
  cases (unset / `OT_IMAGE_TAG` set / `DIAR_NATIVE_IMAGE` override).
- `bash -n` + `shellcheck` clean on all three shell scripts; `safe-precommit.sh` clean per commit.

⚠️ **Not verified: real Blackwell hardware.** This machine has 2× RTX A6000 + an RTX 3080 Ti and
no SM_121 card. The #640 fix is verified *structurally* — the installer demonstrably downloads
`docker-compose.blackwell.yml` — but the NVRTC `compute_121` runtime behaviour it protects against
is unverified here and needs a real RTX 50-series / GB10 host.

## Not included

Issue #638 (offline `file://` OpenSearch-ML registration) was investigated but not fixed; findings
are in the issue thread rather than this branch.
