### PR TITLE
fix(install): resolve the manifest at a ref that actually has it (#683)

### DIFF
--- a/.github/workflows/release-validate.yml
+++ b/.github/workflows/release-validate.yml
@@ -43,12 +43,24 @@ on:
       # the stage DIRECTORY. Same for the rehearsal harness the release stages invoke.
       - 'scripts/release.sh'
       - 'scripts/release-tests/**'
+      # The two scripts a user actually runs were in NO path filter, so a PR editing the
+      # installer ran this workflow zero times. That is how #683 merged: the commit adding
+      # release-manifest.txt changed setup-opentranscribe.sh, and the only check that
+      # could have caught it was gated `if: github.ref_type == 'tag'` anyway.
+      - 'setup-opentranscribe.sh'
+      - 'opentranscribe.sh'
+      - 'scripts/verify-install-paths.sh'
       # The docs job below runs `npm ci && npm run build`, and it was unreachable from a PR:
       # docs-site/** was not listed here, and deploy-docs.yml only fires on push to master.
       # So a duplicate blog slug or an undefined author merged green and broke master on
       # deploy. deployment-configuration.md is included because validate-deployments.sh
       # parses it as its anti-staleness source.
       - 'docs-site/**'
+  # The install-paths job below compares the TIP scripts against the PUBLISHED releases,
+  # so it can start failing with no commit at all — publishing a release is enough. A
+  # push-triggered workflow can never notice that, which is why this runs on a timer too.
+  schedule:
+    - cron: '17 6 * * *'
   workflow_dispatch:
     inputs:
       tag:
@@ -130,12 +142,44 @@ jobs:
           shellcheck --severity=warning \
             setup-opentranscribe.sh \
             opentranscribe.sh \
+            scripts/verify-install-paths.sh \
             scripts/release.sh \
             scripts/release/*.sh \
             scripts/validate-deployments.sh \
             scripts/security-scan.sh \
             scripts/release-tests/*.sh \
             scripts/release-tests/lib/*.sh
+
+  install-paths:
+    name: Install paths work against published releases
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          # Tags are required: the pin check compares each downloaded artifact against
+          # `git show <tag>:<path>`. Without full history it would silently skip that
+          # comparison and pass an unpinned install.
+          fetch-depth: 0
+
+      - name: Verify install / update / upgrade paths
+        env:
+          # Raises the API limit from 60/hr per runner IP to 5000/hr. Without it a busy
+          # day makes this job fail on rate limiting rather than on a real defect.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # THE cross-ref check nothing else does: everything else in this workflow
+          # validates a tag against its OWN checkout, so none of them can see "the
+          # installer at the tip cannot install the release users are being handed".
+          # That blind spot broke 100% of `curl | bash` installs for 22 days (#683).
+          #
+          # --all-releases on a schedule/tag (thorough, ~1 min of curls); latest-only on
+          # a PR, where the question is just "did this change break the live one-liner".
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            ./scripts/verify-install-paths.sh
+          else
+            ./scripts/verify-install-paths.sh --all-releases
+          fi
 
   schema:
     name: Schema integrity

--- a/backend/tests/unit/test_install_upgrade_scripts.py
+++ b/backend/tests/unit/test_install_upgrade_scripts.py
@@ -38,13 +38,27 @@ pytestmark = pytest.mark.skipif(
 
 
 def _extract_function(script: Path, name: str) -> str:
-    """Pull one shell function out of a script so it can be run in isolation."""
+    """Pull one shell function out of a script so it can be run in isolation.
+
+    Two definition shapes exist. opentranscribe.sh ships standalone to end users, so
+    read_env_value/resolve_default_branch are defined inside an
+    ``if ! declare -F <name>; then ... fi`` guard (common.sh's copy wins when present) —
+    they are indented, and a ``^name()`` match cannot see them. Extracting the whole
+    guard block yields valid bash either way.
+    """
     out = subprocess.run(
         ["sed", "-n", f"/^{name}()/,/^}}/p", str(script)],
         capture_output=True,
         text=True,
         check=True,
     ).stdout
+    if not out.strip():
+        out = subprocess.run(
+            ["sed", "-n", rf"/^if ! declare -F {name}\b/,/^fi$/p", str(script)],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
     assert out.strip(), f"{name}() not found in {script.name}"
     return out
 
@@ -1394,3 +1408,242 @@ set -- restore --yes {dump}
         f"the lock from the first restore leaked into the second: {second}"
     )
     assert "Database restored successfully" in second, second
+
+
+# --------------------------------------------------------------------------- #
+# Install-path compatibility across releases (issue #683)
+#
+# A self-hosted install has TWO sources and only one of them is pinned: the
+# installer is served from the default branch (the docs one-liner hardcodes it),
+# while everything it downloads comes from the resolved release tag. The installer
+# is therefore always NEWER than the release it installs, and it must stay able to
+# install every release resolve_install_ref() can hand it.
+#
+# release-manifest.txt was added after v0.4.1 shipped. The new installer asked that
+# tag for a file it had never heard of, 404ed, and fail-closed — killing 100% of
+# `curl | bash` installs for 22 days. Nothing caught it, because every other check
+# validates a tag against its OWN checkout and so cannot see a cross-ref break.
+#
+# scripts/verify-install-paths.sh is the live network gate. These are the hermetic
+# half: no network, so they run in CI and in the fast suite.
+# --------------------------------------------------------------------------- #
+
+_PINNED_TAG = "v0.4.1"
+
+
+def _curl_stub(bin_dir: Path, requested: Path, *, manifest_at: set[str]) -> None:
+    """A curl that 404s like GitHub does.
+
+    ``manifest_at`` is the set of refs that actually HAVE release-manifest.txt, so a
+    test can reproduce the exact shape of #683: present on the default branch, absent
+    on the pinned tag.
+    """
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    serve = "\n".join(f"    */{ref}/release-manifest.txt) ok=1 ;;" for ref in sorted(manifest_at))
+    stub = bin_dir / "curl"
+    stub.write_text(
+        "#!/bin/bash\n"
+        "url=''; out=''\n"
+        'while [ $# -gt 0 ]; do case "$1" in\n'
+        '  -o) out="$2"; shift 2 ;;\n'
+        '  http*) url="$1"; shift ;;\n'
+        "  *) shift ;;\n"
+        "esac; done\n"
+        f'echo "$url" >> {requested}\n'
+        # The repo API call feeds resolve_default_branch; it writes to stdout, not -o.
+        'case "$url" in\n'
+        '  *api.github.com/repos/*/OpenTranscribe) printf \'{"default_branch": "master"}\\n\'; exit 0 ;;\n'
+        "esac\n"
+        "ok=0\n"
+        'case "$url" in\n'
+        f"{serve}\n"
+        "    *release-manifest.txt) ok=0 ;;\n"
+        "    *) ok=1 ;;\n"
+        "esac\n"
+        '[ "$ok" = 1 ] || exit 22\n'
+        'if [ -n "$out" ]; then\n'
+        '  case "$url" in\n'
+        f'    *release-manifest.txt) cp {REPO_ROOT / "release-manifest.txt"} "$out" ;;\n'
+        '    *) printf "stub-content\\n" > "$out" ;;\n'
+        "  esac\n"
+        "fi\n"
+        "exit 0\n"
+    )
+    stub.chmod(0o755)
+
+
+def _run_installer_download(tmp_path: Path, *, manifest_at: set[str], ref: str = _PINNED_TAG):
+    bin_dir = tmp_path / "bin"
+    requested = tmp_path / "requested.txt"
+    requested.write_text("")
+    _curl_stub(bin_dir, requested, manifest_at=manifest_at)
+
+    workdir = tmp_path / "install"
+    workdir.mkdir()
+
+    snippet = (
+        "set -uo pipefail\n"
+        "RED=''; GREEN=''; YELLOW=''; BLUE=''; NC=''\n"
+        + _extract_function(INSTALLER, "resolve_default_branch")
+        + _extract_function(INSTALLER, "download_release_manifest_artifacts")
+        + "\ndownload_release_manifest_artifacts\n"
+    )
+    proc = subprocess.run(
+        ["bash", "-c", snippet],
+        capture_output=True,
+        text=True,
+        cwd=str(workdir),
+        env={"PATH": f"{bin_dir}:/usr/bin:/bin", "OPENTRANSCRIBE_BRANCH": ref},
+    )
+    return proc, workdir, requested.read_text().splitlines()
+
+
+def test_installer_installs_a_release_that_predates_the_manifest(tmp_path: Path):
+    """THE #683 regression test: v0.4.1 has no release-manifest.txt, master does.
+
+    Watched fail against the pre-fix installer, which exits 1 here with
+    "Refusing to install from an unknown artifact list."
+    """
+    proc, workdir, _ = _run_installer_download(tmp_path, manifest_at={"master"})
+
+    assert proc.returncode == 0, (
+        "a release predating release-manifest.txt must still install:\n"
+        f"{proc.stdout}\n{proc.stderr}"
+    )
+    assert (workdir / "docker-compose.yml").is_file(), "no compose file was written"
+    assert "predates release-manifest.txt" in proc.stdout, (
+        "the fallback must announce itself — a silent one hides which list was used"
+    )
+
+
+def test_manifest_fallback_never_unpins_the_artifacts(tmp_path: Path):
+    """Only the file LIST may fall back. Every artifact must come from the pinned ref.
+
+    If the fallback pulled artifacts from the default branch too, this would still
+    "install" — while silently shipping tip-of-development config against a pinned
+    release's images. That is the exact failure pinning exists to prevent, and an
+    existence-only assertion cannot see it.
+    """
+    _, _, urls = _run_installer_download(tmp_path, manifest_at={"master"})
+
+    artifact_urls = [u for u in urls if "release-manifest.txt" not in u and "api.github" not in u]
+    assert artifact_urls, "no artifacts were requested at all"
+
+    unpinned = [u for u in artifact_urls if f"/{_PINNED_TAG}/" not in u]
+    assert not unpinned, (
+        f"artifacts fetched from somewhere other than {_PINNED_TAG} — install is unpinned:\n"
+        + "\n".join(unpinned[:5])
+    )
+
+
+def test_installer_still_fails_closed_when_no_manifest_exists_anywhere(tmp_path: Path):
+    """The fallback must not become a guess.
+
+    Guessing the artifact list is the bug release-manifest.txt replaced (#640), so with
+    no manifest reachable at all the installer must still refuse rather than assume.
+    """
+    proc, workdir, _ = _run_installer_download(tmp_path, manifest_at=set())
+
+    assert proc.returncode != 0, "no manifest anywhere must be fatal, not a guessed list"
+    assert "Refusing to install from an unknown artifact list" in proc.stdout
+    assert not (workdir / "docker-compose.yml").exists(), "nothing may be written on refusal"
+
+
+def _resolve_config_ref(tmp_path: Path, env_body: str, *, offline: bool = False):
+    """Run opentranscribe.sh's real resolve_config_ref() against a fake .env."""
+    (tmp_path / ".env").write_text(env_body)
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    # resolve_default_branch is the only curl caller here; `offline` makes it fail.
+    (bin_dir / "curl").write_text(
+        "#!/bin/bash\nexit 7\n"
+        if offline
+        else '#!/bin/bash\nprintf \'{"default_branch": "master"}\\n\'\nexit 0\n'
+    )
+    (bin_dir / "curl").chmod(0o755)
+
+    snippet = (
+        "set -uo pipefail\n"
+        "RED=''; GREEN=''; YELLOW=''; BLUE=''; NC=''\n"
+        + _extract_function(MANAGER, "read_env_value")
+        + _extract_function(MANAGER, "resolve_default_branch")
+        + _extract_function(MANAGER, "deployment_ref")
+        + _extract_function(MANAGER, "resolve_config_ref")
+        + "\nunset OPENTRANSCRIBE_BRANCH\nresolve_config_ref\n"
+    )
+    return subprocess.run(
+        ["bash", "-c", snippet],
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+        env={"PATH": f"{bin_dir}:/usr/bin:/bin"},
+    )
+
+
+def test_update_full_takes_config_from_the_pinned_release(tmp_path: Path):
+    """update-full defaulted to master, so a pinned install re-downloaded tip config.
+
+    It did not 404 — it silently merged newer compose files onto older images. Service
+    definitions live in docker-compose.yml, so the base file could reference services
+    the pinned containers know nothing about. Silent is worse than broken.
+    """
+    proc = _resolve_config_ref(tmp_path, f"OT_IMAGE_TAG={_PINNED_TAG}\n")
+
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == _PINNED_TAG, (
+        f"update-full on a {_PINNED_TAG} install took config from "
+        f"{proc.stdout.strip()!r} — config/image mismatch"
+    )
+
+
+@pytest.mark.parametrize(
+    "env_body,label",
+    [("FOO=bar\n", "no OT_IMAGE_TAG at all"), ("OT_IMAGE_TAG=latest\n", "pinned to 'latest'")],
+)
+def test_update_full_still_works_on_a_pre_pinning_install(tmp_path: Path, env_body, label):
+    """Backward compatibility: installs predating OT_IMAGE_TAG must keep updating.
+
+    They may fall back to the default branch — but must SAY so. Falling back silently
+    is how an unpinned install stops being visible as one.
+    """
+    proc = _resolve_config_ref(tmp_path, env_body)
+
+    assert proc.returncode == 0, f"an install with {label} must still update:\n{proc.stderr}"
+    assert proc.stdout.strip() == "master"
+    assert "not pinned to a release" in proc.stderr, (
+        f"an install with {label} fell back to the tip without warning"
+    )
+
+
+def test_update_full_refuses_rather_than_guessing_a_branch_name(tmp_path: Path):
+    """No hardcoded branch name anywhere: unresolvable means stop, not assume 'master'.
+
+    This is what lets the branch be renamed without breaking installs — the whole
+    point of resolving it at runtime instead of writing it down.
+    """
+    proc = _resolve_config_ref(tmp_path, "FOO=bar\n", offline=True)
+
+    assert proc.returncode != 0, "an unresolvable default branch must not be guessed"
+    assert "not pinned to a release" in proc.stderr
+    assert "--version vX.Y.Z" in proc.stderr, "the failure must tell the user how to proceed"
+
+
+def test_no_hardcoded_default_branch_in_the_install_download_paths():
+    """The literal 'master' must not reappear in a download URL.
+
+    Every hardcoded branch in a fetch URL is a rename waiting to break installs. The
+    fallback resolves the default branch from the API precisely so `master` -> `main`
+    is a non-event; a literal would quietly defeat that.
+    """
+    offenders = []
+    for script in (INSTALLER, MANAGER):
+        for num, line in enumerate(script.read_text().splitlines(), 1):
+            if "raw.githubusercontent.com" not in line or line.lstrip().startswith("#"):
+                continue
+            if "/master" in line or "/main" in line:
+                offenders.append(f"{script.name}:{num}: {line.strip()}")
+
+    assert not offenders, (
+        "a branch name is hardcoded into a download URL — resolve it at runtime instead:\n"
+        + "\n".join(offenders)
+    )

--- a/opentranscribe.sh
+++ b/opentranscribe.sh
@@ -106,9 +106,14 @@ raw_url_for() {
 }
 
 resolve_config_ref() {
-    if [ -n "${OPENTRANSCRIBE_BRANCH:-}" ]; then
-        echo -e "${BLUE}ℹ️  Using branch override: ${OPENTRANSCRIBE_BRANCH}${NC}" >&2
-        printf '%s\n' "$OPENTRANSCRIBE_BRANCH"
+    # Read the override into a defaulted local ONCE rather than expanding the env var at
+    # each use site: `set -u` aborts on a bare $OPENTRANSCRIBE_BRANCH even when an earlier
+    # `[ -n "${VAR:-}" ]` guard proves it is set, and test_shell_expansion_guards.py
+    # enforces that repo-wide (it caught exactly this).
+    local override="${OPENTRANSCRIBE_BRANCH:-}"
+    if [ -n "$override" ]; then
+        echo -e "${BLUE}ℹ️  Using branch override: ${override}${NC}" >&2
+        printf '%s\n' "$override"
         return 0
     fi
 

--- a/opentranscribe.sh
+++ b/opentranscribe.sh
@@ -48,6 +48,91 @@ if ! declare -F read_env_value >/dev/null 2>&1; then
     }
 fi
 
+# The repo's default branch, asked for at runtime rather than written down.
+#
+# Every hardcoded "master" in a download URL is a rename waiting to break an install.
+# Echoes empty on any failure (offline, rate-limited, malformed); callers MUST treat
+# empty as "no fallback available" and fail closed rather than guessing a branch name.
+# Defined here rather than only in common.sh for the same reason as read_env_value
+# above: this script ships standalone, and update-full needs this BEFORE it has
+# downloaded a newer common.sh.
+if ! declare -F resolve_default_branch >/dev/null 2>&1; then
+    resolve_default_branch() {
+        curl -fsSL --connect-timeout 10 --max-time 20 \
+            "https://api.github.com/repos/attevon-llc/OpenTranscribe" 2>/dev/null \
+            | grep -m1 '"default_branch"' \
+            | sed -E 's/.*"default_branch"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/' \
+            || true
+    }
+fi
+
+# Which ref does `update-full` take CONFIG files from? Echoes it; messages go to stderr.
+#
+# This was `${OPENTRANSCRIBE_BRANCH:-master}`, so an install pinned to vX.Y.Z re-downloaded
+# tip-of-development compose files on top of vX.Y.Z images. It did not 404 — it silently
+# produced exactly the config/image mismatch OT_IMAGE_TAG exists to prevent, which is worse
+# than failing (issue #683). Service definitions live in docker-compose.yml, so a newer base
+# file can reference services, images and env keys the pinned containers know nothing about.
+#
+# So: follow the pin. Fall back to the default branch ONLY for installs predating pinning
+# (OT_IMAGE_TAG unset or 'latest'), and say so out loud. OPENTRANSCRIBE_BRANCH still
+# overrides, for testing. A function, not inline in the update-full arm, so the invariant
+# is testable — scripts/verify-install-paths.sh and the unit tests both run this directly.
+deployment_ref() {
+    local pinned fallback
+    pinned=$(read_env_value OT_IMAGE_TAG)
+    case "$pinned" in
+        '' | latest)
+            fallback=$(resolve_default_branch)
+            [ -n "$fallback" ] || return 1
+            printf '%s\tfallback\n' "$fallback"
+            ;;
+        *) printf '%s\tpinned\n' "$pinned" ;;
+    esac
+}
+
+# A raw.githubusercontent URL for <path>, at THIS deployment's ref.
+#
+# Every URL printed or fetched by this script used to say /master/ literally, which hands
+# a v0.4.1 user a v0.5.0-development file — the same config/image mismatch as #683, just
+# arriving through a copy-pasted remedy instead of update-full. Falls back to a visible
+# placeholder rather than guessing a branch name, so an unresolvable ref reads as unknown
+# instead of silently wrong.
+raw_url_for() {
+    local out ref=""
+    out=$(deployment_ref) && ref=${out%%$'\t'*}
+    printf 'https://raw.githubusercontent.com/attevon-llc/OpenTranscribe/%s/%s\n' \
+        "${ref:-<your-release-tag>}" "$1"
+}
+
+resolve_config_ref() {
+    if [ -n "${OPENTRANSCRIBE_BRANCH:-}" ]; then
+        echo -e "${BLUE}ℹ️  Using branch override: ${OPENTRANSCRIBE_BRANCH}${NC}" >&2
+        printf '%s\n' "$OPENTRANSCRIBE_BRANCH"
+        return 0
+    fi
+
+    local out ref how
+    if ! out=$(deployment_ref); then
+        echo -e "${RED}❌ This install is not pinned to a release (OT_IMAGE_TAG is unset${NC}" >&2
+        echo -e "${RED}   or 'latest') and the default branch could not be resolved.${NC}" >&2
+        echo -e "${YELLOW}   Pin it first:  ./opentranscribe.sh update --version vX.Y.Z${NC}" >&2
+        echo -e "${YELLOW}   Or update images only:  ./opentranscribe.sh update${NC}" >&2
+        return 1
+    fi
+    ref=${out%%$'\t'*}
+    how=${out##*$'\t'}
+
+    if [ "$how" = pinned ]; then
+        echo -e "${BLUE}ℹ️  Updating config files at the pinned release: ${ref}${NC}" >&2
+    else
+        echo -e "${YELLOW}⚠️  This install is not pinned to a release; taking config from '${ref}'.${NC}" >&2
+        echo -e "${YELLOW}   That config is not guaranteed to match your running images.${NC}" >&2
+        echo -e "${YELLOW}   Pin it with:  ./opentranscribe.sh update --version vX.Y.Z${NC}" >&2
+    fi
+    printf '%s\n' "$ref"
+}
+
 function show_help {
     echo -e "${BLUE}OpenTranscribe Management Script${NC}"
     echo ""
@@ -108,7 +193,7 @@ require_db_helpers() {
         echo -e "${RED}   backup/restore implementation.${NC}"
         echo -e "${YELLOW}   Fix with:  ./opentranscribe.sh update-full${NC}"
         echo -e "${YELLOW}   Or fetch it directly:${NC}"
-        echo -e "     mkdir -p scripts && curl -fsSL https://raw.githubusercontent.com/attevon-llc/OpenTranscribe/master/scripts/common.sh -o scripts/common.sh && chmod +x scripts/common.sh"
+        echo -e "     mkdir -p scripts && curl -fsSL $(raw_url_for scripts/common.sh) -o scripts/common.sh && chmod +x scripts/common.sh"
         exit 1
     fi
 }
@@ -745,15 +830,11 @@ case "${1:-help}" in
         echo -e "${YELLOW}📥 Full update: Updating configuration files and Docker images...${NC}"
         echo ""
 
-        # GitHub raw URL base - supports OPENTRANSCRIBE_BRANCH env var for testing
-        BRANCH="${OPENTRANSCRIBE_BRANCH:-master}"
+        BRANCH=$(resolve_config_ref) || exit 1
+
         # URL-encode the branch name (replace / with %2F for feature branches)
         ENCODED_BRANCH=$(echo "$BRANCH" | sed 's|/|%2F|g')
         GITHUB_RAW="https://raw.githubusercontent.com/attevon-llc/OpenTranscribe/${ENCODED_BRANCH}"
-
-        if [ "$BRANCH" != "master" ]; then
-            echo -e "${BLUE}ℹ️  Using branch: $BRANCH${NC}"
-        fi
 
         # Backup current opentranscribe.sh
         cp opentranscribe.sh opentranscribe.sh.bak 2>/dev/null || true
@@ -768,12 +849,29 @@ case "${1:-help}" in
         # hardcoded here. See that file's header for the two silent-breakage bugs
         # the old duplicated lists caused (missing docker-compose.yml on upgrade,
         # missing blackwell overlay on fresh install).
+        # Releases published before release-manifest.txt existed have no list to read, and
+        # following the pin (above) means we now ask them for one. Borrow the list from the
+        # default branch in that case — the ARTIFACTS still come from $GITHUB_RAW, i.e. the
+        # pinned release, so this cannot un-pin the install. The manifest's `optional` flag
+        # absorbs entries the older release does not have. Same fallback as
+        # setup-opentranscribe.sh's download_release_manifest_artifacts(); see issue #683.
         echo "  Downloading release-manifest.txt..."
         if ! curl -fsSL "$GITHUB_RAW/release-manifest.txt" -o release-manifest.txt.new; then
-            echo -e "  ${RED}✗${NC} could not fetch release-manifest.txt from $BRANCH"
-            echo -e "  ${YELLOW}Refusing to update config files from an unknown artifact list.${NC}"
-            echo -e "  ${YELLOW}Use './opentranscribe.sh update' to update images only.${NC}"
-            exit 1
+            rm -f release-manifest.txt.new
+            MANIFEST_FALLBACK_BRANCH=$(resolve_default_branch)
+
+            if [ -n "$MANIFEST_FALLBACK_BRANCH" ] && [ "$MANIFEST_FALLBACK_BRANCH" != "$BRANCH" ] &&
+                curl -fsSL "https://raw.githubusercontent.com/attevon-llc/OpenTranscribe/${MANIFEST_FALLBACK_BRANCH}/release-manifest.txt" \
+                    -o release-manifest.txt.new; then
+                echo -e "  ${YELLOW}⚠️${NC}  $BRANCH predates release-manifest.txt — using the file list from '${MANIFEST_FALLBACK_BRANCH}'."
+                echo -e "     Config files are still downloaded from $BRANCH."
+            else
+                rm -f release-manifest.txt.new
+                echo -e "  ${RED}✗${NC} could not fetch release-manifest.txt from $BRANCH"
+                echo -e "  ${YELLOW}Refusing to update config files from an unknown artifact list.${NC}"
+                echo -e "  ${YELLOW}Use './opentranscribe.sh update' to update images only.${NC}"
+                exit 1
+            fi
         fi
         mv release-manifest.txt.new release-manifest.txt
 
@@ -1020,7 +1118,7 @@ case "${1:-help}" in
             echo "   Expected: scripts/generate-ssl-cert.sh"
             echo ""
             echo "   Download it from:"
-            echo "   curl -fsSL https://raw.githubusercontent.com/attevon-llc/OpenTranscribe/master/scripts/generate-ssl-cert.sh -o scripts/generate-ssl-cert.sh"
+            echo "   curl -fsSL $(raw_url_for scripts/generate-ssl-cert.sh) -o scripts/generate-ssl-cert.sh"
             echo "   chmod +x scripts/generate-ssl-cert.sh"
             exit 1
         fi
@@ -1031,7 +1129,7 @@ case "${1:-help}" in
             echo "   Expected: docker-compose.nginx.yml"
             echo ""
             echo "   Download it from:"
-            echo "   curl -fsSL https://raw.githubusercontent.com/attevon-llc/OpenTranscribe/master/docker-compose.nginx.yml -o docker-compose.nginx.yml"
+            echo "   curl -fsSL $(raw_url_for docker-compose.nginx.yml) -o docker-compose.nginx.yml"
             exit 1
         fi
 
@@ -1040,8 +1138,12 @@ case "${1:-help}" in
             echo -e "${YELLOW}⚠️  NGINX configuration template not found${NC}"
             echo "   Downloading nginx/site.conf.template..."
             mkdir -p nginx/ssl
-            curl -fsSL https://raw.githubusercontent.com/attevon-llc/OpenTranscribe/master/nginx/site.conf.template -o nginx/site.conf.template || {
+            # A REAL fetch, not a printed remedy: this pulled the nginx template from
+            # tip-of-development onto a pinned deployment, so an HTTPS install could get
+            # a proxy config written for a backend it is not running.
+            curl -fsSL "$(raw_url_for nginx/site.conf.template)" -o nginx/site.conf.template || {
                 echo -e "${RED}❌ Failed to download nginx configuration${NC}"
+                echo -e "${YELLOW}   Or run:  ./opentranscribe.sh update-full${NC}"
                 exit 1
             }
         fi

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -345,6 +345,31 @@ this file is for.
   wrong data — psql treats an unterminated `COPY ... FROM stdin` at EOF as simply
   ending the copy, not a parse error — so that fault mode's rehearsal assertion
   is a content digest, never `restore`'s exit code.
+- **Install-path gate** — `verify-install-paths.sh` (issue #683). The ONLY check that compares
+  the scripts at the TIP against the releases actually PUBLISHED. Everything else in
+  `release-validate.yml` validates a tag against its own checkout, which structurally cannot see
+  the failure this exists for: a self-hosted install has two sources and only one is pinned —
+  `setup-opentranscribe.sh` comes from the default branch (the docs one-liner hardcodes it),
+  everything it downloads comes from the resolved release tag. The installer is therefore always
+  NEWER than what it installs. `release-manifest.txt` was added after v0.4.1 shipped, the new
+  installer asked that tag for a file it had never heard of, and **every `curl | bash` install
+  died for 22 days**. The manifest-fetchable step that could have caught it was gated
+  `if: github.ref_type == 'tag'`, and neither installer script was in any `paths:` filter, so
+  the PR that broke it ran this workflow zero times. Both are fixed.
+  It runs the REAL shell functions out of the REAL scripts against the REAL GitHub in a temp dir
+  — never a re-implementation of the download loop, which would have passed throughout the
+  outage. Four paths: fresh install, `update-full` on a pinned install, `update-full` on a
+  pre-pinning install, and the default one-liner's release resolution. **The pin check is the
+  load-bearing one**: it compares each downloaded artifact against `git show <tag>:<path>`,
+  because a fallback that also pulled *artifacts* from the tip would satisfy an
+  existence-only assertion while silently shipping an unpinned install. Needs
+  `fetch-depth: 0` for that reason. `MIN_SUPPORTED_RELEASE` (v0.3.0) is a declared floor with a
+  written reason — v0.1.0–v0.2.1 predate two non-optional manifest paths; marking those
+  `optional` to make old tags pass would stop the gate noticing if a CURRENT release lost them.
+  Never lower it to silence a red run. Runs on PRs (latest release only), and on a **schedule**
+  because publishing a release can break the invariant with no commit at all. The hermetic half
+  (no network, so it runs in the fast suite and CI) is
+  `backend/tests/unit/test_install_upgrade_scripts.py`'s install-path section.
 - **Release gates** — `check-schema-drift.py` (model-vs-schema, report-first),
   `validate-deployments.sh` (~20 compose permutations in ~15 s),
   `release/check-version-consistency.py` (the six version sources + Alembic single head).

--- a/scripts/verify-install-paths.sh
+++ b/scripts/verify-install-paths.sh
@@ -1,0 +1,388 @@
+#!/bin/bash
+# Prove the CHECKED-OUT installer can install and update every PUBLISHED release.
+#
+# WHY THIS EXISTS (issue #683)
+#
+# A self-hosted install has two sources and only one of them is pinned:
+#
+#   setup-opentranscribe.sh  <- served from the DEFAULT BRANCH (the docs one-liner)
+#   everything it downloads  <- served from the RESOLVED RELEASE TAG
+#
+# So the installer is always NEWER than the thing it installs. release-manifest.txt was
+# added after v0.4.1 shipped; the new installer asked that tag for a file it had never
+# heard of, 404ed, and fail-closed. Every `curl | bash` install died for 22 days and
+# nothing noticed, because every test we had validated a tag against ITS OWN checkout.
+#
+# That is the blind spot this closes. The invariant is a CROSS-REF one and cannot be
+# checked from a single tree:
+#
+#   The scripts at the tip must install every release that resolve_install_ref() can
+#   resolve to — which means the newest published GitHub Release, and every older one
+#   a user may pin with --version.
+#
+# HOW IT CHECKS
+#
+# It runs the REAL shell functions out of the REAL scripts against the REAL GitHub, in a
+# throwaway directory. It does not re-implement the download loop; a re-implementation
+# would have passed happily throughout the outage.
+#
+# Usage:
+#   ./scripts/verify-install-paths.sh                 # the latest release (CI default)
+#   ./scripts/verify-install-paths.sh --all-releases  # every published release
+#   ./scripts/verify-install-paths.sh --ref v0.4.1    # one specific tag
+#
+# Env: GITHUB_TOKEN (optional) raises the API rate limit from 60/hr to 5000/hr.
+# Exit: 0 all paths good, 1 a path is broken, 2 misuse//unreachable API.
+
+set -euo pipefail
+
+REPO="attevon-llc/OpenTranscribe"
+
+# The oldest release `--version vX.Y.Z` is supported for, and WHY it is not simply "all".
+#
+# v0.1.0-v0.2.1 shipped before nginx/site.conf.template and scripts/generate-ssl-cert.sh
+# existed, and both are non-optional in release-manifest.txt because the nginx/HTTPS
+# deployment genuinely cannot run without them. The alternative -- marking them optional
+# so old tags pass -- would stop the gate noticing if a CURRENT release lost them, which
+# is the failure that actually matters. So the floor is declared, not papered over.
+#
+# Those releases were already 100% uninstallable before the #683 fix (they 404ed one step
+# earlier, on the manifest itself), so nothing regressed here. Raise this only when a
+# release genuinely drops out of support; never lower it to silence a red run.
+MIN_SUPPORTED_RELEASE="v0.3.0"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INSTALLER="$ROOT/setup-opentranscribe.sh"
+MANAGER="$ROOT/opentranscribe.sh"
+
+RED=$'\033[0;31m'; GREEN=$'\033[0;32m'; YELLOW=$'\033[1;33m'; BLUE=$'\033[0;34m'; NC=$'\033[0m'
+
+FAILURES=0
+CHECKS=0
+
+UNSUPPORTED=0
+# Set per-release: a failure below MIN_SUPPORTED_RELEASE is reported, but is not a gate
+# failure. It must still be PRINTED -- an unsupported release that silently vanished from
+# the output would be indistinguishable from one that passed.
+LENIENT=false
+
+pass() { CHECKS=$((CHECKS + 1)); echo "    ${GREEN}✓${NC} $1"; }
+info() { echo "    ${BLUE}·${NC} $1"; }
+fail() {
+    CHECKS=$((CHECKS + 1))
+    if [[ "$LENIENT" == true ]]; then
+        UNSUPPORTED=$((UNSUPPORTED + 1))
+        echo "    ${YELLOW}○${NC} $1 ${YELLOW}(below the v${MIN_SUPPORTED_RELEASE#v} support floor — not a gate failure)${NC}"
+    else
+        FAILURES=$((FAILURES + 1))
+        echo "    ${RED}✗${NC} $1"
+    fi
+}
+
+# True when $1 is older than MIN_SUPPORTED_RELEASE.
+is_unsupported() {
+    local oldest
+    oldest=$(printf '%s\n%s\n' "${1#v}" "${MIN_SUPPORTED_RELEASE#v}" | sort -V | head -1)
+    [[ "$oldest" == "${1#v}" && "${1#v}" != "${MIN_SUPPORTED_RELEASE#v}" ]]
+}
+
+gh_api() {
+    local url="$1"
+    if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+        curl -fsSL --connect-timeout 10 --max-time 30 \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" "$url"
+    else
+        curl -fsSL --connect-timeout 10 --max-time 30 "$url"
+    fi
+}
+
+# Pull one shell function out of a script so it can be run in isolation. Same approach as
+# backend/tests/unit/test_release_manifest.py::_extract_function -- deliberately, so the
+# shell gate and the pytest gate exercise identical text.
+# Two definition shapes exist and both must be extractable. opentranscribe.sh ships
+# standalone, so read_env_value/resolve_default_branch are defined INSIDE an
+# `if ! declare -F <name>; then ... fi` guard (common.sh's copy wins when present) --
+# i.e. indented, and invisible to a `^name()` match. Extracting the whole guard block
+# yields valid bash either way.
+extract_fn() {
+    local script="$1" name="$2" out
+    out=$(sed -n "/^${name}()/,/^}/p" "$script")
+    if [[ -z "$out" ]]; then
+        out=$(sed -n "/^if ! declare -F ${name}\b/,/^fi$/p" "$script")
+    fi
+    printf '%s\n' "$out"
+}
+
+# Assert every function the checks below run actually exists, BEFORE running any of them.
+#
+# extract_fn is always called inside $(...), so an `exit` there would only kill the
+# subshell: the harness would be built with an empty body and die with a bare 127, which
+# reads like a broken test rather than a deleted invariant. Measured -- against a pre-fix
+# tree this gate exited 127 with no usable message. Fail here instead, with the name.
+require_functions() {
+    local missing=() script name
+    for spec in "$INSTALLER:resolve_install_ref" \
+        "$INSTALLER:resolve_default_branch" \
+        "$INSTALLER:download_release_manifest_artifacts" \
+        "$MANAGER:read_env_value" \
+        "$MANAGER:resolve_default_branch" \
+        "$MANAGER:deployment_ref" \
+        "$MANAGER:raw_url_for" \
+        "$MANAGER:resolve_config_ref"; do
+        script="${spec%%:*}"
+        name="${spec##*:}"
+        [[ -n "$(extract_fn "$script" "$name")" ]] || missing+=("$(basename "$script")::${name}()")
+    done
+
+    [[ ${#missing[@]} -eq 0 ]] && return 0
+
+    echo "${RED}❌ Required function(s) missing — the install-path invariant is gone:${NC}" >&2
+    printf '     %s\n' "${missing[@]}" >&2
+    echo "   These are what make a pinned install resolvable (issue #683)." >&2
+    echo "   Restore them, or update this gate deliberately if the design changed." >&2
+    exit 1
+}
+
+# ---------------------------------------------------------------------------------------
+# Path 1 — a FRESH INSTALL at $tag (`curl … | bash`, with or without --version)
+#
+# Runs the installer's real download loop. Then checks the thing the 404 hid: that the
+# files on disk are the TAG's bytes, not the default branch's. A manifest fallback that
+# quietly pulled artifacts from the tip would "pass" an existence check while shipping an
+# unpinned install -- the exact bug pinning exists to prevent.
+# ---------------------------------------------------------------------------------------
+check_fresh_install() {
+    local tag="$1" workdir log
+    workdir=$(mktemp -d)
+    log=$(mktemp)
+
+    if ! (
+        cd "$workdir"
+        # shellcheck disable=SC2016  # the harness is built as text on purpose
+        bash -c "
+            set -uo pipefail
+            RED=''; GREEN=''; YELLOW=''; BLUE=''; NC=''
+            $(extract_fn "$INSTALLER" resolve_default_branch)
+            $(extract_fn "$INSTALLER" download_release_manifest_artifacts)
+            OPENTRANSCRIBE_BRANCH='$tag' download_release_manifest_artifacts
+        "
+    ) >"$log" 2>&1; then
+        fail "fresh install at ${tag}: the download loop failed"
+        sed 's/^/        /' "$log" | tail -15
+        rm -rf "$workdir" "$log"
+        return
+    fi
+    pass "fresh install at ${tag}: all required artifacts downloaded"
+
+    if grep -q "predates release-manifest.txt" "$log"; then
+        info "used the fallback manifest (this release predates release-manifest.txt)"
+    fi
+
+    # Every non-optional manifest entry must be on disk.
+    local missing=() path flags
+    while IFS= read -r line; do
+        case "$line" in '' | '#'*) continue ;; esac
+        path=$(printf '%s' "$line" | cut -f1 | tr -d '[:space:]')
+        flags=$(printf '%s' "$line" | cut -s -f2)
+        [[ -n "$path" ]] || continue
+        case ",$flags," in *,optional,*) continue ;; esac
+        [[ -f "$workdir/$path" ]] || missing+=("$path")
+    done <"$workdir/release-manifest.txt"
+
+    if [[ ${#missing[@]} -eq 0 ]]; then
+        pass "fresh install at ${tag}: every required manifest path is on disk"
+    else
+        fail "fresh install at ${tag}: required paths absent: ${missing[*]}"
+    fi
+
+    # THE pin check: bytes must match the tag, not the tip.
+    local drifted=() f tag_sha got_sha
+    for f in docker-compose.yml opentranscribe.sh .env.example; do
+        [[ -f "$workdir/$f" ]] || continue
+        tag_sha=$(git -C "$ROOT" show "${tag}:${f}" 2>/dev/null | sha256sum | cut -d' ' -f1)
+        got_sha=$(sha256sum "$workdir/$f" | cut -d' ' -f1)
+        [[ -n "$tag_sha" ]] || continue
+        [[ "$tag_sha" == "$got_sha" ]] || drifted+=("$f")
+    done
+
+    if [[ ${#drifted[@]} -eq 0 ]]; then
+        pass "fresh install at ${tag}: artifacts are ${tag} content (pin intact)"
+    else
+        fail "fresh install at ${tag}: NOT ${tag} content -- install is unpinned: ${drifted[*]}"
+    fi
+
+    rm -rf "$workdir" "$log"
+}
+
+# ---------------------------------------------------------------------------------------
+# Path 2 — `opentranscribe.sh update-full` on an install pinned to $tag
+#
+# The failure mode here is silent, not a 404: config from the tip merged onto pinned
+# images. So the assertion is on the REF CHOSEN, not on whether a download succeeded.
+# ---------------------------------------------------------------------------------------
+check_update_full_ref() {
+    local tag="$1" workdir got
+    workdir=$(mktemp -d)
+    printf 'OT_IMAGE_TAG=%s\n' "$tag" >"$workdir/.env"
+
+    got=$(cd "$workdir" && bash -c "
+        set -uo pipefail
+        RED=''; GREEN=''; YELLOW=''; BLUE=''; NC=''
+        $(extract_fn "$MANAGER" read_env_value)
+        $(extract_fn "$MANAGER" resolve_default_branch)
+        $(extract_fn "$MANAGER" deployment_ref)
+        $(extract_fn "$MANAGER" resolve_config_ref)
+        unset OPENTRANSCRIBE_BRANCH
+        resolve_config_ref
+    " 2>/dev/null)
+
+    if [[ "$got" == "$tag" ]]; then
+        pass "update-full on a ${tag} install: takes config from ${tag}"
+    else
+        fail "update-full on a ${tag} install: took config from '${got}' -- config/image mismatch"
+    fi
+    rm -rf "$workdir"
+}
+
+# ---------------------------------------------------------------------------------------
+# Path 3 — an UNPINNED install (pre-pinning, OT_IMAGE_TAG unset or 'latest')
+#
+# Backward compatibility: these installs predate OT_IMAGE_TAG entirely and must keep
+# working -- but they must SAY they are unpinned rather than pretending otherwise.
+# ---------------------------------------------------------------------------------------
+check_unpinned_update_full() {
+    local label="$1" env_body="$2" workdir out rc
+    workdir=$(mktemp -d)
+    printf '%s' "$env_body" >"$workdir/.env"
+
+    set +e
+    out=$(cd "$workdir" && bash -c "
+        set -uo pipefail
+        RED=''; GREEN=''; YELLOW=''; BLUE=''; NC=''
+        $(extract_fn "$MANAGER" read_env_value)
+        $(extract_fn "$MANAGER" resolve_default_branch)
+        $(extract_fn "$MANAGER" deployment_ref)
+        $(extract_fn "$MANAGER" resolve_config_ref)
+        unset OPENTRANSCRIBE_BRANCH
+        resolve_config_ref
+    " 2>&1)
+    rc=$?
+    set -e
+
+    if [[ $rc -eq 0 ]] && grep -q "not pinned to a release" <<<"$out"; then
+        pass "update-full on ${label}: still works AND warns it is unpinned"
+    elif [[ $rc -eq 0 ]]; then
+        fail "update-full on ${label}: took tip config with NO unpinned warning"
+    else
+        fail "update-full on ${label}: refused outright (rc=${rc}) -- breaks existing installs"
+    fi
+    rm -rf "$workdir"
+}
+
+# ---------------------------------------------------------------------------------------
+# Path 4 — the default `curl | bash` resolves to the newest PUBLISHED release
+#
+# resolve_install_ref() reads the GitHub *Release*, never the newest git tag: a tag
+# appears 30-90 min before its images are promoted, and resolving to it would hand new
+# users a version whose images do not exist. This asserts that is still what happens.
+# ---------------------------------------------------------------------------------------
+check_default_install_resolves_latest() {
+    local expected="$1" got
+    got=$(bash -c "
+        set -uo pipefail
+        print_info(){ :; }; print_success(){ :; }; print_error(){ :; }; print_warning(){ :; }
+        $(extract_fn "$INSTALLER" resolve_install_ref)
+        unset OPENTRANSCRIBE_VERSION OPENTRANSCRIBE_BRANCH
+        resolve_install_ref >/dev/null 2>&1
+        printf '%s|%s\n' \"\$OPENTRANSCRIBE_BRANCH\" \"\$OT_IMAGE_TAG\"
+    " 2>/dev/null || true)
+
+    if [[ "$got" == "${expected}|${expected}" ]]; then
+        pass "default 'curl | bash' resolves to ${expected} and pins images to it"
+    else
+        fail "default 'curl | bash' resolved '${got}', expected '${expected}|${expected}'"
+    fi
+}
+
+main() {
+    local mode=latest explicit_ref=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --all-releases) mode=all; shift ;;
+            --ref) explicit_ref="${2:-}"; mode=one
+                  [[ -n "$explicit_ref" ]] || { echo "--ref needs a tag" >&2; exit 2; }
+                  shift 2 ;;
+            -h | --help) sed -n '2,30p' "${BASH_SOURCE[0]}"; exit 0 ;;
+            *) echo "unknown argument: $1" >&2; exit 2 ;;
+        esac
+    done
+
+    echo "${BLUE}▶ Verifying install/update paths against real published releases${NC}"
+    echo "  repo: ${REPO}   scripts: working tree at $(git -C "$ROOT" rev-parse --short HEAD)"
+    echo ""
+
+    require_functions
+
+    local latest default_branch
+    if ! latest=$(gh_api "https://api.github.com/repos/${REPO}/releases/latest" |
+        grep -m1 '"tag_name"' | sed -E 's/.*"(v?[0-9]+\.[0-9]+\.[0-9]+)".*/\1/'); then
+        echo "${RED}✗ Could not reach the GitHub API (rate limited? set GITHUB_TOKEN)${NC}" >&2
+        exit 2
+    fi
+    default_branch=$(gh_api "https://api.github.com/repos/${REPO}" |
+        grep -m1 '"default_branch"' | sed -E 's/.*"default_branch"[^"]*"([^"]+)".*/\1/')
+
+    echo "  latest published release: ${YELLOW}${latest}${NC}"
+    echo "  default branch (installer is served from here): ${YELLOW}${default_branch}${NC}"
+    echo ""
+
+    local -a targets=()
+    case "$mode" in
+        latest) targets=("$latest") ;;
+        one) targets=("$explicit_ref") ;;
+        all)
+            mapfile -t targets < <(gh_api "https://api.github.com/repos/${REPO}/releases" |
+                grep '"tag_name"' | sed -E 's/.*"(v?[0-9]+\.[0-9]+\.[0-9]+)".*/\1/')
+            ;;
+    esac
+
+    echo "${BLUE}▶ Path 4: default one-line install${NC}"
+    check_default_install_resolves_latest "$latest"
+    echo ""
+
+    echo "${BLUE}▶ Path 3: pre-pinning installs (backward compatibility)${NC}"
+    check_unpinned_update_full "an install with no OT_IMAGE_TAG" 'FOO=bar
+'
+    check_unpinned_update_full "an install pinned to 'latest'" 'OT_IMAGE_TAG=latest
+'
+    echo ""
+
+    local tag
+    for tag in "${targets[@]}"; do
+        if is_unsupported "$tag"; then
+            LENIENT=true
+            echo "${BLUE}▶ Release ${tag}${NC} ${YELLOW}(pre-${MIN_SUPPORTED_RELEASE}, unsupported)${NC}"
+        else
+            LENIENT=false
+            echo "${BLUE}▶ Release ${tag}${NC}"
+        fi
+        check_fresh_install "$tag"
+        check_update_full_ref "$tag"
+        echo ""
+    done
+
+    echo "─────────────────────────────────────────────────────"
+    if [[ $UNSUPPORTED -gt 0 ]]; then
+        echo "${YELLOW}○ ${UNSUPPORTED} check(s) failed on releases older than ${MIN_SUPPORTED_RELEASE}${NC}"
+        echo "  Those tags predate files release-manifest.txt marks required; they were"
+        echo "  uninstallable before this gate existed too. Not counted as failures."
+    fi
+    if [[ $FAILURES -eq 0 ]]; then
+        echo "${GREEN}✅ ${CHECKS} checks run, 0 failures — every supported path installs and updates cleanly${NC}"
+        exit 0
+    fi
+    echo "${RED}❌ ${FAILURES} of ${CHECKS} checks FAILED${NC}"
+    echo "   A user running the documented one-liner would hit this. Do not release."
+    exit 1
+}
+
+main "$@"

--- a/setup-opentranscribe.sh
+++ b/setup-opentranscribe.sh
@@ -466,6 +466,19 @@ create_configuration_files() {
     fi
 }
 
+# The repo's default branch, asked for at runtime rather than written down.
+#
+# Every hardcoded "master" in a download URL is a rename waiting to break installs, and
+# this script is about to be served from a branch that is renamed. Resolve it instead.
+# Echoes empty on any failure (offline, rate-limited, malformed) — callers MUST treat
+# empty as "no fallback available" and fail closed rather than guessing a name.
+resolve_default_branch() {
+    curl -fsSL --connect-timeout 10 --max-time 20 \
+        "https://api.github.com/repos/attevon-llc/OpenTranscribe" 2>/dev/null |
+        grep -m1 '"default_branch"' |
+        sed -E 's/.*"default_branch"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/' || true
+}
+
 # Download every artifact listed in release-manifest.txt, at the resolved install ref.
 #
 # The file list lives in release-manifest.txt, NOT in this script. This installer used to
@@ -492,12 +505,44 @@ download_release_manifest_artifacts() {
 
     # The manifest itself is required. Guessing the file list is the bug this replaced,
     # so refuse to install rather than fall back to an assumed set.
+    #
+    # WHY THERE IS A FALLBACK REF (issue #683)
+    #
+    # This installer is served from the default branch, but installs whatever
+    # resolve_install_ref() picks — the latest published GitHub Release. Those are two
+    # different refs, and release-manifest.txt was added AFTER the newest release at the
+    # time. So the current installer asked an older tag for a file that tag had never
+    # heard of, 404ed, and correctly-but-fatally refused: 100% of fresh installs died
+    # for 22 days.
+    #
+    # A release that ships its own manifest describes itself best, so that is still
+    # preferred. Only when the pinned ref predates the manifest do we borrow the list
+    # from the default branch. The ARTIFACTS are always fetched from the pinned ref
+    # ($github_raw) either way — only the file *list* falls back, so this cannot
+    # reintroduce an unpinned install. The manifest's `optional` flag is what absorbs
+    # the skew: a file a newer manifest lists but an older release does not have is
+    # reported and skipped, not fatal.
     if ! curl -fsSL --connect-timeout 10 --max-time 30 \
         "$github_raw/release-manifest.txt" -o release-manifest.txt.new; then
-        echo -e "${RED}❌ Failed to download release-manifest.txt from ${branch}${NC}"
-        echo "Refusing to install from an unknown artifact list."
-        echo "Alternative: You can manually download from: $github_raw/release-manifest.txt"
-        exit 1
+        rm -f release-manifest.txt.new
+
+        local default_branch
+        default_branch=$(resolve_default_branch)
+
+        if [ -n "$default_branch" ] && [ "$default_branch" != "$branch" ] &&
+            curl -fsSL --connect-timeout 10 --max-time 30 \
+                "https://raw.githubusercontent.com/attevon-llc/OpenTranscribe/${default_branch}/release-manifest.txt" \
+                -o release-manifest.txt.new; then
+            echo -e "  ${YELLOW}⚠️${NC}  ${branch} predates release-manifest.txt — using the file list from '${default_branch}'."
+            echo "     Deployment files are still downloaded from ${branch}; files that release"
+            echo "     does not have are skipped only if the manifest marks them optional."
+        else
+            rm -f release-manifest.txt.new
+            echo -e "${RED}❌ Failed to download release-manifest.txt from ${branch}${NC}"
+            echo "Refusing to install from an unknown artifact list."
+            echo "Alternative: You can manually download from: $github_raw/release-manifest.txt"
+            exit 1
+        fi
     fi
     mv release-manifest.txt.new release-manifest.txt
 


### PR DESCRIPTION
Fixes #683 — the one-line installer has been failing with a 404 for 22 days.

## What broke

A self-hosted install has **two sources and only one was pinned**:

| Piece | Served from |
|---|---|
| `setup-opentranscribe.sh` (the `curl \| bash` one-liner) | the **default branch** — hardcoded in the docs/README |
| everything it downloads | the **resolved release tag** (`resolve_install_ref()` → latest GitHub Release) |

So the installer is always *newer* than the release it installs. `release-manifest.txt` landed
4 months after v0.4.1 shipped, so the current installer asked that tag for a file it had never
heard of, 404ed, and fail-closed. Correct behaviour — fatal outcome.

Nothing caught it because **every existing check validates a tag against its own checkout**, and
this is a cross-ref break. The one check that could have seen it was gated
`if: github.ref_type == 'tag'`, and neither installer script was in any `paths:` filter — so the
PR that broke installs ran `release-validate` zero times.

## The fixes

**`setup-opentranscribe.sh`** — prefer the pinned ref's own manifest; on 404, borrow the list from
the default branch, **resolved at runtime from the GitHub API rather than written down**. Only the
file *list* falls back — artifacts still come from the pinned ref, so this cannot un-pin an
install. Still fails closed when no manifest is reachable anywhere. Version skew is absorbed by
the manifest's existing `optional` flag; **no file list is hardcoded**.

**`opentranscribe.sh`** — a second, quieter bug: `update-full` defaulted to `master`, so an install
pinned to vX.Y.Z re-downloaded **tip-of-development compose files onto vX.Y.Z images**. It didn't
404, it silently produced the exact config/image mismatch `OT_IMAGE_TAG` exists to prevent. It now
follows the pin. The four remaining hardcoded `/master/` URLs now go through `raw_url_for()` —
including the nginx template fetch, which was a *real* unpinned download on a pinned deployment.

No branch name is written into either script, so **`master` → `main` becomes a non-event** rather
than a second outage.

## The recurrence guard

`scripts/verify-install-paths.sh` — runs the **real shell functions** from the **real scripts**
against the **real GitHub**, across four paths: fresh install, `update-full` pinned, `update-full`
pre-pinning, and the one-liner's release resolution.

The load-bearing assertion is the **pin check**: each downloaded artifact is compared against
`git show <tag>:<path>`. An existence-only check would pass while shipping an unpinned install.

`MIN_SUPPORTED_RELEASE` (v0.3.0) is a *declared floor with a written reason* — v0.1.0–v0.2.1
predate two non-optional manifest paths. Marking those `optional` to make old tags pass would stop
the gate noticing if a **current** release lost them. Those releases were already 100%
uninstallable before this PR.

CI: new `install-paths` job, on PRs and **on a schedule** (publishing a release can break this
invariant with no commit at all), plus the missing `paths:` entries.

## Evidence

| Check | Result |
|---|---|
| Pre-fix code vs real v0.4.1 (`git archive HEAD`) | **exit 1**, reproduces the reporter's error verbatim, 0 files |
| Fixed code vs real v0.4.1 | **exit 0**, 15 files, 2 optional correctly skipped |
| Downloaded `docker-compose.yml` / `opentranscribe.sh` / `.env.example` | **byte-identical to `v0.4.1`** — pin intact |
| `verify-install-paths.sh --all-releases` | **33 checks, 0 failures** |
| The gate run against pre-fix code | **exit 1** with a named cause |
| Unit tests | **84 passed** |
| `scripts/safe-precommit.sh run --all-files` | clean |

Red-before-green was done via a `git archive HEAD` tree, never by reverting files in the shared
checkout.

## Not covered

A live `update-full` upgrade end-to-end against a real pinned install — the ref-selection logic is
unit- and gate-verified, but no full upgrade was run.
