### PR TITLE
fix(llm): recover mid-document malformed JSON in AI summaries

### DIFF
--- a/backend/app/core/default_prompts.py
+++ b/backend/app/core/default_prompts.py
@@ -27,6 +27,10 @@ CRITICAL REQUIREMENTS:
 5. Identify content-appropriate action items, decisions, or key takeaways
 6. Use clear, professional language appropriate for the detected content type
 7. Your response must be valid JSON matching the exact structure specified
+8. **Escaping**: If any string value needs to include a double quote character
+   (") — including when quoting someone's speech, or a measurement written
+   with an inch/foot mark like 6'6" — you MUST escape it as \" inside the
+   JSON string. Never place a literal, unescaped " inside a JSON string value.
 
 IMPORTANT: The transcript has already been processed with speaker embedding matching. Use the speaker information provided in SPEAKER INFORMATION section - do NOT attempt to identify or rename speakers. Focus on analyzing content and extracting insights.
 </task_instructions>
@@ -380,6 +384,11 @@ CRITICAL REQUIREMENTS:
 1. Use clear, professional language appropriate for the answer information
 2. Be gender neutral in the answer summaries
 3. Your response must be valid JSON matching the exact structure specified
+4. **Escaping**: Questions are repeated verbatim, so if a question or answer
+   needs to include a double quote character (") — including quoted speech or
+   a measurement written with an inch/foot mark like 6'6" — you MUST escape it
+   as \" inside the JSON string. Never place a literal, unescaped " inside a
+   JSON string value.
 
 IMPORTANT: The transcript has already been processed with speaker embedding matching. Use the speaker information provided in SPEAKER INFORMATION section - do NOT attempt to identify or rename speakers. Focus on analyzing content and extracting insights.
 </task_instructions>

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -1265,7 +1265,26 @@ class LLMService:
             parsed_result: dict[str, Any] = json.loads(content)
             return parsed_result
         except json.JSONDecodeError as e:
-            logger.error(f"Failed to parse section {section_num} JSON: {e}")
+            logger.warning(f"Failed to parse section {section_num} JSON: {e}")
+
+            # Same recovery as `_parse_summary_response` for a mid-document break
+            # (e.g. an unescaped literal `"` in the source transcript reproduced
+            # verbatim in a string value) — see that method for the full
+            # rationale. Worth doing here too: an unrecovered section becomes a
+            # "Failed to parse" placeholder that gets stitched verbatim into the
+            # combine-step prompt, degrading the final summary for that section.
+            try:
+                from json_repair import loads as repair_json_loads
+
+                lib_repaired = repair_json_loads(content)
+            except Exception:
+                lib_repaired = None
+
+            if isinstance(lib_repaired, dict) and lib_repaired:
+                logger.info(f"json_repair recovered section {section_num}'s summary")
+                return lib_repaired
+
+            logger.error(f"Section {section_num} JSON repair also failed")
             return {
                 "key_points": [f"Section {section_num}: Failed to parse structured summary"],
                 "speakers_in_section": [],
@@ -1399,10 +1418,7 @@ class LLMService:
         except json.JSONDecodeError as e:
             logger.warning(f"Initial JSON parse failed: {e}")
 
-            # Attempt JSON repair for truncated responses
-            repaired = self._repair_truncated_json(content)
-            if repaired is not None:
-                logger.info("JSON repair succeeded, using repaired summary")
+            def _repaired_metadata() -> dict[str, Any]:
                 metadata = {
                     "provider": self.config.provider.value,
                     "model": self.config.model,
@@ -1413,8 +1429,42 @@ class LLMService:
                 }
                 if extra_metadata:
                     metadata.update(extra_metadata)
-                repaired["metadata"] = metadata
+                return metadata
+
+            # Attempt JSON repair for truncated responses (a response cut off at
+            # the token limit, i.e. finish_reason="length" — nothing to close mid-
+            # document, only an open string/array/object at the very end).
+            repaired = self._repair_truncated_json(content)
+            if repaired is not None:
+                logger.info("JSON repair succeeded, using repaired summary")
+                repaired["metadata"] = _repaired_metadata()
                 return repaired
+
+            # The bracket-closer above only fixes a trailing cut-off. It does
+            # nothing for a MID-document syntax break, which produces a different
+            # symptom: json.loads fails well past the actual defect (e.g.
+            # "Expecting ':' delimiter" deep into an otherwise well-formed
+            # document) rather than at end-of-string, because there is no open
+            # bracket to close. Measured live: gemma-4-e4b, asked to summarize a
+            # transcript that contains a literal `"` (a spoken aside quoting a
+            # feet/inches measurement, e.g. `6'6"`), sometimes reproduces it
+            # unescaped inside a JSON string value — one stray quote desyncs the
+            # parser's in-string tracking for everything that follows.
+            # `json_repair` (zero transitive deps, MIT) handles this class
+            # directly instead of us hand-rolling a quote-scanner; it never
+            # raises, so a non-dict/empty result means it couldn't make sense of
+            # the content either.
+            try:
+                from json_repair import loads as repair_json_loads
+
+                lib_repaired = repair_json_loads(content)
+            except Exception:
+                lib_repaired = None
+
+            if isinstance(lib_repaired, dict) and lib_repaired:
+                logger.info("json_repair recovered a malformed (non-truncated) summary response")
+                lib_repaired["metadata"] = _repaired_metadata()
+                return lib_repaired
 
             logger.error(f"JSON repair also failed. Response content: {response.content[:500]}...")
 

--- a/backend/requirements-ci.txt
+++ b/backend/requirements-ci.txt
@@ -103,6 +103,8 @@ speechmatics-batch==0.5.0
 boto3==1.43.74
 openai==3.3.0
 requests==2.34.2
+# See requirements.txt for why — LLM summary JSON repair (llm_service.py)
+json-repair==0.63.4
 
 # Diarization metrics (cpWER) — exercised by tests/unit/test_diarization_metrics.py
 meeteval==0.4.3

--- a/backend/requirements-lite.txt
+++ b/backend/requirements-lite.txt
@@ -95,3 +95,5 @@ boto3==1.43.74
 openai==3.3.0
 # requests is pulled in transitively by many packages above, but list explicitly for clarity
 requests==2.34.2
+# See requirements.txt for why — LLM summary JSON repair (llm_service.py)
+json-repair==0.63.4

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -206,6 +206,14 @@ boto3==1.43.74
 openai==3.3.0
 # requests is pulled in by many packages but listed explicitly for Gladia REST calls
 requests==2.34.2
+# Recovers structurally-malformed JSON from LLM summary responses
+# (llm_service.py::_parse_summary_response) that `_repair_truncated_json`'s
+# bracket-closing can't fix — chiefly an unescaped literal `"` inside a string
+# value (e.g. a transcript quoting a feet/inches measurement like `6'6"`,
+# verified live on a real transcript), which desyncs the parser's
+# in-string tracking for everything after it, not just the tail. Zero
+# transitive dependencies.
+json-repair==0.63.4
 
 # Diarization-boundary benchmark (issue #193): cpWER metric. Lazily imported by
 # app.utils.diarization_metrics.cpwer + backend/scripts/benchmark_boundary.py — only

--- a/backend/tests/unit/test_llm_summary_json_repair.py
+++ b/backend/tests/unit/test_llm_summary_json_repair.py
@@ -1,0 +1,257 @@
+"""``LLMService._parse_summary_response`` / ``_summarize_section`` -- recovering
+malformed JSON from an AI-summary response.
+
+**Real bug found live** on a 3-hour transcript ("Joe Rogan Experience #2219",
+vllm/gemma-4-e4b): the same file, same model, summarized twice in a row --
+run 1 succeeded, run 2 failed with ``Initial JSON parse failed: Expecting ':'
+delimiter: line 83 column 19 (char 6413)``, followed by ``JSON repair also
+failed``, surfacing a raw ``{"error": "JSON parsing failed", ...}`` card to the
+user instead of a summary.
+
+``_repair_truncated_json`` (the existing fallback) only closes brackets/strings
+left open at the very END of the response -- it exists for a response cut off
+at the token limit (``finish_reason="length"``). It cannot fix a MID-document
+syntax break, which is a different failure shape: ``json.loads`` fails well
+past the actual defect, deep inside an otherwise well-formed document, because
+there is no open bracket to close.
+
+The real transcript was checked directly (fetched via the live demo's API,
+960 segments) and contains exactly three literal ``"`` characters -- all from
+an ASR-transcribed aside about Lincoln being ``6'6"`` tall (a feet/inches
+mark), inside a Lincoln Bedroom anecdote. Re-running that exact snippet
+through the real prompt against the real model (``otfresh-demo``'s vLLM)
+showed gemma-4-e4b sometimes renders it correctly escaped (``6'6\\"``) and
+plausibly, on other samples, does not -- an unescaped ``"`` inside a JSON
+string value desyncs the parser's in-string tracking for everything that
+follows, which matches the reported error shape (a delimiter error deep into
+the document, not an end-of-string error) far better than truncation would:
+every live reproduction had ``finish_reason="stop"`` (natural completion),
+never ``"length"``.
+
+Fixed by adding ``json_repair`` (issue: no repair library was a dependency
+yet; `requirements.txt` now pins ``json-repair==0.63.4``) as a second-tier
+repair, tried when the bracket-closer returns ``None``, in both
+``_parse_summary_response`` (the final/combined summary) and
+``_summarize_section`` (a section summary, so an unrecovered section does not
+get stitched into the combine-step prompt as a "failed to parse" placeholder).
+
+``TestMidDocumentUnescapedQuote`` is red against the pre-fix code (git HEAD
+before this change) via a `git archive` copy -- see
+``test_would_have_failed_against_the_pre_fix_repair_alone``.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from app.services.llm_service import LLMConfig
+from app.services.llm_service import LLMProvider
+from app.services.llm_service import LLMResponse
+from app.services.llm_service import LLMService
+
+# The exact malformation class found live: a JSON string value containing a
+# literal, unescaped double quote from a feet/inches measurement mentioned in
+# the source transcript ("He was 6'6\" tall..."), which desyncs the parser's
+# in-string tracking so the *next* member fails with "Expecting ':' delimiter"
+# rather than an end-of-string error -- reproducing the reported shape.
+MID_DOCUMENT_UNESCAPED_QUOTE_JSON = (
+    "{\n"
+    '  "bluf": "Discussion touches on presidential history, including a fun '
+    'aside that Lincoln was 6\'6" tall.",\n'
+    '  "brief_summary": "A wide-ranging conversation covering the Lincoln '
+    'Bedroom and its history.",\n'
+    '  "major_topics": [],\n'
+    '  "action_items": [],\n'
+    '  "key_decisions": [],\n'
+    '  "follow_up_items": [],\n'
+    '  "overall_sentiment": "neutral",\n'
+    '  "content_type_detected": "podcast"\n'
+    "}"
+)
+
+TRAILING_TRUNCATION_JSON = (
+    "{\n"
+    '  "bluf": "Budget overrun addressed by deferring feature releases.",\n'
+    '  "brief_summary": "Team resolved a Q4 budget shortfall.",\n'
+    '  "major_topics": [{"topic": "Budget review", "summary": "Engineering '
+    'overspent", "key_points": ["Over by $50K'
+)
+
+UNRECOVERABLE_GARBAGE = "Sorry, I cannot help with that request."
+
+
+def _service(max_tokens: int = 60000) -> LLMService:
+    return LLMService(
+        LLMConfig(
+            provider=LLMProvider.VLLM,
+            model="test-model",
+            base_url="http://llm.test/v1",
+            max_tokens=max_tokens,
+        )
+    )
+
+
+class TestMidDocumentUnescapedQuote:
+    """The bug: an unescaped quote breaks parsing well past where it occurs."""
+
+    def test_the_fixture_actually_reproduces_the_reported_error_shape(self):
+        """Sanity check: this is a mid-document break, not a truncation.
+
+        `json.loads` must fail on a delimiter/structural error *before*
+        end-of-string, matching "Expecting ':' delimiter: line 83 column 19
+        (char 6413)" from the live incident -- not `json.JSONDecodeError`'s
+        end-of-file variants ("Unterminated string starting at", "Expecting
+        value" at the final character), which is what a truncated response
+        produces instead.
+        """
+        with pytest.raises(json.JSONDecodeError) as exc_info:
+            json.loads(MID_DOCUMENT_UNESCAPED_QUOTE_JSON)
+
+        err = exc_info.value
+        assert err.pos < len(MID_DOCUMENT_UNESCAPED_QUOTE_JSON) - 5, (
+            "fixture must fail well before end-of-string to reproduce a "
+            "mid-document break, not a truncation-shaped error"
+        )
+
+    def test_would_have_failed_against_the_pre_fix_repair_alone(self):
+        """Red check: the bracket-closing repair alone cannot recover this.
+
+        Runs the actual pre-fix `_repair_truncated_json` from git HEAD (before
+        this change) against the fixture, in an isolated `git archive` copy --
+        never by editing the tracked file in place. It must return `None`,
+        proving the bug was real and this test is not vacuous.
+        """
+        repo_root = Path(__file__).resolve().parents[3]
+
+        with tempfile.TemporaryDirectory(prefix="otredcheck_llm_json_repair_") as archive_dir_str:
+            archive_dir = Path(archive_dir_str)
+
+            tar_proc = subprocess.run(
+                ["git", "archive", "HEAD", "--", "backend/app/services/llm_service.py"],
+                cwd=repo_root,
+                capture_output=True,
+                check=True,
+            )
+            subprocess.run(
+                ["tar", "-x", "-C", str(archive_dir)],
+                input=tar_proc.stdout,
+                check=True,
+            )
+
+            pre_fix_module_path = archive_dir / "backend" / "app" / "services" / "llm_service.py"
+            assert pre_fix_module_path.exists()
+
+            # Load the pre-fix module under a private name so it never shadows the
+            # real `app.services.llm_service` import used by the rest of this file.
+            import importlib.util
+
+            spec = importlib.util.spec_from_file_location(
+                "otredcheck_pre_fix_llm_service", pre_fix_module_path
+            )
+            assert spec is not None and spec.loader is not None
+            pre_fix_module = importlib.util.module_from_spec(spec)
+            sys.modules[spec.name] = pre_fix_module
+            try:
+                spec.loader.exec_module(pre_fix_module)
+
+                pre_fix_service = pre_fix_module.LLMService(
+                    pre_fix_module.LLMConfig(
+                        provider=pre_fix_module.LLMProvider.VLLM,
+                        model="test-model",
+                        base_url="http://llm.test/v1",
+                        max_tokens=60000,
+                    )
+                )
+                result = pre_fix_service._repair_truncated_json(MID_DOCUMENT_UNESCAPED_QUOTE_JSON)
+            finally:
+                del sys.modules[spec.name]
+
+        assert result is None, (
+            "the pre-fix bracket-closing repair recovered this fixture -- "
+            "the fixture no longer reproduces the bug, or the repo's "
+            "llm_service.py changed shape enough to invalidate this check"
+        )
+
+    def test_parse_summary_response_recovers_it_via_json_repair(self):
+        """Green: the new json_repair fallback recovers the full structure."""
+        service = _service()
+        response = LLMResponse(
+            content=MID_DOCUMENT_UNESCAPED_QUOTE_JSON,
+            usage_tokens=123,
+            finish_reason="stop",
+        )
+
+        result = service._parse_summary_response(response, transcript_length=205684)
+
+        assert "error" not in result
+        assert result["overall_sentiment"] == "neutral"
+        assert result["content_type_detected"] == "podcast"
+        assert "6'6" in result["bluf"]
+        assert result["metadata"]["json_repaired"] is True
+
+    def test_summarize_section_recovers_it_via_json_repair(self, monkeypatch):
+        """The section-summary path gets the same recovery, not a placeholder."""
+        service = _service()
+        monkeypatch.setattr(
+            service,
+            "chat_completion",
+            lambda *a, **k: LLMResponse(
+                content=MID_DOCUMENT_UNESCAPED_QUOTE_JSON,
+                usage_tokens=42,
+                finish_reason="stop",
+            ),
+        )
+
+        result = service._summarize_section(
+            chunk="irrelevant, chat_completion is stubbed",
+            section_num=1,
+            total_sections=2,
+            speaker_data=None,
+            prompt_template="{transcript}{speaker_data}",
+        )
+
+        assert "6'6" in result["bluf"]
+        assert result.get("key_points") != ["Section 1: Failed to parse structured summary"]
+
+
+class TestTrailingTruncationStillHandledFirst:
+    """Control: the original bracket-closing repair path is untouched."""
+
+    def test_a_genuinely_truncated_response_is_still_repaired_by_the_bracket_closer(
+        self,
+    ):
+        service = _service()
+        response = LLMResponse(
+            content=TRAILING_TRUNCATION_JSON,
+            usage_tokens=99,
+            finish_reason="length",
+        )
+
+        result = service._parse_summary_response(response, transcript_length=1000)
+
+        assert "error" not in result
+        assert result["bluf"].startswith("Budget overrun")
+        assert result["metadata"]["json_repaired"] is True
+
+
+class TestUnrecoverableContentStillFailsGracefully:
+    """`json_repair` never raises, but garbage in must not become garbage out."""
+
+    def test_non_json_content_still_returns_the_error_structure(self):
+        service = _service()
+        response = LLMResponse(
+            content=UNRECOVERABLE_GARBAGE,
+            usage_tokens=10,
+            finish_reason="stop",
+        )
+
+        result = service._parse_summary_response(response, transcript_length=50)
+
+        assert result["error"] == "JSON parsing failed"
+        assert result["raw_response_preview"] == UNRECOVERABLE_GARBAGE


### PR DESCRIPTION
## Bug

A 3-hour transcript ("Joe Rogan Experience #2219", vllm/gemma-4-e4b) summarized twice in a
row on a live demo: run 1 succeeded, run 2 failed with `Initial JSON parse failed: Expecting
':' delimiter: line 83 column 19 (char 6413)`, then `JSON repair also failed`, surfacing a
raw `{"error": "JSON parsing failed", ...}` card to the user instead of a summary.

## Root cause (verified live, not guessed)

Fetched the real transcript (960 segments) via the live demo's API and confirmed it contains
exactly three literal `"` characters — all from an ASR-transcribed aside about Lincoln being
`6'6"` tall (a feet/inches mark), inside a Lincoln Bedroom anecdote.

Re-ran the actual prompt-building code against the real model (`otfresh-demo`'s vLLM,
gemma-4-e4b) multiple times, including that exact snippet. The model sometimes renders the
mark correctly escaped (`6'6\"`) and, per the live incident, does not always — an unescaped
`"` inside a JSON string value desyncs the parser's in-string tracking for everything that
follows, producing a delimiter error deep into the document rather than an end-of-string
error. This matches the reported shape far better than truncation would: every live
reproduction had `finish_reason="stop"` (natural completion), never `"length"`.

The existing `_repair_truncated_json` fallback only closes brackets/strings left open at the
very end of a response cut off at the token limit — it has nothing to close for a
mid-document break, so it correctly returned `None` here.

## Fix

- Add `json-repair` (`0.63.4`, zero transitive deps) as a second-tier repair in
  `llm_service.py`, tried when the bracket-closer can't recover the content. Applied to both
  `_parse_summary_response` (the final/combined summary) and `_summarize_section` (so a bad
  section doesn't get stitched into the combine-step prompt as a "failed to parse"
  placeholder).
- Strengthen the JSON-formatting instructions in both `UNIVERSAL_CONTENT_ANALYZER_PROMPT` and
  `QA_PANEL_PROMPT` (`default_prompts.py`) to explicitly require escaping embedded quotes.
  Note: these are DB-seeded defaults (`initial_data.py`) — existing deployments that already
  seeded a prompt row keep the old text unless the user regenerates/re-selects the default
  prompt; only fresh installs pick up the wording automatically.

## Testing

`backend/tests/unit/test_llm_summary_json_repair.py` (new):
- Reproduces the exact malformation class (unescaped feet/inches quote mid-document).
- Red-checked against the pre-fix code via a `git archive HEAD` copy (never editing the
  tracked file in place) — confirms `_repair_truncated_json` alone returns `None` on this
  fixture.
- Green against the fix for both `_parse_summary_response` and `_summarize_section`.
- Control test confirms the original trailing-truncation repair path is untouched.
- Control test confirms genuinely unrecoverable content still returns the graceful error
  structure (not an exception), since `json_repair` never raises.

All 6 new tests pass; `scripts/safe-precommit.sh run --files <changed files>` is clean
(ruff, ruff-format, mypy, bandit, audit-tests, import-linter, secret-detection all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)