### PR TITLE
docs: state the project's development status on the README and docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
   **AI-Powered Transcription and Media Analysis Platform**
 </div>
 
+> **Project status — active development.** The default branch tracks ongoing work and may
+> contain unreleased or in-progress features. For a stable deployment, install a published
+> [release](https://github.com/attevon-llc/OpenTranscribe/releases) — the one-line installer
+> below resolves the latest release automatically and pins your deployment to it.
+
 OpenTranscribe is a powerful, containerized web application for transcribing and analyzing audio/video files using state-of-the-art AI models. Built with modern technologies and designed for scalability, it provides an end-to-end solution for speech-to-text conversion, speaker identification, and content analysis.
 
 > **Note**: This application is 99.9% written by AI using frontier models from commercial providers, demonstrating the power of AI-assisted development.

--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -120,6 +120,22 @@ const config: Config = {
       defaultMode: 'dark',
       respectPrefersColorScheme: true,
     },
+    // This site is built and deployed from the default branch (deploy-docs.yml), while
+    // the installer deliberately installs the latest published RELEASE. Those are two
+    // different points in history, so the docs can legitimately describe features that
+    // have not shipped yet. Say so rather than letting a reader discover it.
+    //
+    // No version number here on purpose: it would be a hand-maintained fact that rots,
+    // and the repo's rule is that version facts are DERIVED, never recorded. The link
+    // sends readers to the release list, which is always current.
+    announcementBar: {
+      id: 'active-development',
+      content:
+        'OpenTranscribe is under active development. These docs track the default branch and may ' +
+        'describe features not yet in the latest ' +
+        '<a target="_blank" rel="noopener" href="https://github.com/attevon-llc/OpenTranscribe/releases">release</a>.',
+      isCloseable: true,
+    },
     navbar: {
       title: 'OpenTranscribe',
       logo: {


### PR DESCRIPTION
Two banners stating the project's development status. No structural change.

## Why

The docs site is built and deployed from the default branch (`deploy-docs.yml`), while the
installer resolves the latest published GitHub Release. Those are two different points in
history — currently **1,698 commits and 4.5 months apart** — so `docs.opentranscribe.app`
can describe features that are not in the release a reader just installed. Nothing said so.

## What

- **README** — a status note above the description, linking to the release list and noting
  that the one-line installer pins to the latest release automatically.
- **Docs site** — a closeable Docusaurus `announcementBar` saying the docs track the default
  branch and may cover unreleased features.

Neither hardcodes a version number. The repo's rule is that version facts are **derived, never
recorded** — a hand-maintained "latest is vX.Y.Z" in two more places is a fact that rots. Both
link to the releases page, which is always current.

The `announcementBar` sets no explicit colours, so it follows the active theme and keeps
light/dark parity.

## Verified

`npm run build` passes, and the banner was checked **rendering** against a real
`docusaurus serve` build in both light and dark mode — not just a successful compile. The
release link is present in the built HTML (the minifier strips attribute quotes, which makes a
naive grep miss it).

## Context

Follow-up to #684 (issue #683). We considered splitting `master` into a stable `main` plus a
`develop` integration branch and **decided against it for now**: it would not have prevented
the install outage — that was one file escaping the artifact pin, not branch drift — and a
stable branch would have *masked* it. The targeted fixes (release-pinned artifacts, the
install-paths CI gate in #684, and these banners) address the actual exposure at a fraction of
the cost. Worth revisiting when two release lines need supporting at once.

## Known, not addressed here

The docs homepage badge reads **`V0.5.0`**, sourced from the `VERSION` file — which is bumped
*ahead* of release, so the site currently advertises a version nobody can install. Out of scope
for a banner change; worth its own issue.
