### PR TITLE
fix(search): register OpenSearch models offline via the shared /ml-models path

### DIFF
--- a/backend/app/services/search/model_downloader.py
+++ b/backend/app/services/search/model_downloader.py
@@ -76,9 +76,12 @@ _OPENSEARCH_MODEL_REGISTRY = {
     },
 }
 
-# Default model cache directory (backend container path)
-# This maps to ${MODEL_CACHE_DIR}/opensearch-ml on the host
-_DEFAULT_CACHE_DIR = Path.home() / ".cache" / "opensearch-ml"
+# Default model cache directory (backend container path).
+# This is the SAME path OpenSearch mounts read-only at /ml-models (docker-compose.yml),
+# backed by ${MODEL_CACHE_DIR}/opensearch-ml on the host -- not a private backend-only
+# cache. ml_model_service.get_local_model_path() reads from this exact path, so a model
+# downloaded anywhere else is invisible to it (issue #638).
+_DEFAULT_CACHE_DIR = Path("/ml-models")
 
 
 def ensure_model_downloaded(model_name: str, cache_dir: Path | None = None) -> Path | None:
@@ -108,12 +111,18 @@ def ensure_model_downloaded(model_name: str, cache_dir: Path | None = None) -> P
     model_dir.mkdir(parents=True, exist_ok=True)
 
     model_path = model_dir / filename
+    config_path = model_dir / "config.json"
+    config_url = f"{model_info['url_base']}/{model_name}/{version}/torch_script/config.json"
 
     # Check if already downloaded
     if model_path.exists() and model_path.stat().st_size > 0:
         logger.info(
             f"Model already cached: {model_path} ({model_path.stat().st_size / (1024 * 1024):.1f} MB)"
         )
+        # An older cache may hold the zip but not the config.json this fetches now
+        # (issue #638) -- the zip alone cannot be registered offline, so fetch the
+        # missing half rather than reporting a complete cache.
+        _fetch_model_config(config_url, config_path)
         return model_path
 
     # Build download URL
@@ -141,6 +150,13 @@ def ensure_model_downloaded(model_name: str, cache_dir: Path | None = None) -> P
             size_mb = model_path.stat().st_size / (1024 * 1024)
             logger.info(f"Model downloaded successfully: {size_mb:.1f} MB")
 
+            # OpenSearch requires model_config for a file:// registration -- without it,
+            # OpenSearch 3.4 answers 400 "model config is null" (issue #638). Fetching
+            # config.json (published beside every artifact) is what makes offline
+            # registration work without hardcoding a per-model type table that would
+            # drift from upstream.
+            _fetch_model_config(config_url, config_path)
+
             # Update manifest
             _update_manifest(cache_dir, model_name, model_info)
 
@@ -159,6 +175,29 @@ def ensure_model_downloaded(model_name: str, cache_dir: Path | None = None) -> P
     except Exception as e:
         logger.error(f"Failed to download model {model_name}: {e}")
         return None
+
+
+def _fetch_model_config(config_url: str, config_path: Path) -> bool:
+    """Fetch the config.json OpenSearch publishes beside a model artifact.
+
+    Registering a model from a ``file://`` URL REQUIRES its ``model_config``; without it
+    OpenSearch answers ``400 illegal_argument_exception: model config is null`` (issue #638).
+    The file also carries ``model_content_hash_value``, so fetching it buys an integrity
+    check for free. Mirrors ``scripts/download-models.py``'s ``_fetch_model_config`` -- keep
+    both in sync; the config format is OpenSearch's, not ours.
+
+    Returns True when a non-empty config.json is present afterwards.
+    """
+    if config_path.exists() and config_path.stat().st_size > 0:
+        return True
+    try:
+        urllib.request.urlretrieve(config_url, config_path)  # noqa: S310  # nosec B310
+        return config_path.exists() and config_path.stat().st_size > 0
+    except Exception as e:
+        logger.warning(
+            f"config.json unavailable ({e}); cannot register {config_path.parent.name} offline"
+        )
+        return False
 
 
 def _update_manifest(cache_dir: Path, model_name: str, model_info: dict[str, Any]) -> None:

--- a/backend/tests/unit/test_model_downloader.py
+++ b/backend/tests/unit/test_model_downloader.py
@@ -65,11 +65,17 @@ def test_ensure_model_downloaded_already_cached_returns_path_without_downloading
     cached_path = model_dir / filename
     cached_path.write_bytes(b"already-here")
 
-    with patch("app.services.search.model_downloader.urllib.request.urlretrieve") as retrieve:
+    with patch(
+        "app.services.search.model_downloader.urllib.request.urlretrieve",
+        side_effect=_fake_urlretrieve_writes_bytes(b"fake-config"),
+    ) as retrieve:
         result = ensure_model_downloaded(_KNOWN_MODEL, cache_dir=tmp_path)
 
     assert result == cached_path
-    retrieve.assert_not_called()
+    # The cached MODEL zip must not be re-downloaded -- only the missing
+    # config.json (issue #638) is fetched on a cache hit.
+    retrieve.assert_called_once()
+    assert retrieve.call_args[0][0].endswith("/config.json")
     # The cached bytes must not have been touched.
     assert cached_path.read_bytes() == b"already-here"
 
@@ -91,7 +97,8 @@ def test_ensure_model_downloaded_zero_byte_cached_file_is_treated_as_not_cached(
     ) as retrieve:
         result = ensure_model_downloaded(_KNOWN_MODEL, cache_dir=tmp_path)
 
-    retrieve.assert_called_once()
+    # One call for the model zip, one for its config.json (issue #638).
+    assert retrieve.call_count == 2
     assert result == stale_empty
     assert stale_empty.read_bytes() == b"fake-model-zip-bytes"
 
@@ -141,12 +148,18 @@ def test_ensure_model_downloaded_url_uses_registry_url_base_name_version_and_fil
     ):
         ensure_model_downloaded(_KNOWN_MODEL, cache_dir=tmp_path)
 
-    assert len(captured_urls) == 1
-    expected = (
+    # One request for the model zip, one for its config.json (issue #638).
+    assert len(captured_urls) == 2
+    expected_zip = (
         f"{_KNOWN_MODEL_INFO['url_base']}/{_KNOWN_MODEL}/{_KNOWN_MODEL_INFO['version']}"
         f"/torch_script/{_KNOWN_MODEL_INFO['filename']}"
     )
-    assert captured_urls[0] == expected
+    expected_config = (
+        f"{_KNOWN_MODEL_INFO['url_base']}/{_KNOWN_MODEL}/{_KNOWN_MODEL_INFO['version']}"
+        f"/torch_script/config.json"
+    )
+    assert captured_urls[0] == expected_zip
+    assert captured_urls[1] == expected_config
 
 
 # =============================================================================
@@ -227,10 +240,12 @@ def test_ensure_model_downloaded_generic_exception_returns_none(tmp_path):
 # =============================================================================
 
 
-def test_ensure_model_downloaded_defaults_to_home_cache_dir_when_none_given(tmp_path):
-    fake_home_cache = tmp_path / "home-cache"
+def test_ensure_model_downloaded_defaults_to_the_module_level_default_cache_dir_when_none_given(
+    tmp_path,
+):
+    fake_default_cache = tmp_path / "shared-ml-models"
     with (
-        patch("app.services.search.model_downloader._DEFAULT_CACHE_DIR", fake_home_cache),
+        patch("app.services.search.model_downloader._DEFAULT_CACHE_DIR", fake_default_cache),
         patch(
             "app.services.search.model_downloader.urllib.request.urlretrieve",
             side_effect=_fake_urlretrieve_writes_bytes(),
@@ -239,7 +254,108 @@ def test_ensure_model_downloaded_defaults_to_home_cache_dir_when_none_given(tmp_
         result = ensure_model_downloaded(_KNOWN_MODEL, cache_dir=None)
 
     assert result is not None
-    assert result.is_relative_to(fake_home_cache)
+    assert result.is_relative_to(fake_default_cache)
+
+
+def test_default_cache_dir_is_the_shared_ml_models_mount():
+    """The default must match OpenSearch's read-only ``/ml-models`` mount
+    (docker-compose.yml), not a private per-service cache -- OpenSearch resolves a
+    ``file://`` registration on ITS OWN filesystem, so a model downloaded anywhere
+    else is invisible to it (issue #638)."""
+    assert Path("/ml-models") == model_downloader._DEFAULT_CACHE_DIR
+
+
+# =============================================================================
+# _fetch_model_config (issue #638) -- OpenSearch refuses a file:// registration
+# with "model config is null" unless config.json sits beside the model zip.
+# =============================================================================
+
+
+def test_fetch_model_config_downloads_when_missing(tmp_path):
+    config_path = tmp_path / "config.json"
+
+    with patch(
+        "app.services.search.model_downloader.urllib.request.urlretrieve",
+        side_effect=_fake_urlretrieve_writes_bytes(b'{"model_config": {}}'),
+    ) as retrieve:
+        result = model_downloader._fetch_model_config(
+            "https://example.test/config.json", config_path
+        )
+
+    assert result is True
+    retrieve.assert_called_once_with("https://example.test/config.json", config_path)
+    assert config_path.read_bytes() == b'{"model_config": {}}'
+
+
+def test_fetch_model_config_skips_download_when_already_present(tmp_path):
+    config_path = tmp_path / "config.json"
+    config_path.write_bytes(b'{"model_config": {}}')
+
+    with patch("app.services.search.model_downloader.urllib.request.urlretrieve") as retrieve:
+        result = model_downloader._fetch_model_config(
+            "https://example.test/config.json", config_path
+        )
+
+    assert result is True
+    retrieve.assert_not_called()
+
+
+def test_fetch_model_config_redownloads_a_zero_byte_existing_file(tmp_path):
+    config_path = tmp_path / "config.json"
+    config_path.write_bytes(b"")
+
+    with patch(
+        "app.services.search.model_downloader.urllib.request.urlretrieve",
+        side_effect=_fake_urlretrieve_writes_bytes(b'{"model_config": {}}'),
+    ) as retrieve:
+        result = model_downloader._fetch_model_config(
+            "https://example.test/config.json", config_path
+        )
+
+    assert result is True
+    retrieve.assert_called_once()
+    assert config_path.read_bytes() == b'{"model_config": {}}'
+
+
+def test_fetch_model_config_returns_false_and_does_not_raise_on_network_failure(tmp_path):
+    """A missing config.json (e.g. offline, or a model with none published) must
+    degrade to a warning -- the caller (``ensure_model_downloaded``) still returns
+    the model zip path even when the config fetch fails, since a stale/absent
+    config.json is a registration-time problem, not a download failure."""
+    config_path = tmp_path / "config.json"
+
+    with patch(
+        "app.services.search.model_downloader.urllib.request.urlretrieve",
+        side_effect=urllib.error.URLError("network unreachable"),
+    ):
+        result = model_downloader._fetch_model_config(
+            "https://example.test/config.json", config_path
+        )
+
+    assert result is False
+    assert not config_path.exists()
+
+
+def test_ensure_model_downloaded_succeeds_even_when_config_fetch_fails(tmp_path):
+    """The model zip download must not be treated as a failure just because the
+    sidecar config.json request failed (e.g. offline) -- see the docstring above."""
+
+    def _fake(url, filename, reporthook=None):
+        if str(filename).endswith("config.json"):
+            raise urllib.error.URLError("network unreachable")
+        Path(filename).write_bytes(b"real-bytes-here")
+
+    with patch(
+        "app.services.search.model_downloader.urllib.request.urlretrieve", side_effect=_fake
+    ):
+        result = ensure_model_downloaded(_KNOWN_MODEL, cache_dir=tmp_path)
+
+    short_name = _KNOWN_MODEL_INFO["short_name"]
+    filename = _KNOWN_MODEL_INFO["filename"]
+    expected_path = tmp_path / short_name / filename
+    assert result == expected_path
+    assert expected_path.read_bytes() == b"real-bytes-here"
+    assert not (tmp_path / short_name / "config.json").exists()
 
 
 # =============================================================================

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -176,6 +176,10 @@ services:
       - plugins.ml_commons.native_memory_threshold=99
       - plugins.ml_commons.model_access_control_enabled=false
       - plugins.ml_commons.allow_registering_model_via_url=true
+      # Required separately from the url permission above -- OpenSearch 3.4 refuses a
+      # file:// registration outright without this, independent of whether the backend
+      # can even reach the shared /ml-models path (issue #638).
+      - plugins.ml_commons.allow_registering_model_via_local_file=true
     ulimits:
       memlock:
         soft: -1
@@ -218,6 +222,11 @@ services:
       - ${MODEL_CACHE_DIR:-./models}/nltk_data:/home/appuser/.cache/nltk_data
       # RAG chat loads a CPU cross-encoder here to rerank retrieval results.
       - ${MODEL_CACHE_DIR:-./models}/huggingface:/home/appuser/.cache/huggingface
+      # Read-write access to the SAME host directory OpenSearch mounts read-only at
+      # /ml-models (issue #638) -- OpenSearch resolves a file:// model registration on
+      # its OWN filesystem, so a model the backend downloads must land in this shared
+      # path, not the backend's private cache, for OpenSearch to ever find it.
+      - ${MODEL_CACHE_DIR:-./models}/opensearch-ml:/ml-models
       # Shared scratch for cross-worker preprocessed-WAV handoff
       - pipeline_scratch:/scratch/opentranscribe
     ports:


### PR DESCRIPTION
## Summary
Fixes #638 — offline/air-gapped OpenSearch neural model registration was failing for three independent reasons:

1. OpenSearch 3.4 refuses a `file://` model registration outright without `plugins.ml_commons.allow_registering_model_via_local_file=true`, separate from the existing `allow_registering_model_via_url` permission.
2. `model_downloader._DEFAULT_CACHE_DIR` pointed at the backend's own private `~/.cache/opensearch-ml`, not the `/ml-models` path OpenSearch mounts read-only — OpenSearch resolves a `file://` URL on its own filesystem, so a model downloaded to the backend's private cache was invisible to it. The backend now also mounts the same host directory read-write.
3. A `file://` registration requires the model's `config.json` (`model_config`); without it OpenSearch answers `400 illegal_argument_exception: model config is null`. The downloader now fetches `config.json` alongside the model zip, mirroring `scripts/download-models.py`'s existing `_fetch_model_config`.

## Testing
- Extended `backend/tests/unit/test_model_downloader.py`: 24 tests, all green (previously 18; 6 net-new covering `_fetch_model_config` and the new default path).
- Verified genuinely red against the pre-fix source via a clean `git archive master` snapshot (8 of the new/changed tests fail against the old code, for the expected reasons), then green on the fix.
- No regressions in `test_offline_model_registration.py` or `test_embedding_model_registries_agree.py`.
- `scripts/safe-precommit.sh run --files ...` clean on all three touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)