### PR TITLE
fix: nine small v0.5.0 cleanup fixes (config, docs, scan gate, search, security, dev-loop)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -289,8 +289,10 @@ DIAR_NATIVE_MODE=cuda
 DIAR_NATIVE_MAX_INFLIGHT=2
 # --with-diar-native overlay: 1 = lazily load models on first request instead of at startup
 DIAR_NATIVE_LAZY_SESSIONS=1
-# --with-diar-native overlay: host CUDA device for the sidecar (falls back to GPU_DEVICE_ID)
-DIAR_NATIVE_GPU=0
+# Pin the diar-native sidecar to a specific GPU. Leave unset to inherit
+# GPU_DEVICE_ID — the sidecar holds ~4.1 GB of warm ORT arena, so pinning
+# it to a card the rest of the stack isn't using is a deliberate choice.
+#DIAR_NATIVE_GPU=
 # Host dir holding the sidecar's exported ONNX/PLDA weights, mounted read-only.
 # Defaults to ${MODEL_CACHE_DIR}/diar-native — a sibling of the huggingface/ and torch/
 # caches above, written by `./opentranscribe.sh download-models diar-native`.

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -32,6 +32,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          # The homepage badge (docusaurus.config.ts's isUnpublishedVersion, issue #686)
+          # derives "is VERSION ahead of the newest release tag" from local git tag
+          # history. The default shallow/no-tags checkout would make that check always
+          # report "not dev" (fails closed), silently defeating the whole point.
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -49,15 +49,33 @@ jobs:
           restore-keys: |
             pre-commit-
 
-      - name: Run pre-commit
+      - name: Run pre-commit (pre-commit stage)
         run: pre-commit run --all-files --show-diff-on-failure
+
+      # ⚠️ BOTH stages, always (issue #688). `pre-commit run` with no --hook-stage runs
+      # DEFAULT-stage hooks only, and .pre-commit-config.yaml sets
+      # `default_stages: [pre-commit]` — so a hook demoted to `stages: [pre-push]` silently
+      # stops running here and the workflow stays green while checking less. That is the
+      # exact failure the tiering had to avoid, so the demotion and this step are one change,
+      # not two. It currently covers the frontend production vite build (the ONLY one in CI
+      # for a PR — docker-publish.yml is workflow_dispatch-only) and the recursive
+      # `bandit -r backend/` scan.
+      #
+      # `--show-diff-on-failure` is kept: shared pre-commit-hooks entries such as
+      # trailing-whitespace/end-of-file-fixer declare pre-push in their own stages and can
+      # rewrite files here too.
+      #
+      # backend/tests/unit/test_precommit_stage_ci_parity.py fails the build if any stage a
+      # hook is assigned to has no CI invocation.
+      - name: Run pre-commit (pre-push stage)
+        run: pre-commit run --all-files --hook-stage pre-push --show-diff-on-failure
 
       - name: Generate pre-commit summary
         if: always()
         run: |
           echo "## Pre-commit Check Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Pre-commit hooks executed on all files." >> $GITHUB_STEP_SUMMARY
+          echo "Pre-commit hooks executed on all files (pre-commit AND pre-push stages)." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Hooks Executed:" >> $GITHUB_STEP_SUMMARY
           echo "- Code formatting (Ruff, Prettier)" >> $GITHUB_STEP_SUMMARY

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -90,17 +90,42 @@ repos:
         types_or: [javascript, jsx, ts, tsx, json, yaml, html, css, scss, markdown]
         args: [--write, --ignore-unknown]
 
-  # Frontend type checking and build verification
+  # Frontend type checking and build verification — TWO TIERS (issue #688).
+  #
+  # `npm run build` measured 91.8 s of a 328 s whole-tree run, and its `prebuild`
+  # (frontend/package.json) is `download-fonts.js && build-ffmpeg.js`, the latter shelling
+  # out to `docker buildx`. Every commit touching one .svelte file paid for a production
+  # bundle. eslint + svelte-check catch what you actually get wrong while editing; a
+  # bundling failure is a push-time concern.
+  #
+  # ⚠️ The pre-push tier is NOT optional cover, and CI must run BOTH stages. On a pull
+  # request this hook is the ONLY vite build anywhere in CI: docker-publish.yml (which
+  # builds frontend/Dockerfile.prod) is `workflow_dispatch` only, and release-validate.yml's
+  # `npm ci && npm run build` is docs-site, not frontend. `pre-commit run --all-files` with
+  # no --hook-stage runs DEFAULT-stage hooks only, and default_stages below is
+  # [pre-commit] — so demoting the build without adding the second CI invocation would have
+  # deleted the frontend build from CI while leaving the workflow green.
+  # `.github/workflows/pre-commit.yml` runs both stages, and
+  # backend/tests/unit/test_precommit_stage_ci_parity.py fails if that ever stops being true.
   - repo: local
     hooks:
       - id: frontend-check
-        name: Frontend Build Verification
-        entry: scripts/frontend-check.sh
+        name: Frontend Type Check (eslint + svelte-check)
+        entry: scripts/frontend-check.sh --check-only
         language: system
         files: ^frontend/src/
         types_or: [svelte, ts, javascript, css, html]
         pass_filenames: false
         stages: [pre-commit]
+        verbose: true
+      - id: frontend-build
+        name: Frontend Build Verification (eslint + svelte-check + vite build)
+        entry: scripts/frontend-check.sh
+        language: system
+        files: ^frontend/src/
+        types_or: [svelte, ts, javascript, css, html]
+        pass_filenames: false
+        stages: [pre-push]
         verbose: true
 
   # Dockerfile linting — runs hadolint via its official pinned Docker image
@@ -133,16 +158,36 @@ repos:
   - repo: https://github.com/PyCQA/bandit
     rev: 1.7.7
     hooks:
+      # TWO TIERS (issue #688). The recursive scan below ignored the staged file list
+      # entirely and re-walked all of backend/ on every Python commit — 71.1 s of a 328 s
+      # whole-tree run. At commit time bandit now sees only the files pre-commit passes it;
+      # the whole-tree walk runs at pre-push and in CI (which invokes BOTH stages — see the
+      # frontend-check comment above for why that pairing is mandatory).
       - id: bandit
+        name: bandit (staged backend files)
+        files: ^backend/
+        # Belt and braces: pre-commit only ever passes TRACKED files and backend/mutants
+        # is gitignored, but a stray `git add` of a mutant must not become a finding.
+        exclude: ^backend/mutants/
+        args: [-c, pyproject.toml]
+        additional_dependencies: ["bandit[toml]"]
+        stages: [pre-commit]
+      - id: bandit
+        alias: bandit-recursive
+        name: bandit (recursive backend/ scan)
         files: ^backend/
         # --exclude on the CLI, not just [tool.bandit] exclude_dirs: the pyproject
         # glob does NOT reliably match here (the hook runs from the repo root, so paths
         # are `backend/mutants/...`), and bandit walks the FILESYSTEM, so gitignoring
         # mutmut's generated tree is not enough. Without this, a mutation run left ~330k
         # lines of deliberately corrupted source that failed the commit on a finding
-        # inside a mutant.
+        # inside a mutant. This is the tier that walks, so this is the tier that needs it.
         args: [-c, pyproject.toml, -x, backend/mutants, -r, backend/]
+        # -r backend/ already covers the tree; passing the changed files too would scan
+        # them twice. `files:` still gates whether this tier runs at all.
+        pass_filenames: false
         additional_dependencies: ["bandit[toml]"]
+        stages: [pre-push]
 
   # Import-linter — enforce the cloud seam direction: the open-source core
   # (`app.*`) must NEVER import the closed-source cloud edition (`cloud`/clerk/
@@ -283,5 +328,12 @@ repos:
         args: [--force-scope]
 
 # Configuration for specific hooks
+#
+# `default_install_hook_types` is what makes the tiering above real for a human: without it
+# `pre-commit install` wires ONLY the pre-commit hook, so the pre-push tier (frontend build,
+# recursive bandit) and the commit-msg tier (conventional commits) would never fire locally
+# no matter what `stages:` says. Existing checkouts must re-run `pre-commit install` once —
+# this key changes what a FUTURE install does, it cannot retro-wire an installed hook.
+default_install_hook_types: [pre-commit, commit-msg, pre-push]
 default_stages: [pre-commit]
 fail_fast: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -256,6 +256,24 @@ repos:
       - id: shellcheck
         args: [--severity=warning]
 
+  # A component that was never scanned must never read as a clean one (issue #681).
+  #
+  # Wired here rather than left as a script somebody might remember to run: the
+  # failure it guards is silent by construction — an unscannable component
+  # printed "All security scans completed successfully!" and `docs` had been in
+  # that state since it was added. Nothing about the output distinguished it
+  # from a real pass, so a human running the gate by hand would not have looked.
+  #
+  # 0.4 s, no Docker, no network, no images.
+  - repo: local
+    hooks:
+      - id: scan-not-a-pass
+        name: an unscanned component cannot report a passing security scan
+        entry: scripts/tests/test-scan-not-a-pass.sh
+        language: system
+        pass_filenames: false
+        files: ^scripts/(docker-build-push\.sh|security-scan\.sh|tests/test-scan-not-a-pass\.sh)$
+
   # Commit message linting (optional)
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v3.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -453,7 +453,7 @@ subsystem, and put new subsystem detail **there**, not in this file.
 | Full local test matrix (4 stages, overlay sub-matrix) | `docs-site/docs/developer-guide/full-test-matrix.md` |
 | Frontend SPA (+ 24 folder-level files) | `frontend/CLAUDE.md` |
 
-> **Cosine score conversion (repo-wide trap):** OpenSearch `cosinesimil` returns `(1 + cosine) / 2`, NOT raw cosine. Every kNN score read must do `raw_cosine = 2.0 * hit["_score"] - 1.0`. All 11 read sites live in the speaker/voiceprint plane under `backend/app/services/` (none in `api/`, and transcript search ranks by RRF, never raw cosine) — all 11 currently correct. Full table: `backend/app/services/search/CLAUDE.md`.
+> **Cosine score conversion (repo-wide trap):** OpenSearch `cosinesimil` returns `(1 + cosine) / 2`, NOT raw cosine. Every kNN score read must do `raw_cosine = 2.0 * hit["_score"] - 1.0`. All 11 read sites live in the speaker/voiceprint plane under `backend/app/services/` (none in `api/`, and transcript search ranks by RRF, never raw cosine) — all 11 currently correct. **It applies to WRITES too** (issue #674): a threshold sent *into* OpenSearch (`min_score`) needs the inverse, `(1 + raw_cosine) / 2`, and no read-site audit can find a bad one. Both directions are named functions in `backend/app/utils/cosine_space.py` — call them. Full table: `backend/app/services/search/CLAUDE.md`.
 
 > **Chat retrieval trap (issue #52), as amended by the redaction policy of 2026-08-13:** the
 > `transcript_chunks` index stores transcript text **UNREDACTED**. Whether it must be masked before

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,8 +215,27 @@ Run the full suite before committing — not just the staged subset, and through
 concurrency-guarded wrapper, not bare `pre-commit` (issue #434):
 
 ```bash
-scripts/safe-precommit.sh run --all-files    # the gate CI mirrors
+scripts/safe-precommit.sh run --all-files                      # commit-stage tier
+scripts/safe-precommit.sh run --all-files --hook-stage pre-push # push-stage tier
 ```
+
+**The gate is TIERED (issue #688), and CI runs BOTH tiers.** The commit stage is the fast
+edit loop (eslint + svelte-check, bandit over the staged files); the push stage carries the
+two whole-tree jobs that dominated it — the frontend production `vite build` and
+`bandit -r backend/`. ⚠️ `pre-commit run --all-files` with no `--hook-stage` runs
+**default-stage hooks only** (`default_stages: [pre-commit]`), so "I ran pre-commit" no
+longer means "I ran everything CI runs" — run the second line too before pushing.
+`.github/workflows/pre-commit.yml` has a step per stage and
+`backend/tests/unit/test_precommit_stage_ci_parity.py` fails if a hook ever sits in a stage
+CI does not invoke.
+
+**One-time local setup, per checkout:** `pre-commit install --install-hooks` — the config's
+`default_install_hook_types` now wires `pre-commit`, `commit-msg` and `pre-push`, but it
+only affects a *future* install; an already-installed checkout has just the `pre-commit`
+script and neither the push tier nor conventional-commit message linting fires until you
+re-run it. ⚠️ **Never run it from a git worktree**: `.git/hooks` there resolves to the
+shared common git dir, so you would rewrite the hooks of the main checkout and every other
+worktree at once.
 
 The wrapper (`scripts/safe-precommit.sh`, self-test: `scripts/safe-precommit-selftest.sh`)
 refuses to start — rather than racing silently — when either of the two *known* unsafe
@@ -268,7 +287,7 @@ an arbitrary unstaged edit elsewhere in the tree safe** — only those two speci
 >
 > `--all-files` is always correct in CI, where nothing else is writing.
 
-Hook inventory is in `.pre-commit-config.yaml`. The frontend hook only fires when `frontend/src/**/*.{svelte,ts,js,css,html}` is staged. Note that `prettier` **rewrites files** and then reports failure — re-stage and re-run, don't "fix" anything by hand.
+Hook inventory is in `.pre-commit-config.yaml`. The frontend hooks (`frontend-check` at commit stage, `frontend-build` at push stage) only fire when `frontend/src/**/*.{svelte,ts,js,css,html}` is staged. Note that `prettier` **rewrites files** and then reports failure — re-stage and re-run, don't "fix" anything by hand.
 
 ### ⚠️ Fix the finding, never silence it
 

--- a/backend/app/api/endpoints/files/crud.py
+++ b/backend/app/api/endpoints/files/crud.py
@@ -1006,6 +1006,18 @@ def delete_media_file(
     from app.services.file_cleanup_service import purge_media_file
 
     result = purge_media_file(db, db_file)
+    if result.get("refused_legal_hold"):
+        # A legal hold is a deliberate, actionable refusal, not a server fault:
+        # the admin has to release the hold first. Reporting it as a 500 told the
+        # caller the delete had broken rather than that it had been declined.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error": "FILE_UNDER_LEGAL_HOLD",
+                "message": result.get("error"),
+                "file_id": str(db_file.uuid),
+            },
+        )
     if not result["deleted"]:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/backend/app/api/endpoints/search.py
+++ b/backend/app/api/endpoints/search.py
@@ -474,6 +474,17 @@ def get_available_filters(
     )
 
 
+def _no_pending(message: str) -> dict[str, Any]:
+    """The "there is nothing to queue" answer, in the shape the panel expects."""
+    return {
+        "task_id": None,
+        "status": "no_pending",
+        "message": message,
+        "reindex_task_ids": {},
+        "reindex_users": 0,
+    }
+
+
 @router.post("/reindex")
 def trigger_reindex(
     file_uuids: list[str] | None = Body(
@@ -482,123 +493,83 @@ def trigger_reindex(
     pending_only: bool = Query(False, description="Only reindex files without chunks"),
     current_user: User = Depends(get_current_admin_user),
 ) -> dict[str, Any]:
-    """
-    Trigger re-indexing of existing transcripts as a background Celery task.
+    """Re-index existing transcripts **deployment-wide**, one coordinator per owner.
+
+    Admin-only (``get_current_admin_user``), and that gate is what makes the
+    corpus-wide scope legitimate rather than a privilege escalation.
+
+    Every mode used to dispatch a single ``reindex_transcripts_task`` for
+    ``current_user.id`` (issue #627). Since that coordinator filters
+    ``MediaFile.user_id == user_id``, an admin pressing "Reindex all" repaired
+    their own account and left every other user's files untouched — silently,
+    with a success toast. The fan-out is #437's
+    ``dispatch_reindex_for_every_owner``, reused rather than reimplemented; the
+    scope of the two narrower modes comes from
+    ``services/search/reindex_scope.py``.
 
     Args:
-        file_uuids: Optional list of specific file UUIDs. None = all files.
-        pending_only: If True, only reindex files that have no chunks in OpenSearch.
+        file_uuids: Optional list of specific file UUIDs, resolved to whichever
+            accounts own them. ``None`` = every owner's whole corpus.
+        pending_only: If True, only reindex files that have no chunks in
+            OpenSearch — surveyed across every owner, not just the caller's.
 
     Returns:
-        Dict with task_id and status.
+        Dict with the caller's ``task_id`` (the run the settings panel's progress
+        stream is keyed to), the per-owner task ids, and how many owners were
+        dispatched.
+
+    Raises:
+        HTTPException: 503 when nothing could be queued at all.
     """
-    if pending_only and file_uuids is None:
-        # Find file UUIDs that are NOT yet indexed in OpenSearch
-        from sqlalchemy import exists
-        from sqlalchemy import select
+    from app.services.search.model_switch import ReindexDispatchError
+    from app.services.search.model_switch import dispatch_reindex_for_every_owner
+    from app.services.search.reindex_scope import owners_of_files
+    from app.services.search.reindex_scope import pending_files_by_owner
 
-        from app.db.session_utils import session_scope
-        from app.models.media import FileStatus
-        from app.models.media import MediaFile
-        from app.models.media import TranscriptSegment
-        from app.services.opensearch_service import opensearch_client
+    scope: dict[int, list[str]] | None = None
 
-        # Get completed file UUIDs that have transcript segments (indexable)
-        with session_scope() as db:
-            has_segments = exists(
-                select(TranscriptSegment.id).where(TranscriptSegment.media_file_id == MediaFile.id)
+    if file_uuids is not None:
+        scope = owners_of_files(file_uuids)
+        if not scope:
+            return _no_pending(
+                f"None of the {len(file_uuids)} requested file(s) are completed "
+                f"transcripts that can be indexed."
             )
-            completed_files = (
-                db.query(MediaFile.uuid)
-                .filter(
-                    MediaFile.user_id == current_user.id,
-                    MediaFile.status == FileStatus.COMPLETED,
-                    has_segments,
-                )
-                .all()
-            )
-            all_uuids = {str(row[0]) for row in completed_files}
-
-        if not all_uuids:
-            return {
-                "task_id": None,
-                "status": "no_pending",
-                "message": "No completed files found to index.",
-            }
-
-        # Find which file UUIDs already have chunks in OpenSearch
-        indexed_uuids: set[str] = set()
-        if opensearch_client:
-            try:
-                index_name = settings.OPENSEARCH_CHUNKS_INDEX
-                if opensearch_client.indices.exists(index=index_name):
-                    agg_response = opensearch_client.search(
-                        index=index_name,
-                        body={
-                            "size": 0,
-                            "query": {
-                                "bool": {
-                                    "filter": [
-                                        {"term": {"user_id": current_user.id}},
-                                        # G4: "which files still need indexing?".
-                                        # A file left with only a digest (a rebuild
-                                        # that failed part-way) would otherwise read
-                                        # as indexed and never be repaired.
-                                        chunk_plane_clause(),
-                                    ]
-                                }
-                            },
-                            "aggs": {
-                                "indexed_files": {
-                                    "terms": {
-                                        "field": "file_uuid",
-                                        "size": min(len(all_uuids) + 100, 65536),
-                                    }
-                                }
-                            },
-                        },
-                    )
-                    buckets = (
-                        agg_response.get("aggregations", {})
-                        .get("indexed_files", {})
-                        .get("buckets", [])
-                    )
-                    indexed_uuids = {b["key"] for b in buckets}
-            except Exception as e:
-                logger.exception(f"Error querying indexed files: {e}")
-
-        # Compute the difference: files that need indexing
-        pending_uuids = list(all_uuids - indexed_uuids)
-
-        if not pending_uuids:
-            return {
-                "task_id": None,
-                "status": "no_pending",
-                "message": "All files are already indexed.",
-            }
-
-        file_uuids = pending_uuids
+    elif pending_only:
+        scope, indexable_total = pending_files_by_owner()
+        if not indexable_total:
+            return _no_pending("No completed files found to index.")
+        if not scope:
+            return _no_pending("All files are already indexed.")
+        queued = sum(len(uuids) for uuids in scope.values())
         logger.info(
-            f"Pending-only reindex: {len(pending_uuids)} files need indexing "
-            f"(out of {len(all_uuids)} total)"
+            f"Pending-only reindex: {queued} files across {len(scope)} owner(s) need "
+            f"indexing (out of {indexable_total} total)"
         )
 
-    from app.tasks.reindex_task import reindex_transcripts_task
+    try:
+        dispatch = dispatch_reindex_for_every_owner(current_user.id, scope)
+    except ReindexDispatchError as e:
+        logger.error(f"Re-index could not be queued: {e}")
+        raise HTTPException(status_code=503, detail=str(e)) from e
 
-    task = reindex_transcripts_task.delay(
-        user_id=current_user.id,
-        file_uuids=file_uuids,
-    )
-
+    task_ids = dispatch["reindex_task_ids"]
     logger.info(
-        f"Re-index task {task.id} started for user {current_user.id}, "
-        f"files: {len(file_uuids) if file_uuids else 'all'}"
+        f"Re-index dispatched by user {current_user.id} for {dispatch['reindex_users']} "
+        f"owner(s), files: {'named' if scope else 'all'}"
     )
 
     return {
-        "task_id": task.id,
+        # The caller's own coordinator, because that is the run the panel's
+        # progress stream and `POST /reindex/stop` are keyed to. It is absent
+        # when a named-file scope contains nothing the caller owns.
+        "task_id": task_ids.get(current_user.id),
         "status": "started",
-        "message": "Re-indexing started. Progress will be sent via WebSocket.",
+        "message": (
+            f"Re-indexing started for {dispatch['reindex_users']} user(s) across the "
+            f"deployment. Progress will be sent via WebSocket."
+        ),
+        **dispatch,
     }
 
 
@@ -606,11 +577,18 @@ def trigger_reindex(
 def stop_reindex(
     current_user: User = Depends(get_current_admin_user),
 ) -> dict[str, Any]:
-    """Request cancellation of a running reindex task.
+    """Request cancellation of the CALLER'S running reindex coordinator.
 
     Sets a Redis flag that the reindex task checks between files.
     The task will stop after completing the current file and restore
     normal index settings (refresh_interval).
+
+    ⚠️ **Per-owner, and ``POST /reindex`` is now per-corpus** (#627). The cancel
+    flag is ``reindex_cancel:{user_id}`` and the coordinators are one per owner,
+    so this stops the caller's run only; the other owners' coordinators run to
+    completion. The message says so rather than claiming the whole fan-out
+    stopped. Cancelling the fan-out would mean persisting the dispatched owner
+    set, which nothing does today.
 
     Returns:
         Dict with stop status.
@@ -631,7 +609,10 @@ def stop_reindex(
 
         return {
             "status": "stop_requested",
-            "message": "Stop signal sent. Reindex will stop after the current file completes.",
+            "message": (
+                "Stop signal sent for your own re-index run; it will stop after the "
+                "current file completes. Other accounts' coordinators are unaffected."
+            ),
         }
     except HTTPException:
         # Re-raise deliberate HTTP responses unchanged. The broad handler below turns

--- a/backend/app/api/endpoints/speaker_profiles.py
+++ b/backend/app/api/endpoints/speaker_profiles.py
@@ -26,6 +26,7 @@ from app.services.opensearch_service import update_speaker_collections
 from app.services.permission_service import PermissionService
 from app.services.speaker_matching_service import ConfidenceLevel
 from app.services.speaker_matching_service import SpeakerMatchingService
+from app.services.speaker_profile_rename import apply_profile_name_to_speakers
 from app.utils.error_handlers import ErrorHandler
 from app.utils.uuid_helpers import get_speaker_by_uuid
 from app.utils.uuid_helpers import get_speaker_profile_by_uuid
@@ -263,6 +264,41 @@ def create_speaker_profile(
         raise ErrorHandler.internal_error() from e
 
 
+def _dispatch_profile_rename_propagation(
+    renames: list[tuple[str, str]], new_name: str | None
+) -> None:
+    """Replay a committed profile rename into ``transcript_chunks`` (issue #675).
+
+    Chunk documents snapshot the speaker display name at index time, and nothing
+    repairs a merely-*wrong* value: ``search_index_maintenance`` only finds files
+    with no chunks at all. So a profile rename that skipped this left search facets,
+    chat's speaker-scoped ``terms`` filter and every citation serving the old name
+    until someone happened to reindex the file.
+
+    ``dispatch_speaker_rename`` is the single entry point every rename path uses
+    (``tasks/rename_propagation_task.py``); it coalesces the pairs per file, so one
+    task is queued per affected file however many members that file holds.
+
+    **No ``speaker_id``.** That argument exists so the task can re-resolve the
+    current name at run time and converge when two renames race. A profile-wide
+    rename sweeps many speakers at once and has no single id to re-read — the
+    omission is the documented contract, not an oversight.
+
+    Best-effort by design, and it must stay that way: the rename is already
+    committed, so an unreachable broker must not turn it into a caller-visible
+    failure. The chunk plane then stays stale until the next reindex, which is
+    exactly the pre-#405 behaviour.
+    """
+    if not renames or not new_name:
+        return
+    try:
+        from app.tasks.rename_propagation_task import dispatch_speaker_rename
+
+        dispatch_speaker_rename(renames, new_name)
+    except Exception as exc:  # noqa: BLE001 — a committed rename must not 500 on dispatch
+        logger.warning(f"Could not queue chunk-plane profile rename propagation: {exc}")
+
+
 @router.put("/profiles/{profile_uuid}", response_model=dict[str, Any])
 def update_speaker_profile(
     profile_uuid: str,
@@ -271,7 +307,16 @@ def update_speaker_profile(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_active_user),
 ):
-    """Update a speaker profile."""
+    """Update a speaker profile.
+
+    A name change is **not** a metadata edit. ``SpeakerProfile.name`` is not a
+    field of any search document; what the chunk plane carries is each member
+    speaker's canonical label, so renaming the profile re-applies the new name to
+    every member (the invariant every other profile-linking path upholds — see
+    ``services/speaker_profile_rename``) and then replays the change into
+    ``transcript_chunks``. Doing only one half would leave Postgres and the index
+    disagreeing in whichever direction was skipped.
+    """
     try:
         profile = get_speaker_profile_by_uuid(db, profile_uuid)
 
@@ -280,6 +325,7 @@ def update_speaker_profile(
         )
 
         profile_id = profile.id
+        renames: list[tuple[str, str]] = []
 
         if name:
             # Check for name conflicts
@@ -300,12 +346,29 @@ def update_speaker_profile(
                 )
 
             profile.name = name  # type: ignore[assignment]
+            # Collected BEFORE the commit below: these are the names the chunk
+            # documents were indexed with, and after the commit Postgres can no
+            # longer say what they were (issue #405).
+            renames = apply_profile_name_to_speakers(
+                db,
+                int(profile_id),
+                name,
+                restrict_to_user_id=None if current_user.is_admin else current_user.id,
+            )
 
         if description is not None:
             profile.description = description  # type: ignore[assignment]
 
         db.commit()
         db.refresh(profile)
+
+        # ─── POST-COMMIT REGION ───────────────────────────────────────────────
+        # The rename is durable from here, so nothing below may raise a 500 that
+        # tells the client it did not happen — the broad handler's `db.rollback()`
+        # cannot undo it. Dispatch AFTER the commit, never before: a rolled-back
+        # rename that reached the index would leave the new name existing only
+        # there (`SpeakerRenameTracker.flush`'s reasoning, same rule).
+        _dispatch_profile_rename_propagation(renames, name)
 
         # updated_at populated by server_default after refresh
         assert profile.updated_at is not None

--- a/backend/app/api/endpoints/speakers.py
+++ b/backend/app/api/endpoints/speakers.py
@@ -1632,10 +1632,14 @@ def _handle_update_profile_action(
     a dozen linked speakers used to cost a dozen-plus synchronous OpenSearch calls
     before the PUT could answer.
 
-    The ``(file_uuid, old_name)`` pairs are collected **before** the overwrite and
-    handed back, because a profile rename spans files and this is the last moment
-    the previous names exist anywhere: once committed, nothing in Postgres can say
-    what the chunk plane was indexed with (issue #405).
+    The member rewrite and the ``(file_uuid, old_name)`` capture live in
+    ``services/speaker_profile_rename.apply_profile_name_to_speakers`` — the ONE
+    implementation of "a profile rename re-applies the name to its members", shared
+    with ``PUT /speaker-profiles/profiles/{uuid}``, the other endpoint that renames a
+    profile (issue #675). It collects the old names **before** the overwrite, because
+    a profile rename spans files and that is the last moment the previous names exist
+    anywhere: once committed, nothing in Postgres can say what the chunk plane was
+    indexed with (issue #405).
 
     Returns:
         ``None`` when no such profile exists. Otherwise the renames to replay into
@@ -1643,6 +1647,8 @@ def _handle_update_profile_action(
         A non-``None`` return also tells the caller a profile was renamed, so it can
         ask the background task to replay the rename into the speaker index.
     """
+    from app.services.speaker_profile_rename import apply_profile_name_to_speakers
+
     profile = (
         db.query(SpeakerProfile)
         .filter(SpeakerProfile.id == profile_id, SpeakerProfile.user_id == current_user.id)
@@ -1655,40 +1661,12 @@ def _handle_update_profile_action(
     profile.name = new_name  # type: ignore[assignment]
     logger.info(f"Updated profile {profile.id} name to '{new_name}' globally")
 
-    # Update all speakers linked to this profile
-    linked_query = db.query(Speaker).filter(Speaker.profile_id == profile_id)
-    if not current_user.is_admin:
-        linked_query = linked_query.filter(Speaker.user_id == current_user.id)
-    linked_speakers = linked_query.all()
-
-    # One grouped lookup, not a lazy `speaker.media_file.uuid` per row.
-    file_uuids: dict[int, str] = {}
-    media_file_ids = {int(s.media_file_id) for s in linked_speakers if s.media_file_id}
-    if media_file_ids:
-        file_uuids = {
-            int(row[0]): str(row[1])
-            for row in db.query(MediaFile.id, MediaFile.uuid).filter(
-                MediaFile.id.in_(media_file_ids)
-            )
-        }
-
-    renames: list[tuple[str, str]] = []
-    for linked_speaker in linked_speakers:
-        # The CANONICAL indexed label (`canonical_speaker_label_for_row`, the
-        # SAME resolver the chunk-index writers use) — not the ad hoc
-        # `display_name or name` chain issue #605's original sweep replaced at
-        # eight other call sites but missed here. A linked speaker indexed
-        # under a confident suggestion (no `display_name` set) would compute
-        # the wrong "old name", and the propagation's `update_by_query` would
-        # match nothing while logging `status: success`.
-        old_chunk_name = canonical_speaker_label_for_row(linked_speaker)
-        file_uuid = file_uuids.get(int(linked_speaker.media_file_id or 0))
-        if file_uuid and old_chunk_name:
-            renames.append((file_uuid, old_chunk_name))
-        linked_speaker.display_name = new_name  # type: ignore[assignment]
-
-    logger.info(f"Updated {len(linked_speakers)} speakers with new profile name '{new_name}'")
-    return renames
+    return apply_profile_name_to_speakers(
+        db,
+        profile_id,
+        new_name,
+        restrict_to_user_id=None if current_user.is_admin else current_user.id,
+    )
 
 
 def _load_profile_speaker_names(db: Session, profile_id: int) -> list[tuple[str, str]]:

--- a/backend/app/services/diarization/CLAUDE.md
+++ b/backend/app/services/diarization/CLAUDE.md
@@ -1,43 +1,47 @@
 # backend/app/services/diarization — pluggable diarization providers
 
-> ⚠️ **Several line references below are stale — verify before following one.** Measured
-> 2026-09-01: `VALID_DIARIZATION_SOURCES` is at `core/constants.py:648`, not `:508`; the factory's
-> only production caller is `tasks/transcription/cloud_asr.py:83-89` guarded at `:265`, not
-> `tasks/transcription/core.py:1804` (that file is 353 lines). `local_provider.py` is described as
-> delegating to PyAnnote — `ModelManager` is **native-first with PyAnnote as fallback**. Correction
-> tracked in **#671**; the wider diarization roadmap in **#572** and
-> [this gist](https://gist.github.com/attevon-admin/a99819c7ec5e8ab8df0eb8e3e8e668e8).
-
 ## Purpose
 
 Speaker segmentation decoupled from ASR. Same skeleton as `../asr/` (`base.py` + `types.py` +
 `factory.py` + one module per vendor) — read **`../asr/CLAUDE.md`** for the shared pattern and the
 "register in the factory, never branch at a call site" rule. This file covers only what differs.
 
+⚠️ **This package is one of two independent axes and they are constantly confused.** *This* one
+picks **where** diarization runs, per user (`transcription_diarization_source`). The other,
+`TranscriptionConfig.diarizer_backend` (`native` | `pyannote`), picks **which local engine**
+runs once the answer here is "on our own GPU" — see `app/transcription/CLAUDE.md`. Changing one
+never changes the other.
+
 ## Key files
 
 - `factory.py` — `DiarizationProviderFactory`. Sources are `provider | local | pyannote | off`
-  (`VALID_DIARIZATION_SOURCES`, duplicated at `core/constants.py:508`), default `provider`. Returns
-  **`None`** for `provider` (use the ASR provider's own labels) and `off`, and **raises `ValueError`**
-  for an unknown source or a missing pyannote key — unlike the ASR factory, which silently degrades to
-  local. Credentials come from `UserDiarizationSettings` and are decrypted with `decrypt_value`
-  (ASR uses `decrypt_api_key` for the same job).
-- `local_provider.py` — delegates to `ModelManager.get_diarizer()` → `app/transcription/diarizer.py`;
-  no duplicated pipeline. It stuffs native objects (`native_embeddings`, `overlap_info`, `diarize_df`)
-  into `DiarizeResult.metadata`, so `DiarizeResult` is **not** a pure DTO.
+  (`VALID_DIARIZATION_SOURCES`, duplicated in `core/constants.py` under the same name), default
+  `provider`. Returns **`None`** for `provider` (use the ASR provider's own labels) and `off`,
+  and **raises `ValueError`** for an unknown source or a missing pyannote key — unlike the ASR
+  factory, which silently degrades to local. Credentials come from `UserDiarizationSettings` and
+  are decrypted with `decrypt_value` (ASR uses `decrypt_api_key` for the same job).
+- `local_provider.py` — delegates to `ModelManager.get_diarizer()`, which is **native-first**:
+  the diar-native sidecar with automatic in-process PyAnnote failover, not PyAnnote directly. It
+  stuffs native objects (`native_embeddings`, `overlap_info`, `diarize_df`) into
+  `DiarizeResult.metadata`, so `DiarizeResult` is **not** a pure DTO. Note its hardcoded
+  `model_name="pyannote/speaker-diarization-community-1"` reports the *weights*, which both
+  engines share — it is not a claim about which engine ran.
 - `pyannote_provider.py` — pyannote.ai cloud diarization (`precision-2`). Distinct from
   `../asr/pyannote_provider.py`, which hits the *STT-orchestration* endpoint. Don't confuse them.
 
 ## How it connects
 
 - The user setting is `UserSetting["transcription_diarization_source"]`, written and validated in
-  `api/endpoints/user_settings.py:778`, read at `factory.py:79` and `tasks/transcription/core.py:179`.
-  Frontend: `components/settings/TranscriptionSettings.svelte`.
-- **Only `source == "pyannote"` actually reaches this factory** (`tasks/transcription/core.py:1804`,
-  guarded at `:1971`), where it runs in parallel with cloud ASR in a 2-thread pool and merges via
-  `utils/diarization_merge`. `source == "local"` is served instead by `rediarize_task` on the GPU queue
-  (`tasks/transcription/postprocess.py:92-128`), so the factory's `local` branch is effectively dead.
-- Migration from the old boolean flag: `alembic/versions/v355_add_diarization_settings.py:44-79`.
+  `api/endpoints/user_settings.py`, read in `factory.create_for_user` and in
+  `tasks/transcription/user_settings.py` (which also derives `disable_diarization` from
+  `source == "off"`). Frontend: `components/settings/TranscriptionSettings.svelte`.
+- **Only `source == "pyannote"` actually reaches this factory.** The single production call site
+  is `tasks/transcription/cloud_asr.py`'s `_run_parallel_cloud_asr_and_diarization`, guarded by
+  `if diarization_source == "pyannote":` in `_run_cloud_asr_pipeline`; it runs cloud ASR
+  and cloud diarization in a 2-thread pool and merges via `utils/diarization_merge`.
+  `source == "local"` is served instead by `rediarize_task` on the GPU queue (dispatched from
+  `tasks/transcription/postprocess.py`), so the factory's `local` branch is effectively dead.
+- Migration from the old boolean flag: `alembic/versions/v355_add_diarization_settings.py`.
 
 ## Gotchas
 
@@ -46,7 +50,10 @@ Speaker segmentation decoupled from ASR. Same skeleton as `../asr/` (`base.py` +
   `sanitize_provider_error` in `asr/base.py`. Change behavior *there* — both hierarchies use it, and
   `tests/unit/test_speaker_label_normalization.py` asserts they agree. (Until #299 this proxied through
   `object.__new__(ASRProvider)`, which trips the ABC check and raised `TypeError` on **every** call,
-  killing `pyannote_provider.py:476` and `local_provider.py:91`.)
-- `factory.py:95` still says "UserDiarizationSettings model will be created in a separate task". The
-  model exists (`models/user_diarization_settings.py`); the comment is stale.
+  killing the label-normalization call in `pyannote_provider._parse_segments` and its twin in
+  `local_provider.diarize`.)
+- `factory.create_for_user`'s pyannote branch still carries the comment "UserDiarizationSettings
+  model will be created in a separate task". The model exists
+  (`models/user_diarization_settings.py`) and the branch imports it two lines later; the comment
+  is stale.
 - `test_provider_sdk_compat.py` covers **no** module in this package.

--- a/backend/app/services/file_cleanup_service.py
+++ b/backend/app/services/file_cleanup_service.py
@@ -20,6 +20,14 @@ from app.utils.task_utils import recover_stuck_file
 
 logger = logging.getLogger(__name__)
 
+#: Refusal reported by :func:`purge_media_file` for a file under an active legal
+#: hold. A module constant rather than an inline literal because callers that
+#: translate the refusal into a user-facing response should not have to re-spell it.
+LEGAL_HOLD_REFUSAL = (
+    "refused: the file is under an active legal hold and cannot be deleted. "
+    "Release the hold before deleting."
+)
+
 
 class FileCleanupService:
     """Service for automated file cleanup and recovery operations."""
@@ -758,8 +766,27 @@ def purge_media_file(db: Session, file: MediaFile) -> dict:
 
     SpeakerProfile records and their profile embeddings are intentionally preserved.
 
+    **A file under an active legal hold is REFUSED before step 1.** The hold is
+    the source of truth that keeps DMCA/litigation evidence alive (the S3 object
+    lock only mirrors it, best-effort), and this destroy is irreversible, so the
+    check lives here rather than only in each caller's query: a guard in one
+    query protects one caller, and this function has four. It fails closed — the
+    refusal is logged at ERROR and reported as ``deleted: False`` with
+    ``refused_legal_hold: True``, never as a quiet no-op that a caller reading
+    only ``deleted`` could mistake for a completed destroy. Clear the hold
+    (``takedown_service.release_file``) to make a held file deletable; there is
+    deliberately no override argument, because an argument that skips the guard
+    is the guard's own failure mode.
+
+    ``is_quarantined`` is deliberately **not** part of this check. Quarantine is
+    a review state an admin can legitimately end by deleting the offending
+    upload; it is the unattended retention sweep that must never destroy a file
+    under review, and that predicate lives on the sweep's query
+    (``tasks/cleanup._select_expired_files``).
+
     Returns ``{"deleted": bool, "file_uuid": str, "error": str | None,
-    "residual_errors": list[dict]}``. Never raises.
+    "residual_errors": list[dict]}``, plus ``refused_legal_hold: True`` on the
+    refusal above. Never raises.
 
     ``deleted`` reports the **database row** only. ``residual_errors`` is
     non-empty when a copy of the file's data may still exist in object storage
@@ -780,6 +807,20 @@ def purge_media_file(db: Session, file: MediaFile) -> dict:
     """
     file_uuid = str(file.uuid)
     residual: list[dict[str, Any]] = []
+
+    if bool(file.legal_hold):
+        logger.error(
+            f"purge_media_file: REFUSED to delete file {file_uuid} — it is under an "
+            "active legal hold. Release the hold before deleting."
+        )
+        return {
+            "deleted": False,
+            "file_uuid": file_uuid,
+            "error": LEGAL_HOLD_REFUSAL,
+            "residual_errors": residual,
+            "refused_legal_hold": True,
+        }
+
     try:
         # Phase 1 — read (DB session open, Postgres only).
         plan = _load_purge_plan(db, file)

--- a/backend/app/services/opensearch_service/__init__.py
+++ b/backend/app/services/opensearch_service/__init__.py
@@ -17,7 +17,9 @@ Where things live:
 
 .. warning::
    ``cosinesimil`` returns ``(1 + cosine) / 2``, never raw cosine. Every kNN
-   score read must convert with ``2.0 * hit["_score"] - 1.0``.
+   score read must convert with ``2.0 * hit["_score"] - 1.0``, and every
+   threshold *written* into a query (``min_score``) needs the inverse
+   ``(1 + raw_cosine) / 2`` — see :mod:`app.utils.cosine_space` (issue #674).
 """
 
 from typing import Any

--- a/backend/app/services/search/CLAUDE.md
+++ b/backend/app/services/search/CLAUDE.md
@@ -26,6 +26,18 @@ in the sibling speaker/voiceprint plane, none in this package):
 This package itself never reads a raw kNN score: transcript search ranks by **RRF**, whose
 output is a rank-fusion score, not a similarity. Don't treat `relevance_score` as cosine.
 
+### The conversion applies to WRITES too (issue #674)
+
+A threshold sent *into* OpenSearch — `min_score`, or any filter expressed in score space —
+lives in the same shifted space and must be converted the other way,
+`opensearch_score = (1 + raw_cosine) / 2`. A read-site audit cannot find a bad write, because
+nothing is being read: `min_score=0.75` looked like the auto-accept gate and actually admitted
+everything at raw cosine ≥ 0.50, which `_propagate_profile_assignment` then wrote `verified=True`.
+Both directions are named functions in `app/utils/cosine_space.py` — call them rather than
+open-coding the arithmetic, so the space is in the name. There is exactly one `min_score` write
+against a cosinesimil index today (`../similarity_service.py`, whose parameter is now
+`min_raw_cosine`); every other kNN caller filters in Python *after* converting the score.
+
 ## Purpose
 
 The transcript-chunk search plane: chunk → index → query. The **speaker/voiceprint** plane is

--- a/backend/app/services/search/CLAUDE.md
+++ b/backend/app/services/search/CLAUDE.md
@@ -76,7 +76,9 @@ separate and lives in the `../opensearch_service/` package (alias `speakers` →
   `settings_service.py` (DB-backed model + dimension), `tenant_scope.py`.
 - `embedding_provenance.py` — which model produced the vectors, and the one-query
   mixed-index survey. `model_switch.py` — the whole model switch, shared by both
-  endpoints. See "Switching the embedding model" below.
+  endpoints, plus the ONE reindex fan-out loop. See "Switching the embedding model"
+  below. `reindex_scope.py` — which owners and which of their files a reindex must
+  cover; see "A reindex is corpus-wide" below.
 
 ## Conventions / patterns
 
@@ -518,6 +520,43 @@ straight into the pipeline. That silently repointed embedding **with no user act
 one deployed model is not a choice and is adopted with a warning (the recovery the fallback
 exists for); more than one returns `None` and leaves search on BM25 — loud, obvious and
 reversible, where a wrong guess is silent and costs a full re-embed.
+
+## A reindex is corpus-wide, in every mode (#627)
+
+**`POST /search/reindex` had the identical defect #437 fixed for the switch, and kept it for
+another release.** All three of its modes dispatched one
+`reindex_transcripts_task.delay(user_id=current_user.id, ...)`, and that coordinator filters
+`MediaFile.user_id == user_id`. So the admin Settings → Search "Reindex all" button repaired the
+pressing admin's own account and left every other user's files exactly as they were — no error,
+no warning, a success toast. The pending-only sweep was scoped twice over (a `user_id ==` in
+Postgres *and* a `{"term": {"user_id": ...}}` beside the chunk-plane clause in the aggregation),
+so it could not even see another account's unindexed files. Naming another user's file UUID
+explicitly did nothing at all.
+
+- **One fan-out loop, not two.** `dispatch_reindex_for_every_owner` grew an optional
+  `file_uuids_by_owner`; it did **not** grow a sibling. `None` still means the whole corpus
+  (every owner of a COMPLETED file, caller first and unconditionally). A mapping means a partial
+  scope, one coordinator per named owner with that owner's files.
+- ⚠️ **An owner with an empty list is DROPPED, never dispatched.**
+  `reindex_transcripts_task` narrows with `if file_uuids:`, so `[]` is indistinguishable from
+  "no filter" and would re-embed that owner's entire account — the opposite of what a
+  pending-only sweep asked for.
+- **`reindex_scope.py` answers the scope question**, the dispatcher answers the fan-out one.
+  `pending_files_by_owner()` distinguishes "nothing indexable exists" from "everything is
+  already indexed"; the endpoint reports them as different messages, because a corpus-wide sweep
+  answering the empty-deployment message would be hiding a survey that saw nothing.
+  `indexed_file_uuids()` **fails open** — an unreachable cluster reads as "nothing is indexed"
+  and queues the corpus rather than nothing. That is the pre-existing direction and the safe one
+  (re-indexing overwrites by deterministic id), but the blast radius is now deployment-wide, so
+  the failure is logged with a traceback.
+- **The gate is `get_current_admin_user`, and it always was.** Corpus-wide work behind a
+  per-user gate would trade a scoping bug for a privilege one;
+  `test_reindex_is_refused_for_a_plain_user` carries the two-owner corpus fixture so a dropped
+  gate shows up as dispatches for *other* owners, not merely a wrong status code.
+- **Not fixed, deliberately: `POST /search/reindex/stop` is still per-owner.** The cancel flag is
+  `reindex_cancel:{user_id}` and the caller can only flag their own coordinator; the endpoint's
+  message says so. Cancelling the whole fan-out needs the dispatched owner set persisted
+  somewhere, which nothing does today.
 
 ## The bootstrap self-heals, and why it is a beat task (#625)
 

--- a/backend/app/services/search/model_switch.py
+++ b/backend/app/services/search/model_switch.py
@@ -46,20 +46,27 @@ class EmbeddingModelNotDeployedError(SearchIndexError):
 
 
 class ReindexDispatchError(SearchIndexError):
-    """The model was switched but the re-embed could not be queued.
+    """The re-index could not be queued.
 
-    Unlike the two above, this is raised **after** the settings, the ingest
+    Unlike the two above, this can be raised **after** the settings, the ingest
     pipeline and the index mapping have already been changed — the deployment is
-    genuinely half-switched, and that state exists whether or not anyone is told.
-    The only decision left is whether to *report* it, and reporting it is not
-    optional: a switch whose reindex never ran leaves new documents embedded by
-    the new model and every existing document by the old one, which is precisely
-    the mixed vector space #437 exists to prevent. Swallowing this would answer
-    ``200`` with "Re-indexing the transcripts of 0 user(s)".
+    then genuinely half-switched, and that state exists whether or not anyone is
+    told. The only decision left is whether to *report* it, and reporting it is
+    not optional: a switch whose reindex never ran leaves new documents embedded
+    by the new model and every existing document by the old one, which is
+    precisely the mixed vector space #437 exists to prevent. Swallowing this
+    would answer ``200`` with "Re-indexing the transcripts of 0 user(s)".
+
+    ``apply_embedding_model_switch`` re-raises it with that switch-specific
+    framing; the plain ``POST /search/reindex`` path (#627) reports the generic
+    message this module raises, because nothing was switched there.
     """
 
 
-def dispatch_reindex_for_every_owner(triggered_by: int) -> dict[str, Any]:
+def dispatch_reindex_for_every_owner(
+    triggered_by: int,
+    file_uuids_by_owner: dict[int, list[str]] | None = None,
+) -> dict[str, Any]:
     """Reindex **every** user's transcripts, not just the caller's.
 
     ``reindex_transcripts_task`` filters ``MediaFile.user_id == user_id``
@@ -100,49 +107,72 @@ def dispatch_reindex_for_every_owner(triggered_by: int) -> dict[str, Any]:
     ``kombu.exceptions.OperationalError`` and **not** an ``OSError``, so catching
     those by name would have caught nothing while looking careful.)
 
+    **A partial scope names its owners explicitly** (#627). ``POST
+    /search/reindex`` has two narrower modes — a pending-only sweep and an
+    operator-supplied list of file UUIDs — and both were scoped to the calling
+    admin by the same defect this function fixes for the whole-corpus case. They
+    pass ``file_uuids_by_owner`` so each owner's coordinator receives that
+    owner's files, resolved by ``services/search/reindex_scope.py``. There is
+    deliberately no second dispatch loop for them: one loop, one failure
+    contract, one place that decides the caller goes first.
+
+    ⚠️ **An owner with an empty list is DROPPED, not dispatched.**
+    ``reindex_transcripts_task`` treats a falsy ``file_uuids`` as "every file
+    this user owns" (``if file_uuids:``), so passing ``[]`` for an owner with
+    nothing to do would re-embed their entire account.
+
     Args:
-        triggered_by: The admin performing the switch, dispatched first so their
-            own progress stream starts immediately.
+        triggered_by: The admin performing the switch or repair, dispatched
+            first so their own progress stream starts immediately.
+        file_uuids_by_owner: Optional per-owner file scope. ``None`` (the
+            default) means the whole corpus: every owner of a COMPLETED file,
+            each re-indexed in full.
 
     Returns:
         Dict with the dispatched task ids keyed by user id, and a user count.
 
     Raises:
-        ReindexDispatchError: no reindex could be queued. The switch itself has
-            already been applied by the time this runs.
+        ReindexDispatchError: no reindex could be queued.
     """
     from app.db.session_utils import session_scope
     from app.models.media import FileStatus
     from app.models.media import MediaFile
     from app.tasks.reindex_task import reindex_transcripts_task
 
-    with session_scope() as db_session:
-        owner_ids = [
-            int(row[0])
-            for row in db_session.query(MediaFile.user_id)
-            .filter(MediaFile.status == FileStatus.COMPLETED)
-            .distinct()
-            .all()
-        ]
+    payloads: dict[int, list[str] | None]
+    if file_uuids_by_owner is None:
+        with session_scope() as db_session:
+            owner_ids = [
+                int(row[0])
+                for row in db_session.query(MediaFile.user_id)
+                .filter(MediaFile.status == FileStatus.COMPLETED)
+                .distinct()
+                .all()
+            ]
+        # The caller is dispatched first and unconditionally: the settings UI keys
+        # its progress stream on the requesting user, so an admin who owns no files
+        # still needs a run to watch. That costs one no-op coordinator.
+        payloads = {uid: None for uid in owner_ids}
+        payloads[triggered_by] = None
+    else:
+        payloads = {uid: list(uuids) for uid, uuids in file_uuids_by_owner.items() if uuids}
 
-    # The caller is dispatched first and unconditionally: the settings UI keys its
-    # progress stream on the requesting user, so an admin who owns no files still
-    # needs a run to watch. That costs one no-op coordinator.
-    ordered = [triggered_by] + [uid for uid in sorted(owner_ids) if uid != triggered_by]
+    ordered = ([triggered_by] if triggered_by in payloads else []) + [
+        uid for uid in sorted(payloads) if uid != triggered_by
+    ]
     tasks: dict[int, str] = {}
     try:
         for user_id in ordered:
-            tasks[user_id] = reindex_transcripts_task.delay(user_id=user_id, file_uuids=None).id
+            tasks[user_id] = reindex_transcripts_task.delay(
+                user_id=user_id, file_uuids=payloads[user_id]
+            ).id
     except Exception as e:
         raise ReindexDispatchError(
-            f"The embedding model was switched, but the re-embed could not be queued "
-            f"after {len(tasks)} of {len(ordered)} users ({e}). New documents will be "
-            f"embedded by the new model and existing ones still hold the old model's "
-            f"vectors — the index is a mixed vector space until a full reindex runs. "
-            f"Restore the message broker and re-run the switch."
+            f"The re-index could not be queued after {len(tasks)} of {len(ordered)} "
+            f"users ({e}). Restore the message broker and re-run it."
         ) from e
 
-    logger.info(f"Model switch dispatched reindex for {len(tasks)} users")
+    logger.info(f"Dispatched reindex for {len(tasks)} users")
     return {"reindex_task_ids": tasks, "reindex_users": len(tasks)}
 
 
@@ -207,8 +237,19 @@ def apply_embedding_model_switch(model_name: str, triggered_by: int) -> dict[str
     reset_search_provenance_advisory()
     recreate_index_for_dimension(dimension)
 
-    # 4. Everyone's documents, not just the caller's.
-    dispatch = dispatch_reindex_for_every_owner(triggered_by)
+    # 4. Everyone's documents, not just the caller's. The dispatcher's own
+    #    failure message is scope-generic, so the switch-specific consequence —
+    #    a half-applied switch leaves a MIXED vector space — is stated here,
+    #    where it is true, rather than in a helper two other callers share.
+    try:
+        dispatch = dispatch_reindex_for_every_owner(triggered_by)
+    except ReindexDispatchError as e:
+        raise ReindexDispatchError(
+            f"The embedding model was switched, but the re-embed could not be queued: "
+            f"{e} New documents will be embedded by the new model and existing ones "
+            f"still hold the old model's vectors — the index is a mixed vector space "
+            f"until a full reindex runs."
+        ) from e
 
     logger.info(f"Embedding model switched to {model_name} ({model_id}, {dimension}d)")
     return {

--- a/backend/app/services/search/reindex_scope.py
+++ b/backend/app/services/search/reindex_scope.py
@@ -1,0 +1,176 @@
+"""Which owners — and which of their files — a reindex must cover (issue #627).
+
+``POST /search/reindex`` scoped **all three** of its modes to the calling admin:
+the "Reindex all" button, the pending-only sweep, and an explicitly supplied list
+of file UUIDs. ``reindex_transcripts_task`` filters ``MediaFile.user_id ==
+user_id`` (``tasks/reindex_task.py``), so an admin repairing "the corpus" from
+Settings → Search repaired only their own account: every other user's files were
+left exactly as they were, with no error, no warning and nothing in the response
+to say the scope had been narrowed. Naming another user's file UUID explicitly
+did nothing at all, for the same reason.
+
+This module answers the **scope** question. Dispatch stays in
+``model_switch.dispatch_reindex_for_every_owner``, which #437 already built for
+the model-switch path and ``index_health`` already reuses — there is one fan-out
+loop in this codebase, not two.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from app.core.config import settings
+from app.services.ingest_artifacts.index_mapping import chunk_plane_clause
+
+logger = logging.getLogger(__name__)
+
+#: Ceiling on the ``terms`` aggregation that surveys which files are indexed.
+#: OpenSearch refuses a ``size`` above ``search.max_buckets``; 65,536 is the
+#: cluster default and also far beyond any realistic corpus.
+_MAX_AGG_BUCKETS = 65536
+
+#: Headroom over the known file count, so a file indexed between the Postgres
+#: read and the aggregation still lands in a bucket instead of being truncated
+#: away and re-queued.
+_AGG_BUCKET_HEADROOM = 100
+
+
+def owners_of_files(file_uuids: list[str]) -> dict[int, list[str]]:
+    """Group explicitly named files by the account that owns them.
+
+    An operator naming file UUIDs by hand has no way to know — and no reason to
+    care — which account each one belongs to. Attributing all of them to the
+    caller means the coordinator's ``MediaFile.user_id == user_id`` filter
+    silently drops every file the caller does not own.
+
+    Only COMPLETED files are returned, matching the coordinator's own filter: a
+    UUID that is unknown, deleted, or still processing cannot be re-indexed, and
+    reporting that as "queued" is the class of silence this module exists to end.
+
+    Args:
+        file_uuids: The UUIDs the caller asked for.
+
+    Returns:
+        Owner id → the subset of ``file_uuids`` that owner owns. Empty when none
+        of them resolve.
+    """
+    from app.db.session_utils import session_scope
+    from app.models.media import FileStatus
+    from app.models.media import MediaFile
+
+    if not file_uuids:
+        return {}
+
+    with session_scope() as db:
+        rows = (
+            db.query(MediaFile.user_id, MediaFile.uuid)
+            .filter(
+                MediaFile.uuid.in_(file_uuids),
+                MediaFile.status == FileStatus.COMPLETED,
+            )
+            .all()
+        )
+
+    grouped: dict[int, list[str]] = {}
+    for user_id, file_uuid in rows:
+        grouped.setdefault(int(user_id), []).append(str(file_uuid))
+    return grouped
+
+
+def pending_files_by_owner() -> tuple[dict[int, list[str]], int]:
+    """Every indexable file with no chunks in the index, grouped by owner.
+
+    "Indexable" is COMPLETED **and** holding at least one transcript segment —
+    a completed file with nothing to chunk would be reported as forever pending.
+
+    Returns:
+        ``(pending_by_owner, indexable_total)``. An empty mapping with a nonzero
+        total means the corpus is fully indexed; a zero total means there is
+        nothing to index at all. The two are different answers and the endpoint
+        reports them differently.
+    """
+    from sqlalchemy import exists
+    from sqlalchemy import select
+
+    from app.db.session_utils import session_scope
+    from app.models.media import FileStatus
+    from app.models.media import MediaFile
+    from app.models.media import TranscriptSegment
+
+    with session_scope() as db:
+        has_segments = exists(
+            select(TranscriptSegment.id).where(TranscriptSegment.media_file_id == MediaFile.id)
+        )
+        rows = (
+            db.query(MediaFile.user_id, MediaFile.uuid)
+            .filter(MediaFile.status == FileStatus.COMPLETED, has_segments)
+            .all()
+        )
+
+    owner_by_uuid = {str(file_uuid): int(user_id) for user_id, file_uuid in rows}
+    if not owner_by_uuid:
+        return {}, 0
+
+    indexed = indexed_file_uuids(len(owner_by_uuid))
+
+    pending: dict[int, list[str]] = {}
+    for file_uuid, user_id in owner_by_uuid.items():
+        if file_uuid not in indexed:
+            pending.setdefault(user_id, []).append(file_uuid)
+    return pending, len(owner_by_uuid)
+
+
+def indexed_file_uuids(expected_files: int) -> set[str]:
+    """File UUIDs that already hold CHUNK-plane documents, across every owner.
+
+    ``chunk_plane_clause()`` rather than a bare ``file_uuid`` term because the
+    question is "which files still need indexing?": a file left holding only a
+    digest — a rebuild that failed part-way — would otherwise read as indexed and
+    never be repaired.
+
+    ⚠️ **This fails OPEN, and now at corpus scale.** An unreachable cluster or a
+    rejected aggregation returns the empty set, so every file reads as pending
+    and the sweep queues the whole corpus rather than nothing. That is the
+    pre-existing behaviour of this survey and it is the safe direction — a
+    re-index overwrites documents in place by deterministic id, so the cost of
+    guessing wrong is time, whereas guessing "already indexed" leaves a broken
+    index broken. The blast radius is larger than it was when the survey was
+    per-caller, which is why the failure is logged with a traceback.
+
+    Args:
+        expected_files: How many files the caller is asking about; sizes the
+            aggregation so no owner's files are truncated out of the answer.
+
+    Returns:
+        The set of file UUIDs with at least one chunk document.
+    """
+    from app.services.opensearch_service import opensearch_client
+
+    if not opensearch_client:
+        return set()
+
+    try:
+        index_name = settings.OPENSEARCH_CHUNKS_INDEX
+        if not opensearch_client.indices.exists(index=index_name):
+            return set()
+
+        agg_response = opensearch_client.search(
+            index=index_name,
+            body={
+                "size": 0,
+                "query": {"bool": {"filter": [chunk_plane_clause()]}},
+                "aggs": {
+                    "indexed_files": {
+                        "terms": {
+                            "field": "file_uuid",
+                            "size": min(expected_files + _AGG_BUCKET_HEADROOM, _MAX_AGG_BUCKETS),
+                        }
+                    }
+                },
+            },
+        )
+        buckets = agg_response.get("aggregations", {}).get("indexed_files", {}).get("buckets", [])
+        return {bucket["key"] for bucket in buckets}
+    except Exception as e:
+        logger.exception(f"Error querying indexed files; treating the corpus as pending: {e}")
+        return set()

--- a/backend/app/services/similarity_service.py
+++ b/backend/app/services/similarity_service.py
@@ -17,6 +17,9 @@ import numpy as np
 import torch
 from torch.nn import functional as nn_functional
 
+from app.utils.cosine_space import opensearch_score_from_raw_cosine
+from app.utils.cosine_space import raw_cosine_from_opensearch_score
+
 logger = logging.getLogger(__name__)
 
 
@@ -115,7 +118,7 @@ class SimilarityService:
         embedding: list[float] | np.ndarray | torch.Tensor,
         user_id: int,
         index_name: str = "speakers",
-        threshold: float = 0.7,
+        min_raw_cosine: float = 0.7,
         max_results: int = 50,
         exclude_ids: list[int] | None = None,
         boost_recent: bool = True,
@@ -127,18 +130,25 @@ class SimilarityService:
         Leverages OpenSearch's native HNSW algorithm with cosine similarity for
         optimal performance at scale.
 
+        The gate is stated in **raw cosine** and converted to OpenSearch's
+        ``cosinesimil`` score space on the way out, so callers never have to know
+        the index's scoring convention (issue #674).
+
         Args:
             embedding: Query embedding vector (any format)
             user_id: User ID for filtering
             index_name: OpenSearch index to search
-            threshold: Minimum similarity threshold
+            min_raw_cosine: Minimum **raw cosine** similarity a hit must reach,
+                in ``[-1, 1]`` — the same space as ``SPEAKER_CONFIDENCE_*`` and as
+                the ``similarity`` this function returns. Never pass a value
+                already in ``cosinesimil`` score space.
             max_results: Maximum number of results (increased default)
             exclude_ids: Optional list of IDs to exclude from results
             boost_recent: Whether to boost recent embeddings in scoring
             organization_id: Active org id (None = personal) — tenant gate.
 
         Returns:
-            List of similarity matches with scores and metadata
+            List of similarity matches with raw-cosine scores and metadata
         """
         from app.services.opensearch_service import _speaker_org_filter_clauses
         from app.services.opensearch_service import opensearch_client
@@ -182,7 +192,10 @@ class SimilarityService:
                 "display_name",
                 "confidence",
             ],
-            "min_score": threshold,
+            # `min_score` is compared against the index's `cosinesimil` score,
+            # which is `(1 + cosine) / 2` — NOT raw cosine. Writing a raw-cosine
+            # value straight in here gates at roughly half the named similarity.
+            "min_score": opensearch_score_from_raw_cosine(min_raw_cosine),
         }
 
         if opensearch_client is None:
@@ -194,7 +207,7 @@ class SimilarityService:
         # Convert OpenSearch cosinesimil scores to raw cosine similarity
         results = []
         for hit in response.get("hits", {}).get("hits", []):
-            similarity = 2.0 * float(hit["_score"]) - 1.0
+            similarity = raw_cosine_from_opensearch_score(hit["_score"])
 
             result = {
                 "similarity": similarity,
@@ -203,7 +216,8 @@ class SimilarityService:
             results.append(result)
 
         logger.info(
-            f"OpenSearch kNN search returned {len(results)} results above threshold {threshold}"
+            f"OpenSearch kNN search returned {len(results)} results "
+            f"above raw cosine {min_raw_cosine}"
         )
         return results
 
@@ -250,7 +264,7 @@ class SimilarityService:
         query_embedding: np.ndarray | torch.Tensor,
         candidate_embeddings: np.ndarray | torch.Tensor | list[np.ndarray],
         k: int = 10,
-        threshold: float = 0.7,
+        min_raw_cosine: float = 0.7,
     ) -> list[tuple[int, float]]:
         """
         Find top-k most similar embeddings using GPU-accelerated operations.
@@ -259,7 +273,10 @@ class SimilarityService:
             query_embedding: Query embedding
             candidate_embeddings: Pool of candidate embeddings
             k: Number of top results to return
-            threshold: Minimum similarity threshold
+            min_raw_cosine: Minimum **raw cosine** similarity, in ``[-1, 1]``.
+                This path computes cosine directly in torch, so no
+                ``cosinesimil`` conversion applies — the name says so rather than
+                leaving the space to be inferred (issue #674).
 
         Returns:
             List of (index, similarity_score) tuples sorted by similarity (highest first)
@@ -293,7 +310,7 @@ class SimilarityService:
         )
 
         # Filter by threshold and get top-k
-        valid_indices = torch.where(similarities >= threshold)[0]
+        valid_indices = torch.where(similarities >= min_raw_cosine)[0]
         if len(valid_indices) == 0:
             return []
 

--- a/backend/app/services/speaker_matching_service.py
+++ b/backend/app/services/speaker_matching_service.py
@@ -1154,7 +1154,10 @@ class SpeakerMatchingService:
                 embedding=embedding,
                 user_id=user_id,
                 index_name="speakers",
-                threshold=0.75,  # High confidence for automatic assignment (matches SPEAKER_CONFIDENCE_HIGH)
+                # Auto-assignment writes `verified=True`, so the gate is the
+                # auto-accept band and nothing weaker. Stated in raw cosine; the
+                # search converts it to OpenSearch score space (issue #674).
+                min_raw_cosine=SPEAKER_CONFIDENCE_HIGH,
                 max_results=20,
                 exclude_ids=[matched_speaker_id],
                 organization_id=profile_org_id,

--- a/backend/app/services/speaker_profile_rename.py
+++ b/backend/app/services/speaker_profile_rename.py
@@ -1,0 +1,106 @@
+"""Apply a speaker-profile rename to the profile's member speakers (issue #675).
+
+A ``SpeakerProfile`` is the corpus-wide identity; a ``Speaker`` is one file's
+diarized voice linked to it. **The profile's name is not indexed anywhere.**
+``transcript_chunks`` carries ``canonical_speaker_label_for_row(speaker)``
+(``app/utils/speaker_labels.py``) — resolved from ``Speaker.display_name`` /
+``suggested_name`` / ``name`` — and neither chunk-index writer
+(``tasks/search_indexing_task.resolve_chunk_speaker_name``,
+``tasks/reindex_task._resolve_reindex_speaker_name``) consults a profile at all.
+
+A profile rename therefore reaches the index only through the invariant every
+other linking path already upholds: **a speaker linked to a profile carries the
+profile's name as its display name.** ``SpeakerClusteringService`` writes
+``speaker.display_name = profile.name`` on cluster promotion and on a batch
+``assign``; ``speakers.py``'s ``update_profile`` action rewrites every member on
+rename. So re-applying the name and dispatching the chunk-plane propagation are
+one unit: dispatching without the rewrite would push a name into the index that
+Postgres does not hold, and the next reindex would revert it.
+
+This module is that unit's single implementation. It exists because there are
+**two** endpoints that rename a profile — ``PUT /speakers/{uuid}`` with
+``profile_action="update_profile"`` and ``PUT /speaker-profiles/profiles/{uuid}``
+— and only the first had it (issue #675). A second copy is how the two would
+drift; note that the first one had already drifted once, in issue #605, over
+which resolver computes the old name.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy.orm import Session
+
+from app.models.media import MediaFile
+from app.models.media import Speaker
+from app.utils.speaker_labels import canonical_speaker_label_for_row
+
+logger = logging.getLogger(__name__)
+
+
+def apply_profile_name_to_speakers(
+    db: Session,
+    profile_id: int,
+    new_name: str,
+    *,
+    restrict_to_user_id: int | None = None,
+) -> list[tuple[str, str]]:
+    """Rewrite every member speaker's display name, reporting the names it replaced.
+
+    **Collects before it overwrites.** The returned old names are what the chunk
+    documents were indexed with, and this is the last moment they exist anywhere:
+    once the caller commits, Postgres cannot say what they were (issue #405).
+    They are resolved with ``canonical_speaker_label_for_row`` — the SAME resolver
+    the chunk-index writers use — because a member with no ``display_name`` but a
+    confident ``suggested_name`` is indexed under the *suggestion*, and a member
+    with neither is indexed under the raw diarizer label. Keying on the profile's
+    own previous name would match nothing for either (issue #605).
+
+    Writes only; the caller owns the commit **and** the dispatch, because a
+    rolled-back rename must never reach the index.
+
+    Args:
+        db: Open session. The profile itself is not read here — the caller has
+            already resolved and authorized it.
+        profile_id: The renamed profile.
+        new_name: Its new name, which becomes every member's display name.
+        restrict_to_user_id: When set, only that user's speakers are rewritten.
+            A profile can be shared, so its members may belong to other accounts;
+            ``None`` (admin) sweeps all of them. This mirrors the authorization
+            the ``update_profile`` action has applied since #284.
+
+    Returns:
+        ``(file_uuid, old_canonical_label)`` pairs ready for
+        ``dispatch_speaker_rename``, which coalesces them per file. Empty when the
+        profile has no members — distinct from "no such profile", which the caller
+        decides.
+    """
+    linked_query = db.query(Speaker).filter(Speaker.profile_id == profile_id)
+    if restrict_to_user_id is not None:
+        linked_query = linked_query.filter(Speaker.user_id == restrict_to_user_id)
+    linked_speakers = linked_query.all()
+
+    # One grouped lookup, not a lazy `speaker.media_file.uuid` per row: a
+    # well-used profile spans dozens of files.
+    file_uuids: dict[int, str] = {}
+    media_file_ids = {int(s.media_file_id) for s in linked_speakers if s.media_file_id}
+    if media_file_ids:
+        file_uuids = {
+            int(row[0]): str(row[1])
+            for row in db.query(MediaFile.id, MediaFile.uuid).filter(
+                MediaFile.id.in_(media_file_ids)
+            )
+        }
+
+    renames: list[tuple[str, str]] = []
+    for speaker in linked_speakers:
+        old_chunk_name = canonical_speaker_label_for_row(speaker)
+        file_uuid = file_uuids.get(int(speaker.media_file_id or 0))
+        if file_uuid and old_chunk_name:
+            renames.append((file_uuid, old_chunk_name))
+        speaker.display_name = new_name  # type: ignore[assignment]
+
+    logger.info(
+        f"Applied profile {profile_id} name '{new_name}' to {len(linked_speakers)} speaker(s)"
+    )
+    return renames

--- a/backend/app/tasks/CLAUDE.md
+++ b/backend/app/tasks/CLAUDE.md
@@ -51,6 +51,20 @@ indexing → WebSocket notification.
   - Scope differs on purpose: **title covers the whole file plane** (a digest inherits `title`
     and renders it as a citation), **speaker covers the chunk plane only** (a digest has no
     `speaker` field and its prose bakes the name — regeneration, not rewriting, is the fix).
+  - ⚠️ **A PROFILE rename reaches the chunk plane only through its member speakers**
+    (issue #675). `SpeakerProfile.name` is indexed nowhere — the chunk writers resolve
+    `canonical_speaker_label_for_row(speaker)` and never look at a profile — so re-applying
+    the name to every member and dispatching are **one unit**:
+    `services/speaker_profile_rename.apply_profile_name_to_speakers` is that unit's single
+    implementation, shared by the **two** endpoints that rename a profile
+    (`PUT /speakers/{uuid}` with `profile_action="update_profile"`, and
+    `PUT /speaker-profiles/profiles/{uuid}` — the Speakers page's editor, which did neither
+    half until #675). Dispatch without the rewrite writes a name Postgres does not hold and
+    the next reindex reverts it; the rewrite without the dispatch is the #675 bug itself, and
+    there is no repair path — `search_index_maintenance` only finds files with **no** chunks,
+    so it cannot fix chunks holding a merely-wrong value. Dispatch carries **no**
+    `speaker_id`: a profile-wide rename sweeps many speakers and has no single id to re-read.
+    Covered by `tests/api/test_rename_propagation_dispatch.py::TestSpeakerProfileUpdateEndpoint`.
 - `ingest_artifacts_task.py` — `artifacts.generate_file_facts` (**nlp** queue, #383 Phase 2).
   Builds the deterministic ingest artifacts (statistics, extractive digest with per-sentence
   provenance, keyphrases) and upserts `file_facts`. It rides the nlp pool because that is the

--- a/backend/app/tasks/cleanup.py
+++ b/backend/app/tasks/cleanup.py
@@ -448,6 +448,17 @@ def _select_expired_files(
     Plain tuples, never ``MediaFile`` instances: the deletion phase runs with no
     session open, and an escaping instance would lazy-load (reopening a
     transaction) the moment ``purge_media_file`` touched it.
+
+    **A file under legal hold or in quarantine is never a candidate** (issue
+    #664). ``status`` alone is not a durable guard for either: a quarantined
+    file keeps its processing status on purpose (so a release restores it
+    verbatim), and ``tasks/transcription/storage`` writes ``COMPLETED`` plus a
+    fresh ``completed_at`` unconditionally when transcription finishes — so a
+    file quarantined *while it was still transcribing* would land in this
+    candidate set with its retention clock started at that write. Both flags are
+    ``NOT NULL DEFAULT false``, so ``is_(False)`` is exact rather than
+    three-valued. ``purge_media_file`` refuses a held file as well; this
+    predicate is the efficient filter, that one is the fail-closed backstop.
     """
     from app.models.media import FileStatus
     from app.models.media import MediaFile
@@ -466,6 +477,8 @@ def _select_expired_files(
         )
         .filter(
             MediaFile.status.in_(eligible_statuses),
+            MediaFile.legal_hold.is_(False),
+            MediaFile.is_quarantined.is_(False),
             ((MediaFile.completed_at.isnot(None)) & (MediaFile.completed_at < query_cutoff))
             | ((MediaFile.completed_at.is_(None)) & (MediaFile.upload_time < query_cutoff)),
         )

--- a/backend/app/transcription/CLAUDE.md
+++ b/backend/app/transcription/CLAUDE.md
@@ -1,62 +1,111 @@
 # app/transcription — ASR + diarization engine
 
-> ⚠️ **STALE — do not trust the diarization sections below.** This file predates the native
-> Rust/ONNX `diar-native` sidecar becoming the coded default (`ffd49433` / `a15e94c2`). It has
-> **zero** mentions of it, still calls PyAnnote "the engine", claims "PyAnnote MPS via our fork is
-> solid" for macOS (MPS is unreachable inside Docker on every platform), and its diarization VRAM
-> figures are wrong by ~4× — the sidecar's warm floor is 4 136 MiB, not ~1 GB, and it does not
-> shrink. The Whisper/transcription sections are unaffected. Rewrite tracked in **#671**; current
-> architecture and the removal roadmap in
-> [this gist](https://gist.github.com/attevon-admin/a99819c7ec5e8ab8df0eb8e3e8e668e8) and **#572**.
-
 ## Purpose
 
-WhisperX transcription and PyAnnote speaker diarization, plus the hardware-adaptive config
-that decides where each stage runs. Called from `app/tasks/transcription/`.
+Whisper transcription and speaker diarization, plus the hardware-adaptive config that decides
+where each stage runs. Called from `app/tasks/transcription/`.
+
+Diarization has **two engines**: the out-of-process `diar-native` sidecar (Rust/ONNX, the coded
+default) and the in-process PyAnnote fork (the failover, and the only other registered backend).
+Read the diarization section below before assuming which one served a given job — several shipped
+topologies silently run the fallback.
 
 ## Whisper model selection
 
-Default: `large-v3-turbo` (6× faster, ~6 GB VRAM). Override via `WHISPER_MODEL`.
+Default: `large-v3-turbo`. Resolution order is pinned value → `SystemSettings` `asr.local_model`
+→ `WHISPER_MODEL` → the coded default (`TranscriptionConfig._resolve_model_name`).
 
 | Model | Best for | VRAM | Translation |
 |---|---|---|---|
-| `large-v3-turbo` | English, most major languages, speed-critical | ~6 GB | **NO** — not trained for it |
-| `large-v3` | Non-English (Thai/Cantonese/Vietnamese), translation, max accuracy | ~10 GB | Yes |
+| `large-v3-turbo` | English-optimized, speed-critical | ~6 GB | **NO** |
+| `large-v3` | Non-English, translation, max accuracy | ~10 GB | Yes |
 | `large-v2` | Legacy fallback | ~10 GB | Yes |
+| `medium` / `small` | Low-VRAM, hybrid CPU leg | ~5 GB / ~2 GB | Yes |
 
-**Gotcha:** if a user enables "Translate to English" they must be on `large-v3` or `large-v2`.
-Turbo will silently not translate.
+Those figures and the `supports_translation` flags come from `ASR_PROVIDER_CATALOG` in
+`services/asr/factory.py` — the same catalog the settings UI reads. Keep them in sync there,
+not here.
 
-## Hybrid mode (CPU transcription + GPU/MPS diarization)
+**Translation gotcha:** requesting "Translate to English" on a model that cannot translate does
+**not** silently transcribe. `transcriber._resolve_task_and_language` consults
+`ASRProviderFactory.get_model_capabilities`, logs `does not support translation — falling back
+to transcribe`, and downgrades the task. Same safety net forces `language="en"` for
+`english_only` models. The user still gets an untranslated transcript, so the UI guard matters —
+the log line is the only signal at this layer.
 
-Auto-activates for low-VRAM CUDA GPUs and always on macOS (faster-whisper MPS is unreliable;
-PyAnnote MPS via our fork is solid). Diarization needs only ~1.3 GB VRAM.
+## Diarization — native first, PyAnnote as failover
 
-CUDA trigger: minimum batch=2 model peak > 80% of total VRAM (turbo/v3: < ~4.9 GB GPU,
-medium: < ~4.8 GB, small: < ~3.7 GB).
+**One decision point:** `TranscriptionConfig.diarizer_backend`, resolved `SystemSettings`
+`engine.diarizer_backend` → env `ENGINE_DIARIZER_BACKEND` → default `"native"`
+(`config._resolve_diarizer_backend`), validated against `VALID_DIARIZER_BACKENDS` in
+`engine/backends/__init__.py` (`{"native", "pyannote"}`, derived from `_DIARIZER_REGISTRY`).
+Unknown values fail safe to `native` with a warning. It is re-read on **every** call — not
+pinned like the model name — so an admin toggle and a recovered sidecar both take effect without
+a worker restart. The old ad-hoc `DIARIZER_ENGINE` env reads are gone (#58); setting it does
+nothing.
 
-```bash
-WHISPER_HYBRID_MODE=auto       # auto (default) | true | false
-WHISPER_HYBRID_CPU_MODEL=small # small | medium | base
-```
+- `ModelManager._build_diarizer` constructs `NativeSpeakerDiarizer` (`diarizer_native.py`) for
+  `native` and falls back to the in-process `SpeakerDiarizer` on **any** exception, logging
+  `Native diarizer unavailable (...); falling back to PyAnnote`.
+- `ModelManager._diarizer_current` re-probes `diarizer_native.sidecar_healthy()` per task and
+  rebuilds in **both** directions — losing the sidecar mid-queue drops to PyAnnote, and a
+  recovered sidecar is picked back up.
+- The native client is a duck-typed drop-in: same `diarize()` / `embed_window()` /
+  `unload_model()` surface, and `embed_window` never raises into the caller.
 
-Key code: `app/utils/hardware_detection.py` (`should_use_hybrid_mode`), `config.py`,
-`diarizer.py`. Benchmarks: `docs/whisper-vram-profile/README.md`.
+**The sidecar** (`docker-compose.diar-native.yml`, service `diar-native`): the *shared* backend
+image with its CMD replaced by `diar-server`, listening on `:8701`, reading ONNX/PLDA artifacts
+exported from `pyannote/speaker-diarization-community-1` out of `DIAR_NATIVE_MODELS_DIR`. It
+holds **~4.1 GB of warm ORT arena** on `DIAR_NATIVE_GPU` (defaulting to `GPU_DEVICE_ID`, never a
+bare 0) for as long as the container is up — that is a separate process's footprint, not the
+worker's. `opentr.sh` auto-loads the overlay when the backend resolves to `native` and the export
+directory exists; `--no-diar-native` suppresses it.
 
-## Diarization (PyAnnote — optimized fork)
+> ⚠️ **"Configured native" is not "running native."** The fallback is silent by design, so a
+> deployment can spend its whole life on PyAnnote while every setting says `native`. Verify by
+> checking **which container served the diarization**, not by looking for an error. Known live
+> gaps: **#654** (nothing in this repo produces `${MODEL_CACHE_DIR}/diar-native`), **#655** (the
+> overlay patches only `celery-worker` — gpu-scale, gpu-split, lite, offline, Windows, `--fresh`
+> and CPU-only never get `DIAR_NATIVE_URL`), **#665** (`_overlap_diarization_enabled` keys off
+> the *configured* backend, so the PyAnnote fallback runs co-resident with Whisper and
+> `release_transcriber()` never fires), **#672** (the admin panel misreports the engine).
 
-Fork: `davidamacey/pyannote-audio@gpu-optimizations` (pip-installable). Embedding batch is
-**fixed at 16** in `SpeakerDiarizer.EMBEDDING_BATCH_SIZE`, which forces the fork's auto-scaler
-off via `PYANNOTE_FORCE_EMBEDDING_BATCH_SIZE=16`.
+### PyAnnote fallback specifics
 
-- Diarization peak ≈ 1 GB VRAM over process baseline → an A6000 hosts ~25 concurrent pipelines.
-- DER vs reference is invariant across batch ∈ {1..128} fp32; fixing the batch trades 3%
-  wall-time for predictable VRAM.
-- `MIN_SPEAKERS=1`, `MAX_SPEAKERS=20` defaults; raise `MAX_SPEAKERS` to 30–50+ for conferences
-  (no hard cap — sklearn `AgglomerativeClustering`).
+Fork `davidamacey/pyannote-audio@gpu-optimizations`, pinned to a **commit SHA** in
+`requirements.txt` (a branch name is not a pin — see `backend/CLAUDE.md`). Embedding batch is
+pinned at 16 by `SpeakerDiarizer.EMBEDDING_BATCH_SIZE`; `_configure_embedding_batch_size` *sets*
+`PYANNOTE_FORCE_EMBEDDING_BATCH_SIZE` in the process env to bypass the fork's auto-scaler.
+`DIARIZATION_EMBEDDING_BATCH_SIZE` overrides it for research only.
 
-Diagnostics: `python -m app.scripts.diarization_diag`. Raw data:
-`docs/diarization-vram-profile/README.md`. Upstream PR: pyannote-audio#1992.
+- Measured (A6000, 2026-04-20, `docs/diarization-vram-profile/README.md`): ~950 MB process
+  footprint at bs=16 fp32 plus ~500 MB CUDA context ≈ **1.5 GB** per pipeline; an A6000 hosts
+  ~20+ concurrent. Above bs=16 the auto-scaler spends 3–7 GB for ~3% throughput.
+- DER is invariant across fp32 batch ∈ {1..128}. **fp16 is not safe to ship**: it systematically
+  merges speakers and drops 30–44% of segments at every batch size.
+- `MIN_SPEAKERS=1` / `MAX_SPEAKERS=20` env defaults; raise `MAX_SPEAKERS` for conferences. On the
+  **native** path these largely do not bind — the sidecar runs community-1 auto speaker counting,
+  and an explicit `num_speakers` is logged as a warning and ignored.
+
+Diagnostics: `python -m app.scripts.diarization_diag`. Upstream PR: pyannote-audio#1992.
+
+## Hybrid mode (CPU transcription + GPU diarization)
+
+`hardware_detection.should_use_hybrid_mode`, overridable with `WHISPER_HYBRID_MODE=true|false|auto`.
+On CUDA it activates when the model's bs=2 peak (`_min_peak_mb`: 3893 MB for large variants,
+3829 medium, 2933 small) exceeds 80% of total VRAM — i.e. below ~4.9 GB / ~4.8 GB / ~3.7 GB of
+card. Transcription then moves to CPU (`WHISPER_HYBRID_CPU_MODEL`, default `small`, int8, bs=4)
+while diarization stays on `hw.device`.
+
+⚠️ **The MPS branch is unreachable in every shipped deployment.** `HardwareConfig._detect_optimal_device`
+gates MPS on `platform.system().lower() == "darwin"`, and every documented install path runs the
+backend in a **Linux** container, where that is `"linux"`. So on Apple Silicon the detector
+returns `cpu`, hybrid mode does not activate, and `_maybe_warn_cpu_mode_misconfigured` fires
+instead. Treat the MPS code paths here and in `README.md` as aspirational (issue #48), not as
+behaviour you can rely on.
+
+Key code: `app/utils/hardware_detection.py`, `config.py`. Benchmarks:
+`docs/whisper-vram-profile/README.md`.
 
 ## Boundary correction (issue #193)
 
@@ -65,22 +114,24 @@ DB-backed and live in the admin UI → Settings → Engine Configuration** (no r
 (`ENGINE_BOUNDARY_*`) is fallback-only — there are no required `.env` vars.
 
 - **Boundary smoothing** (default ON, pure-CPU): collapses 1–3 word "wrong-speaker islands"
-  flanked by the same speaker with no real pause. Runs at the `finalize_segments()` chokepoint.
-  −32% WSER on the reporter's clip, AMI-regression-safe. Code: `boundary_resolver.py`
-  (`smooth_word_speakers`, `BoundarySmoothingConfig`), `app/utils/segment_postprocess.py`,
-  called from `app/tasks/transcription/core.py`. Key: `boundary_smoothing_enabled`.
+  flanked by the same speaker with no real pause. Runs at the `finalize_segments()` chokepoint in
+  `app/utils/segment_postprocess.py`, called from **`app/tasks/transcription/finalize.py`** (not
+  `core.py`). −32% WSER on the reporter's clip, AMI-regression-safe. Code: `boundary_resolver.py`
+  (`smooth_word_speakers`, `BoundarySmoothingConfig.from_db_env`). Key: `boundary_smoothing_enabled`.
 - **Acoustic backchannel re-check** (default OFF, experimental, GPU): re-embeds short
   disputed/overlap words and reassigns by voiceprint cosine — relabels existing words only,
-  never invents speech. +~15% WSER on top of the smoother, ~1.9 s / 10-min file. Code:
-  `acoustic_recheck` (`boundary_resolver.py`), `diarizer.embed_window`, wired in
-  `engine/stages.py`; carried on `EngineConfig` to keep the engine DB-free. Keys:
-  `boundary_acoustic_recheck_enabled`, `boundary_acoustic_cosine_margin` (0.05),
-  `boundary_acoustic_max_word_dur` (1.0).
+  never invents speech. Code: `acoustic_recheck` (`boundary_resolver.py`) driven through
+  `manager.get_diarizer(tc).embed_window`, wired in `engine/stages.py`; carried on `EngineConfig`
+  to keep the engine DB-free. Keys: `boundary_acoustic_recheck_enabled`,
+  `boundary_acoustic_cosine_margin` (0.05), `boundary_acoustic_max_word_dur` (1.0). Because it
+  goes through `get_diarizer`, it inherits whichever engine is live — the sidecar's
+  `/embed_window` on the native path, which has its own window-length trap documented in
+  `app/services/CLAUDE.md`.
 - Settings API: `app/api/endpoints/engine_settings.py`; UI:
   `frontend/src/components/settings/EngineSettings.svelte`. Metrics (WSER/island/DER):
-  `app/utils/diarization_metrics.py`. Benchmark: `scripts/benchmark_boundary.py`. GPU-free
-  regression: `backend/tests/integration/test_boundary_regression.py` (fixtures:
-  `backend/tests/fixtures/boundary/`).
+  `app/utils/diarization_metrics.py`. Benchmark: `backend/scripts/benchmark_boundary.py` (under
+  `backend/`, not the repo-root `scripts/`). GPU-free regression:
+  `backend/tests/integration/test_boundary_regression.py` (fixtures: `backend/tests/fixtures/boundary/`).
 
 Docs: `docs-site/docs/features/boundary-correction.md`,
 `docs-site/docs/developer-guide/diarization-boundary-correction.md`.
@@ -89,5 +140,13 @@ Docs: `docs-site/docs/features/boundary-correction.md`,
 
 - `EngineConfig` is deliberately **DB-free** — settings are resolved and passed in, not read
   from the DB inside the engine. Keep it that way so the engine stays unit-testable.
+- **Overlapped diarization requires the sidecar.** `engine/stages._overlap_diarization_enabled`
+  runs diarization concurrently with transcription only for `diarizer_backend == "native"`
+  (`DIAR_OVERLAP=0` disables). When it is on, `_collect_diarization` skips
+  `_make_room_for_local_diarizer` — which is where `release_transcriber()` lives. See #665.
 - Changing `EMBEDDING_BATCH_SIZE` changes VRAM predictability, not accuracy. Don't "optimize"
   it back to auto-scaling without re-running the VRAM profile.
+- `DiarizationProviderFactory` (`app/services/diarization/`) is a **different axis** from
+  `diarizer_backend`: it selects *where diarization happens* per user (ASR provider / local /
+  pyannote.ai cloud / off). This file's `native` vs `pyannote` choice only applies once the
+  answer is "locally, on our GPU". Read that package's CLAUDE.md before conflating them.

--- a/backend/app/utils/cosine_space.py
+++ b/backend/app/utils/cosine_space.py
@@ -1,0 +1,46 @@
+"""Conversions between raw cosine similarity and OpenSearch ``cosinesimil`` scores.
+
+Every kNN field in this app is mapped ``"space_type": "cosinesimil"``, and Lucene's
+``cosinesimil`` does **not** report raw cosine — it reports ``(1 + cosine) / 2`` so
+that every score is non-negative. Both directions of that conversion are
+load-bearing, and both have been got wrong here:
+
+* **Reading** a hit's ``_score`` as a cosine overstates every similarity. The
+  repo-wide invariant covers this direction; all read sites convert.
+* **Writing** a raw-cosine threshold into a query — ``min_score``, or any other
+  filter expressed in score space — *understates* the gate by the same amount.
+  ``min_score=0.75`` admits everything at raw cosine ``>= 0.50`` (issue #674), and
+  a read-site audit cannot see it, because nothing is being read.
+
+Call these instead of open-coding the arithmetic, so the space a number lives in is
+stated by the name at the call site rather than inferred from its surroundings.
+"""
+
+
+def raw_cosine_from_opensearch_score(opensearch_score: float) -> float:
+    """Convert an OpenSearch ``cosinesimil`` score to raw cosine similarity.
+
+    Args:
+        opensearch_score: A hit's ``_score`` from a ``cosinesimil`` kNN query,
+            in ``[0, 1]``.
+
+    Returns:
+        The raw cosine similarity, in ``[-1, 1]``.
+    """
+    return 2.0 * float(opensearch_score) - 1.0
+
+
+def opensearch_score_from_raw_cosine(raw_cosine: float) -> float:
+    """Convert a raw cosine similarity to the OpenSearch ``cosinesimil`` score space.
+
+    Use this for any threshold sent *into* OpenSearch (``min_score`` and friends).
+    A raw-cosine value passed through unconverted gates at roughly half the
+    similarity it names.
+
+    Args:
+        raw_cosine: A cosine similarity, in ``[-1, 1]``.
+
+    Returns:
+        The equivalent ``cosinesimil`` score, in ``[0, 1]``.
+    """
+    return (1.0 + float(raw_cosine)) / 2.0

--- a/backend/tests/api/endpoints/test_search_admin_routes.py
+++ b/backend/tests/api/endpoints/test_search_admin_routes.py
@@ -199,20 +199,60 @@ def deployed_model():
         yield recorder
 
 
-@pytest.fixture
-def other_users_files(db_session):
-    """A second account owning a COMPLETED file — the user a scoped reindex skips.
+def _indexable_media_file(db_session, owner_id: int, label: str):
+    """One COMPLETED file with a transcript segment — i.e. one the sweep can index.
 
-    ``_dispatch_reindex_for_every_owner`` opens its **own** ``session_scope``,
-    which under the savepoint harness cannot see uncommitted fixture rows, so the
-    scope is pointed at ``db_session``. That is what makes the row observable at
-    all; it stands in for no behaviour under test.
+    The segment is not decoration: the pending-only survey filters on
+    ``EXISTS (transcript_segment)``, because a completed file with nothing to
+    chunk would otherwise report as forever pending.
+    """
+    import uuid as _uuid
+
+    from app.models.media import FileStatus
+    from app.models.media import MediaFile
+    from app.models.media import TranscriptSegment
+
+    suffix = str(_uuid.uuid4())[:8]
+    media = MediaFile(
+        uuid=str(_uuid.uuid4()),
+        user_id=owner_id,
+        filename=f"{label}_{suffix}.wav",
+        storage_path=f"{label}/{suffix}.wav",
+        file_size=1024,
+        content_type="audio/wav",
+        status=FileStatus.COMPLETED,
+    )
+    db_session.add(media)
+    db_session.flush()
+
+    db_session.add(
+        TranscriptSegment(
+            media_file_id=media.id,
+            start_time=0.0,
+            end_time=1.5,
+            text=f"segment for {label}",
+        )
+    )
+    db_session.flush()
+    return media
+
+
+@pytest.fixture
+def two_owner_corpus(db_session, admin_user):
+    """Two accounts, each owning an indexable COMPLETED file.
+
+    The second account is the user a caller-scoped reindex skips — the whole of
+    issues #437 and #627. Both files carry a transcript segment so they are
+    visible to the pending-only survey as well as to the whole-corpus fan-out.
+
+    ``dispatch_reindex_for_every_owner`` and ``reindex_scope`` open their **own**
+    ``session_scope``, which under the savepoint harness cannot see uncommitted
+    fixture rows, so the scope is pointed at ``db_session``. That is what makes
+    the rows observable at all; it stands in for no behaviour under test.
     """
     import uuid as _uuid
 
     from app.core.security import get_password_hash
-    from app.models.media import FileStatus
-    from app.models.media import MediaFile
     from app.models.user import User
 
     suffix = str(_uuid.uuid4())[:8]
@@ -226,24 +266,59 @@ def other_users_files(db_session):
     db_session.add(owner)
     db_session.flush()
 
-    media = MediaFile(
-        uuid=str(_uuid.uuid4()),
-        user_id=owner.id,
-        filename=f"other_{suffix}.wav",
-        storage_path=f"other/{suffix}.wav",
-        file_size=1024,
-        content_type="audio/wav",
-        status=FileStatus.COMPLETED,
-    )
-    db_session.add(media)
-    db_session.flush()
+    other_media = _indexable_media_file(db_session, owner.id, "other")
+    admin_media = _indexable_media_file(db_session, admin_user.id, "admin")
 
     @contextmanager
     def _savepoint_scope():
         yield db_session
 
     with patch("app.db.session_utils.session_scope", _savepoint_scope):
-        yield SimpleNamespace(owner_id=owner.id, file_uuid=media.uuid)
+        yield SimpleNamespace(
+            owner_id=owner.id,
+            file_uuid=other_media.uuid,
+            admin_file_uuid=admin_media.uuid,
+        )
+
+
+def _completed_file_uuids(db_session) -> set[str]:
+    """Every COMPLETED file UUID the survey could possibly consider.
+
+    A superset of the indexable set (it does not require a segment), which is
+    exactly what a test wanting "the whole corpus already has chunks" needs.
+    """
+    from app.models.media import FileStatus
+    from app.models.media import MediaFile
+
+    return {
+        str(row[0])
+        for row in db_session.query(MediaFile.uuid)
+        .filter(MediaFile.status == FileStatus.COMPLETED)
+        .all()
+    }
+
+
+class _StandInIndexedFiles:
+    """OpenSearch stand-in reporting a fixed set of files as already chunked.
+
+    The pending-only survey asks the cluster which files hold chunk-plane
+    documents. Against the real cluster that answer depends on whatever the dev
+    stack happens to hold, so the two tests that need a determinate pending set
+    state it instead.
+    """
+
+    def __init__(self, indexed: set[str]) -> None:
+        self.indexed = indexed
+        self.bodies: list[dict] = []
+        self.indices = SimpleNamespace(exists=lambda **_kwargs: True)
+
+    def search(self, *, index: str, body: dict) -> dict:
+        self.bodies.append(body)
+        return {
+            "aggregations": {
+                "indexed_files": {"buckets": [{"key": u} for u in sorted(self.indexed)]}
+            }
+        }
 
 
 @pytest.fixture
@@ -384,7 +459,7 @@ def test_switching_the_model_repoints_the_ingest_pipeline_not_only_the_setting(
 
 
 def test_switching_the_model_reindexes_every_owner_not_only_the_caller(
-    client, admin_token_headers, admin_user, reindex_task, deployed_model, other_users_files
+    client, admin_token_headers, admin_user, reindex_task, deployed_model, two_owner_corpus
 ):
     """A per-caller reindex leaves every other user in the OLD vector space (#437).
 
@@ -403,7 +478,7 @@ def test_switching_the_model_reindexes_every_owner_not_only_the_caller(
 
     assert response.status_code == status.HTTP_200_OK
     dispatched_for = {d["user_id"] for d in reindex_task.dispatches}
-    assert other_users_files.owner_id in dispatched_for
+    assert two_owner_corpus.owner_id in dispatched_for
     assert admin_user.id in dispatched_for
     assert all(d["file_uuids"] is None for d in reindex_task.dispatches)
     assert response.json()["reindex_users"] == len(dispatched_for)
@@ -512,39 +587,134 @@ def test_setting_a_model_requires_authentication(client, reindex_task):
 # ---------------------------------------------------------------------------
 # POST /reindex — dispatch contract and the pending-only guard
 # ---------------------------------------------------------------------------
-def test_reindex_dispatches_the_named_files_for_the_calling_admin(
-    client, admin_token_headers, admin_user, reindex_task
+def test_reindex_all_fans_out_to_every_owner_not_only_the_caller(
+    client, admin_token_headers, admin_user, reindex_task, two_owner_corpus
 ):
-    """``user_id`` comes from the credential and ``file_uuids`` straight from the body.
+    """The #627 fix: "Reindex all" must reach every account, not the admin's own.
 
-    Attributing a reindex to the wrong account is the #431 shape: progress goes to
-    someone else and the requester waits forever. The task itself is a stand-in —
-    a real dispatch re-embeds transcripts on the dev stack.
+    ``reindex_transcripts_task`` filters ``MediaFile.user_id == user_id``, so the
+    single ``delay(user_id=current_user.id)`` this endpoint used to issue repaired
+    the calling admin's files and left every other user's exactly as they were —
+    no error, no warning, and a success toast. That is not a race: it is what the
+    documented "Reindex all" button did on every multi-user deployment.
     """
-    response = client.post(
-        REINDEX, headers=admin_token_headers, json=["11111111-1111-4111-8111-111111111111"]
-    )
+    response = client.post(REINDEX, headers=admin_token_headers, json=None)
 
     assert response.status_code == status.HTTP_200_OK
     body = response.json()
     assert body["status"] == "started"
+
+    dispatched_for = {d["user_id"] for d in reindex_task.dispatches}
+    assert two_owner_corpus.owner_id in dispatched_for
+    assert admin_user.id in dispatched_for
+    # A whole-corpus run names no files: each owner's coordinator takes their all.
+    assert all(d["file_uuids"] is None for d in reindex_task.dispatches)
+    assert body["reindex_users"] == len(dispatched_for)
+    # The panel's progress stream and POST /reindex/stop are keyed to the caller.
     assert body["task_id"] == reindex_task.task_id
+    assert str(admin_user.id) in body["reindex_task_ids"]
+
+
+def test_pending_only_reindex_surveys_every_owner_not_only_the_caller(
+    client, admin_token_headers, db_session, reindex_task, two_owner_corpus
+):
+    """The pending sweep was caller-scoped in both halves, and both are fixed.
+
+    The Postgres query filtered ``user_id == current_user.id`` and the OpenSearch
+    aggregation carried a ``{"term": {"user_id": ...}}`` beside the chunk-plane
+    clause, so an admin repairing "files without chunks" could not even see
+    another account's unindexed files. Here the whole corpus is declared indexed
+    EXCEPT one file owned by somebody else: the only correct dispatch names that
+    owner and that file.
+    """
+    already_indexed = _completed_file_uuids(db_session) - {two_owner_corpus.file_uuid}
+    opensearch = _StandInIndexedFiles(already_indexed)
+
+    with patch("app.services.opensearch_service.opensearch_client", opensearch):
+        response = client.post(
+            REINDEX, headers=admin_token_headers, params={"pending_only": True}, json=None
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["status"] == "started"
     assert reindex_task.dispatches == [
-        {"user_id": admin_user.id, "file_uuids": ["11111111-1111-4111-8111-111111111111"]}
+        {"user_id": two_owner_corpus.owner_id, "file_uuids": [two_owner_corpus.file_uuid]}
     ]
 
 
-def test_pending_only_reindex_with_nothing_to_index_dispatches_nothing(
-    client, admin_token_headers, reindex_task
+def test_pending_only_reindex_dispatches_nothing_when_the_corpus_is_fully_indexed(
+    client, admin_token_headers, db_session, reindex_task, two_owner_corpus
 ):
-    """The guard: no indexable files means ``no_pending`` and no task at all.
+    """The guard: nothing pending anywhere means ``no_pending`` and no task at all.
 
-    A freshly created admin owns no completed files, so this exercises the
-    early-return branch rather than the sweep. Catches the guard being dropped,
-    which would queue an empty full reindex on every panel visit.
+    Dropping it would queue an empty full reindex on every panel visit — and now
+    one per owner rather than one for the caller. The message is asserted exactly
+    because the sibling ``no_pending`` answer ("No completed files found to
+    index.") means something different, and a corpus-wide sweep that reported the
+    empty-deployment message would be hiding a survey that saw nothing.
+    """
+    opensearch = _StandInIndexedFiles(_completed_file_uuids(db_session))
+
+    with patch("app.services.opensearch_service.opensearch_client", opensearch):
+        response = client.post(
+            REINDEX, headers=admin_token_headers, params={"pending_only": True}, json=None
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    body = response.json()
+    assert body["status"] == "no_pending"
+    assert body["message"] == "All files are already indexed."
+    assert body["task_id"] is None
+    assert reindex_task.dispatches == []
+
+    # ...and the survey that produced that answer asked about the whole index.
+    # It used to AND in `{"term": {"user_id": <caller>}}` beside the chunk-plane
+    # clause, so "all files are already indexed" only ever meant the caller's.
+    [agg_body] = opensearch.bodies
+    caller_scoped = [
+        f for f in agg_body["query"]["bool"]["filter"] if "user_id" in f.get("term", {})
+    ]
+    assert caller_scoped == [], "the pending survey is still scoped to one account"
+
+
+def test_a_named_file_is_reindexed_by_the_account_that_owns_it(
+    client, admin_token_headers, admin_user, reindex_task, two_owner_corpus
+):
+    """Naming another user's file used to queue a coordinator that skipped it.
+
+    ``file_uuids`` went straight to ``delay(user_id=current_user.id, ...)``, and
+    the coordinator's owner filter then matched none of them — a run that reported
+    started, did nothing, and said so nowhere. Each named file now goes to its own
+    owner's coordinator.
     """
     response = client.post(
-        REINDEX, headers=admin_token_headers, params={"pending_only": True}, json=None
+        REINDEX,
+        headers=admin_token_headers,
+        json=[two_owner_corpus.file_uuid, two_owner_corpus.admin_file_uuid],
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["status"] == "started"
+    assert sorted(reindex_task.dispatches, key=lambda d: d["user_id"]) == sorted(
+        [
+            {"user_id": admin_user.id, "file_uuids": [two_owner_corpus.admin_file_uuid]},
+            {"user_id": two_owner_corpus.owner_id, "file_uuids": [two_owner_corpus.file_uuid]},
+        ],
+        key=lambda d: d["user_id"],
+    )
+
+
+def test_reindex_of_an_unresolvable_file_uuid_queues_nothing(
+    client, admin_token_headers, reindex_task, two_owner_corpus
+):
+    """A UUID that names no completed file cannot be re-indexed, so say so.
+
+    It previously dispatched a coordinator for the caller that found zero files
+    and reported ``started``. Answering ``no_pending`` is what distinguishes a
+    typo from a queued repair.
+    """
+    response = client.post(
+        REINDEX, headers=admin_token_headers, json=["11111111-1111-4111-8111-111111111111"]
     )
 
     assert response.status_code == status.HTTP_200_OK
@@ -554,8 +724,18 @@ def test_pending_only_reindex_with_nothing_to_index_dispatches_nothing(
     assert reindex_task.dispatches == []
 
 
-def test_reindex_is_refused_for_a_plain_user(client, user_token_headers, reindex_task):
+def test_reindex_is_refused_for_a_plain_user(
+    client, user_token_headers, reindex_task, two_owner_corpus
+):
+    """The admin gate is what makes a corpus-wide reindex legitimate (#627).
+
+    Fanning out across every owner without it would let any account queue a
+    re-embed of the entire deployment's transcripts — a scoping bug traded for a
+    privilege one. The corpus fixture is present so a dropped gate shows up as
+    dispatches for *other* owners, not merely a wrong status code.
+    """
     response = client.post(REINDEX, headers=user_token_headers, json=None)
+
     assert response.status_code == status.HTTP_403_FORBIDDEN
     assert reindex_task.dispatches == []
 

--- a/backend/tests/api/test_file_mutation_permissions.py
+++ b/backend/tests/api/test_file_mutation_permissions.py
@@ -241,7 +241,7 @@ MUTATING_ENDPOINTS: list[tuple[str, int]] = [
     ("files/__init__.py", 1204),
     ("files/crud.py", 874),
     ("files/crud.py", 965),
-    ("files/crud.py", 1040),
+    ("files/crud.py", 1052),
     ("files/management.py", 206),
     ("files/management.py", 258),
     ("files/management.py", 356),

--- a/backend/tests/api/test_rename_propagation_dispatch.py
+++ b/backend/tests/api/test_rename_propagation_dispatch.py
@@ -23,6 +23,7 @@ from app.models.media import SpeakerProfile
 
 _DELAY = "app.tasks.rename_propagation_task.propagate_speaker_rename.delay"
 _TITLE_DELAY = "app.tasks.rename_propagation_task.propagate_title_rename.delay"
+_DIGEST_DELAY = "app.tasks.rename_propagation_task.regenerate_rename_digests.delay"
 
 
 def _make_media_file(db_session, user, name: str) -> MediaFile:
@@ -60,6 +61,20 @@ def quiet_opensearch():
         patch("app.services.opensearch_service.update_speaker_profile"),
     ):
         yield
+
+
+@pytest.fixture
+def quiet_rename_dispatch():
+    """Capture the chunk-plane dispatch and silence the digest-plane one beside it.
+
+    ``dispatch_speaker_rename`` queues two things per coalesced file: the
+    ``propagate_speaker_rename`` rewrite (what these tests assert on) and a
+    ``regenerate_rename_digests`` batch. Only the first is yielded — patching the
+    second keeps the digest fan-out from reaching a broker without hiding the
+    dispatch under test.
+    """
+    with patch(_DIGEST_DELAY), patch(_DELAY) as delay_mock:
+        yield delay_mock
 
 
 def _queued(delay_mock) -> dict[str, list[str]]:
@@ -289,6 +304,167 @@ class TestSpeakerRenameEndpoint:
             str(other_file.uuid): ["Old Name"],
         }
         assert {c.kwargs["new_name"] for c in delay_mock.call_args_list} == {"New Name"}
+
+
+class TestSpeakerProfileUpdateEndpoint:
+    """``PUT /speaker-profiles/profiles/{uuid}`` — the second profile-rename path (#675).
+
+    There are two ways to rename a profile and only one of them was covered.
+    ``PUT /speakers/{uuid}`` with ``profile_action="update_profile"`` (the file
+    detail page) has dispatched since #405; ``PUT /speaker-profiles/profiles/{uuid}``
+    — what the **Speakers page's** profile editor calls
+    (``frontend/src/routes/speakers/+page.svelte``) — set ``SpeakerProfile.name``
+    and nothing else.
+
+    ⚠️ **``SpeakerProfile.name`` is not a field of ``transcript_chunks``.** The
+    chunk plane carries ``canonical_speaker_label_for_row(speaker)``, resolved from
+    ``Speaker.display_name`` / ``suggested_name`` / ``name`` — a profile is not
+    consulted at index time at all. So dispatching a propagation from this endpoint
+    *without* also re-applying the profile name to its member speakers would write a
+    name into the index that Postgres does not hold, and the next reindex would
+    revert it. The rename and the dispatch are one unit, which is why these tests
+    assert on both halves.
+    """
+
+    def test_renaming_a_profile_queues_propagation_for_every_file_it_reaches(
+        self, client, db_session, normal_user, user_token_headers, quiet_rename_dispatch
+    ):
+        """One profile, three files, three different indexed labels.
+
+        The old name is per-SPEAKER, not per-profile: a member indexed under a
+        confident suggestion and a member with no label at all were indexed under
+        strings the profile never held, so a dispatch keyed on the profile's own
+        previous name would match nothing for either.
+        """
+        profile = SpeakerProfile(uuid=str(uuid_mod.uuid4()), user_id=normal_user.id, name="Bob")
+        db_session.add(profile)
+        db_session.flush()
+
+        labelled_file = _make_media_file(db_session, normal_user, "profile-put-labelled")
+        _make_speaker(
+            db_session,
+            normal_user,
+            labelled_file,
+            "SPEAKER_00",
+            profile_id=profile.id,
+            display_name="Bob",
+        )
+        unlabelled_file = _make_media_file(db_session, normal_user, "profile-put-unlabelled")
+        unlabelled = _make_speaker(
+            db_session, normal_user, unlabelled_file, "SPEAKER_07", profile_id=profile.id
+        )
+        suggested_file = _make_media_file(db_session, normal_user, "profile-put-suggested")
+        _make_speaker(
+            db_session,
+            normal_user,
+            suggested_file,
+            "SPEAKER_03",
+            profile_id=profile.id,
+            suggested_name="Bobby (Host)",
+            confidence=0.9,
+        )
+        # Shares a file with a member but belongs to no profile: a profile rename
+        # must not sweep it along, or an unrelated speaker's chunks get rewritten.
+        bystander = _make_speaker(
+            db_session,
+            normal_user,
+            labelled_file,
+            "SPEAKER_09",
+            display_name="Someone Else",
+        )
+
+        resp = client.put(
+            f"/api/speaker-profiles/profiles/{profile.uuid}?name=Robert",
+            headers=user_token_headers,
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["name"] == "Robert"
+        assert _queued(quiet_rename_dispatch) == {
+            str(labelled_file.uuid): ["Bob"],
+            str(unlabelled_file.uuid): ["SPEAKER_07"],
+            str(suggested_file.uuid): ["Bobby (Host)"],
+        }
+        assert {c.kwargs["new_name"] for c in quiet_rename_dispatch.call_args_list} == {"Robert"}
+
+        # The other half of the unit: Postgres must now hold the name the
+        # propagation just wrote into the index, or the next reindex reverts it.
+        db_session.refresh(unlabelled)
+        assert unlabelled.display_name == "Robert"
+        db_session.refresh(bystander)
+        assert bystander.display_name == "Someone Else"
+
+    def test_two_members_in_one_file_coalesce_into_a_single_task(
+        self, client, db_session, normal_user, user_token_headers, quiet_rename_dispatch
+    ):
+        """Two tasks over one file would each rewrite the same ``speakers`` array.
+
+        The loser of the version conflict is silently dropped, so the coalescing
+        in ``dispatch_speaker_rename`` is correctness, not efficiency.
+        """
+        profile = SpeakerProfile(uuid=str(uuid_mod.uuid4()), user_id=normal_user.id, name="Bob")
+        db_session.add(profile)
+        db_session.flush()
+
+        media_file = _make_media_file(db_session, normal_user, "profile-put-coalesce")
+        _make_speaker(
+            db_session,
+            normal_user,
+            media_file,
+            "SPEAKER_00",
+            profile_id=profile.id,
+            display_name="Bob",
+        )
+        _make_speaker(db_session, normal_user, media_file, "SPEAKER_07", profile_id=profile.id)
+
+        resp = client.put(
+            f"/api/speaker-profiles/profiles/{profile.uuid}?name=Robert",
+            headers=user_token_headers,
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert quiet_rename_dispatch.call_count == 1, (
+            "two diarized speakers in ONE file must coalesce into one "
+            "update_by_query, not race each other"
+        )
+        assert _queued(quiet_rename_dispatch) == {str(media_file.uuid): ["Bob", "SPEAKER_07"]}
+
+    def test_an_update_that_does_not_change_the_name_queues_nothing(
+        self, client, db_session, normal_user, user_token_headers, quiet_rename_dispatch
+    ):
+        """A description edit touches no indexed field — dispatching would be noise.
+
+        The member deliberately carries **no** ``display_name``, so it is indexed
+        under ``SPEAKER_00`` while the profile is called ``Bob``. That gap is what
+        makes this test able to fail: an implementation that re-applied the profile
+        name on every update (rather than only on a name change) would relabel this
+        speaker and queue a real ``SPEAKER_00 -> Bob`` rewrite. Had the member
+        already been labelled ``Bob``, both assertions would hold either way.
+        """
+        profile = SpeakerProfile(uuid=str(uuid_mod.uuid4()), user_id=normal_user.id, name="Bob")
+        db_session.add(profile)
+        db_session.flush()
+
+        media_file = _make_media_file(db_session, normal_user, "profile-put-desc-only")
+        member = _make_speaker(
+            db_session, normal_user, media_file, "SPEAKER_00", profile_id=profile.id
+        )
+
+        resp = client.put(
+            f"/api/speaker-profiles/profiles/{profile.uuid}?description=Podcast+host",
+            headers=user_token_headers,
+        )
+
+        assert resp.status_code == 200, resp.text
+        # Positive control: the request really did update something, so a
+        # not-called assertion cannot pass on a rejected or no-op request.
+        assert resp.json()["description"] == "Podcast host"
+        assert resp.json()["name"] == "Bob"
+        quiet_rename_dispatch.assert_not_called()
+        db_session.refresh(member)
+        assert member.display_name is None, (
+            "an update that changed no name must not relabel the profile's members"
+        )
 
 
 class TestProfileRenameCapture:

--- a/backend/tests/unit/test_legal_hold_delete_guard.py
+++ b/backend/tests/unit/test_legal_hold_delete_guard.py
@@ -1,0 +1,251 @@
+"""A legal hold must survive every deletion path (issue #664).
+
+``purge_media_file`` is the canonical destroy — it removes the object from storage
+and the row from Postgres, and nothing brings either back. Until this suite it
+consulted ``legal_hold`` **nowhere**, and the hourly retention sweep built its
+candidate set from ``status`` alone. A DMCA/litigation hold could therefore be
+destroyed by a background task, which is the one failure mode legal hold exists
+to prevent.
+
+``status`` is not a durable stand-in for the flag either:
+``tasks/transcription/storage.update_media_file_transcription_status`` writes
+``status = COMPLETED`` and ``completed_at = now()`` unconditionally, with no
+quarantine check. A file quarantined *while it was still transcribing* therefore
+ends up ``legal_hold=True, is_quarantined=True, status='completed'`` with a
+retention clock starting at the moment of that clobber —
+:func:`test_a_hold_survives_a_mid_transcription_status_clobber` reproduces it
+through the real writer.
+
+Every test drives real rows through the savepoint-rolled-back ``db_session``;
+the two purge tests use fabricated storage paths, so the object-storage and
+OpenSearch legs of the destroy address nothing that exists.
+"""
+
+import datetime
+import uuid
+
+import pytest
+from fastapi import HTTPException
+
+from app.models.media import FileStatus
+from app.models.media import MediaFile
+from app.services import file_cleanup_service
+from app.tasks import cleanup
+
+#: The sweep window every test in this module measures against: a file whose
+#: reference timestamp predates this is past its retention.
+_RETENTION_DAYS = 30
+
+#: How far back an "expired" file's ``completed_at`` is placed. Comfortably
+#: outside :data:`_RETENTION_DAYS` so eligibility is never a boundary question.
+_LONG_EXPIRED_DAYS = 400
+
+
+def _make_file(
+    db_session,
+    owner,
+    *,
+    legal_hold: bool = False,
+    is_quarantined: bool = False,
+    status: str = FileStatus.COMPLETED.value,
+    age_days: int = _LONG_EXPIRED_DAYS,
+) -> MediaFile:
+    """Persist one MediaFile that the retention sweep would otherwise expire.
+
+    Args:
+        db_session: The savepoint-isolated test session.
+        owner: The ``User`` the file belongs to.
+        legal_hold: Value for the source-of-truth legal-hold flag.
+        is_quarantined: Value for the takedown/quarantine flag.
+        status: Processing status to store.
+        age_days: How many days ago the file completed and was uploaded.
+
+    Returns:
+        The persisted, refreshed ``MediaFile``.
+    """
+    when = datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=age_days)
+    media_file = MediaFile(
+        uuid=str(uuid.uuid4()),
+        filename=f"hold-guard-{uuid.uuid4().hex[:8]}.mp4",
+        storage_path=f"media/hold-guard/{uuid.uuid4().hex}.mp4",
+        content_type="video/mp4",
+        file_size=1024,
+        user_id=owner.id,
+        status=status,
+        is_public=False,
+        upload_time=when,
+        completed_at=when,
+        legal_hold=legal_hold,
+        is_quarantined=is_quarantined,
+    )
+    db_session.add(media_file)
+    db_session.commit()
+    db_session.refresh(media_file)
+    return media_file
+
+
+def _sweep_candidate_ids(db_session) -> set[int]:
+    """Run the retention sweep's SELECTION phase and return the file ids it chose.
+
+    Calls ``_select_expired_files`` directly rather than the task: selection is a
+    pure read, while the task's second phase destroys everything it selected.
+
+    Args:
+        db_session: The savepoint-isolated test session.
+
+    Returns:
+        The set of ``media_file.id`` values the sweep would hand to the purger.
+    """
+    from app.core.tenant_limits import resolve_retention_days
+
+    cutoff = datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=_RETENTION_DAYS)
+    config = {"delete_error_files": False}
+    expired = cleanup._select_expired_files(
+        db_session, config, cutoff, cutoff, resolve_retention_days
+    )
+    return {file_id for file_id, _ in expired}
+
+
+def test_the_sweep_still_selects_an_ordinary_expired_file(db_session, sample_user):
+    """CONTROL: without it, a guard is indistinguishable from a broken query.
+
+    Every other selection test in this module asserts an *absence*. An empty
+    result set satisfies all of them, so this one proves the query still finds
+    the files retention exists to delete.
+    """
+    ordinary = _make_file(db_session, sample_user)
+
+    assert int(ordinary.id) in _sweep_candidate_ids(db_session)
+
+
+def test_the_sweep_skips_a_file_under_legal_hold(db_session, sample_user):
+    """A held file is otherwise fully eligible — completed and long past the window."""
+    held = _make_file(db_session, sample_user, legal_hold=True)
+    ordinary = _make_file(db_session, sample_user)
+
+    candidates = _sweep_candidate_ids(db_session)
+
+    assert int(held.id) not in candidates
+    # Paired with the control in the same query, so an empty result cannot pass.
+    assert int(ordinary.id) in candidates
+
+
+def test_the_sweep_skips_a_quarantined_file(db_session, sample_user):
+    """A file under review for a takedown must not be destroyed by a beat task.
+
+    Quarantine is deliberately independent of ``status`` (the row keeps its
+    processing state so a release restores it verbatim), so nothing else in the
+    candidate query excludes it.
+    """
+    quarantined = _make_file(db_session, sample_user, is_quarantined=True)
+    ordinary = _make_file(db_session, sample_user)
+
+    candidates = _sweep_candidate_ids(db_session)
+
+    assert int(quarantined.id) not in candidates
+    assert int(ordinary.id) in candidates
+
+
+def test_a_hold_survives_a_mid_transcription_status_clobber(db_session, sample_user):
+    """Issue #664's exact scenario, reproduced through the real status writer.
+
+    A file is quarantined and held while it is still PROCESSING. The transcription
+    pipeline then finishes and calls the real
+    ``update_media_file_transcription_status``, which writes ``COMPLETED`` and a
+    fresh ``completed_at`` with no quarantine check — so the only thing that had
+    been keeping the row out of the candidate set is gone, and the retention clock
+    now starts at the clobber. The file must still survive the sweep.
+    """
+    from app.tasks.transcription.storage import update_media_file_transcription_status
+
+    held = _make_file(
+        db_session,
+        sample_user,
+        legal_hold=True,
+        is_quarantined=True,
+        status=FileStatus.PROCESSING.value,
+    )
+    file_id = int(held.id)
+
+    update_media_file_transcription_status(db_session, file_id, [{"end": 12.0}], "en")
+    db_session.refresh(held)
+
+    # The clobber really did happen — otherwise this test proves nothing about it.
+    assert held.status == FileStatus.COMPLETED.value
+    assert bool(held.legal_hold) is True
+
+    # Age the clobbered timestamp past the window, i.e. the sweep that runs
+    # _RETENTION_DAYS after the clobber rather than the one that runs today.
+    held.completed_at = datetime.datetime.now(datetime.UTC) - datetime.timedelta(
+        days=_LONG_EXPIRED_DAYS
+    )
+    db_session.commit()
+
+    assert file_id not in _sweep_candidate_ids(db_session)
+
+
+def test_purge_media_file_refuses_a_file_under_legal_hold(db_session, sample_user):
+    """The fail-closed backstop every caller inherits.
+
+    The sweep predicate protects one caller. This is the guard that protects the
+    interactive delete, the orphan sweep, and anything added later — and it must
+    report the refusal, never a quiet no-op that reads as success.
+    """
+    held = _make_file(db_session, sample_user, legal_hold=True)
+    file_id = int(held.id)
+
+    result = file_cleanup_service.purge_media_file(db_session, held)
+
+    assert result["deleted"] is False
+    assert result["refused_legal_hold"] is True
+    assert "legal hold" in result["error"]
+    assert db_session.query(MediaFile).filter(MediaFile.id == file_id).first() is not None
+
+
+def test_purge_media_file_still_destroys_an_ordinary_file(db_session, sample_user):
+    """CONTROL: the guard must not have broken the destroy it guards."""
+    ordinary = _make_file(db_session, sample_user)
+    file_id = int(ordinary.id)
+
+    result = file_cleanup_service.purge_media_file(db_session, ordinary)
+
+    assert result["deleted"] is True
+    assert db_session.query(MediaFile).filter(MediaFile.id == file_id).first() is None
+
+
+def test_purge_media_file_still_destroys_a_quarantined_file_with_no_hold(db_session, sample_user):
+    """The in-function guard is keyed on the HOLD, not on quarantine — deliberately.
+
+    ``quarantine_file`` can be called with ``legal_hold=False``, and taking an
+    AUP-violating upload down and then deleting it is a real admin workflow. The
+    unattended sweep still skips quarantined files (it must never destroy anything
+    under review), but an admin acting deliberately is not blocked. Without this
+    test, widening the guard to ``is_quarantined`` would look like an improvement.
+    """
+    quarantined = _make_file(db_session, sample_user, is_quarantined=True)
+    file_id = int(quarantined.id)
+
+    result = file_cleanup_service.purge_media_file(db_session, quarantined)
+
+    assert result["deleted"] is True
+    assert db_session.query(MediaFile).filter(MediaFile.id == file_id).first() is None
+
+
+def test_the_interactive_delete_reports_a_hold_as_a_conflict(db_session, sample_user):
+    """A refusal is not a server fault, and the admin needs to know which it was.
+
+    ``crud.delete_media_file`` turns any failed purge into a 500. A legal hold is
+    a deliberate, actionable refusal — the admin must release the hold first — so
+    it surfaces as a 409 naming the cause instead of an opaque internal error.
+    """
+    from app.api.endpoints.files import crud
+
+    held = _make_file(db_session, sample_user, legal_hold=True)
+    file_id = int(held.id)
+
+    with pytest.raises(HTTPException) as excinfo:
+        crud.delete_media_file(db_session, str(held.uuid), sample_user, force=True)
+
+    assert excinfo.value.status_code == 409
+    assert excinfo.value.detail["error"] == "FILE_UNDER_LEGAL_HOLD"
+    assert db_session.query(MediaFile).filter(MediaFile.id == file_id).first() is not None

--- a/backend/tests/unit/test_model_switch.py
+++ b/backend/tests/unit/test_model_switch.py
@@ -218,6 +218,57 @@ def test_dispatch_reindex_ignores_owners_whose_files_are_not_completed(
     assert set(result["reindex_task_ids"].keys()) == baseline | {normal_user.id}
 
 
+def test_dispatch_reindex_with_a_named_scope_covers_exactly_those_owners(
+    db_session, normal_user, other_user
+):
+    """The #627 partial scope: each owner's coordinator gets that owner's files.
+
+    A partial scope must NOT also sweep in every other owner of a completed file
+    the way the default whole-corpus mode does — a pending-only sweep that
+    re-embedded fully-indexed accounts is the opposite defect.
+    """
+    _make_media_file(db_session, other_user, FileStatus.COMPLETED)
+    fake_delay = MagicMock(side_effect=lambda **kw: MagicMock(id=f"task-{kw['user_id']}"))
+
+    with (
+        patch("app.db.session_utils.session_scope", lambda: _yield_session(db_session)),
+        patch("app.tasks.reindex_task.reindex_transcripts_task.delay", fake_delay),
+    ):
+        result = dispatch_reindex_for_every_owner(
+            triggered_by=normal_user.id,
+            file_uuids_by_owner={other_user.id: ["uuid-a", "uuid-b"]},
+        )
+
+    assert set(result["reindex_task_ids"].keys()) == {other_user.id}
+    fake_delay.assert_called_once_with(user_id=other_user.id, file_uuids=["uuid-a", "uuid-b"])
+
+
+def test_dispatch_reindex_drops_a_named_owner_with_an_empty_file_list(
+    db_session, normal_user, other_user
+):
+    """``file_uuids=[]`` would re-embed that owner's WHOLE account, not nothing.
+
+    ``reindex_transcripts_task`` narrows its snapshot with ``if file_uuids:``, so a
+    falsy list is indistinguishable from "no filter given". An owner the scope
+    resolved to zero pending files must therefore be dropped, never dispatched
+    with an empty list.
+    """
+    _make_media_file(db_session, other_user, FileStatus.COMPLETED)
+    fake_delay = MagicMock(side_effect=lambda **kw: MagicMock(id=f"task-{kw['user_id']}"))
+
+    with (
+        patch("app.db.session_utils.session_scope", lambda: _yield_session(db_session)),
+        patch("app.tasks.reindex_task.reindex_transcripts_task.delay", fake_delay),
+    ):
+        result = dispatch_reindex_for_every_owner(
+            triggered_by=normal_user.id,
+            file_uuids_by_owner={other_user.id: [], normal_user.id: ["uuid-a"]},
+        )
+
+    assert set(result["reindex_task_ids"].keys()) == {normal_user.id}
+    fake_delay.assert_called_once_with(user_id=normal_user.id, file_uuids=["uuid-a"])
+
+
 def test_dispatch_reindex_raises_when_delay_fails_and_message_reports_partial_progress(
     db_session, normal_user, other_user
 ):

--- a/backend/tests/unit/test_precommit_stage_ci_parity.py
+++ b/backend/tests/unit/test_precommit_stage_ci_parity.py
@@ -1,0 +1,153 @@
+"""Every pre-commit stage a hook is assigned to must be invoked by CI (issue #688).
+
+``pre-commit run --all-files`` with no ``--hook-stage`` runs **default-stage hooks
+only**, and ``.pre-commit-config.yaml`` sets ``default_stages: [pre-commit]``. So the
+moment a hook is demoted to ``stages: [pre-push]`` — which is exactly what #688 did to
+the frontend production build and the recursive ``bandit -r backend/`` scan — it stops
+running in CI, and the workflow goes **green while checking less**. Nothing about that
+failure is visible: no error, no skip line, no missing job.
+
+That is a silent-coverage-loss class, so it gets a gate rather than a paragraph. This
+test reads the two files that jointly decide what CI checks and fails when they
+disagree:
+
+* ``.pre-commit-config.yaml`` — which stage each hook is assigned to
+* ``.github/workflows/pre-commit.yml`` — which stages the workflow actually invokes
+
+⚠️ **Scope, stated honestly:** this checks stages declared *in this repo's config*.
+A hook can also carry ``stages`` in its upstream ``.pre-commit-hooks.yaml`` (several
+``pre-commit-hooks`` entries such as ``trailing-whitespace`` declare ``pre-push``
+there), which no static read of this repo can see. Those are not what a demotion
+touches, and they only ever ADD coverage, never remove it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PRECOMMIT_CONFIG = REPO_ROOT / ".pre-commit-config.yaml"
+PRECOMMIT_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pre-commit.yml"
+
+#: Stages that legitimately have no ``--all-files`` CI invocation, each with the reason.
+#: An entry here is a decision, not a backlog item.
+EXEMPT_STAGES: dict[str, str] = {
+    "commit-msg": (
+        "A commit-msg hook is handed the path of a commit message file; there is no "
+        "commit message in a `pre-commit run --all-files` sweep, so the stage cannot "
+        "be exercised that way. conventional-pre-commit is enforced at commit time on "
+        "a developer's machine and by the PR title, not by this workflow."
+    ),
+    "manual": (
+        "`manual` means opt-in by definition — a hook parked there is deliberately not "
+        "part of any automatic gate."
+    ),
+}
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    """Parse a YAML file, failing the test with the path when it is unreadable.
+
+    Raises ``AssertionError`` rather than calling ``pytest.fail``: the mypy hook runs in
+    an isolated env with no pytest, so ``pytest.fail`` is untyped there and does not
+    narrow as ``NoReturn`` — the ``isinstance`` guard below would then not hold.
+    """
+    if not path.is_file():
+        raise AssertionError(f"expected file is missing: {path}")
+    with path.open(encoding="utf-8") as handle:
+        loaded: object = yaml.safe_load(handle)
+    if not isinstance(loaded, dict):
+        raise AssertionError(f"{path} did not parse as a YAML mapping")
+    return {str(key): value for key, value in loaded.items()}
+
+
+def _hooks_with_stages() -> list[tuple[str, tuple[str, ...]]]:
+    """Return ``(hook id, stages)`` for every hook declared in the config.
+
+    The id is the ``alias`` when one is set, since that is what identifies the hook
+    on the command line and in ``SKIP=``.
+    """
+    config = _load_yaml(PRECOMMIT_CONFIG)
+    default_stages = tuple(config.get("default_stages") or ("pre-commit",))
+    hooks: list[tuple[str, tuple[str, ...]]] = []
+    for repo in config.get("repos") or []:
+        for hook in repo.get("hooks") or []:
+            hook_id = hook.get("alias") or hook.get("id")
+            stages = tuple(hook.get("stages") or default_stages)
+            hooks.append((str(hook_id), stages))
+    return hooks
+
+
+def _ci_invoked_stages() -> set[str]:
+    """Return the set of stages ``.github/workflows/pre-commit.yml`` actually runs.
+
+    A ``pre-commit run`` command with no ``--hook-stage`` runs the default stage,
+    which is what made the trap invisible — so an unflagged invocation is recorded
+    as ``pre-commit``, not as "everything".
+    """
+    workflow = _load_yaml(PRECOMMIT_WORKFLOW)
+    jobs = workflow.get("jobs") or {}
+    stages: set[str] = set()
+    for job in jobs.values():
+        for step in job.get("steps") or []:
+            run = str(step.get("run") or "")
+            if "pre-commit run" not in run:
+                continue
+            tokens = run.split()
+            if "--hook-stage" in tokens:
+                stages.add(tokens[tokens.index("--hook-stage") + 1])
+            else:
+                stages.add("pre-commit")
+    return stages
+
+
+def test_every_hook_stage_is_invoked_by_ci() -> None:
+    """No hook may sit in a stage the pre-commit workflow never runs."""
+    invoked = _ci_invoked_stages()
+    offenders = [
+        f"{hook_id} (stages={list(stages)})"
+        for hook_id, stages in _hooks_with_stages()
+        if not [s for s in stages if s in invoked or s in EXEMPT_STAGES]
+    ]
+    assert not offenders, (
+        "These hooks run in NO stage that .github/workflows/pre-commit.yml invokes, so "
+        f"CI silently stops checking them: {offenders}. Stages CI runs: {sorted(invoked)}. "
+        "Add `pre-commit run --all-files --hook-stage <stage>` to the workflow, or "
+        "record the stage in EXEMPT_STAGES with a written reason."
+    )
+
+
+def test_ci_runs_the_pre_push_stage() -> None:
+    """The pre-push tier must have its own CI invocation.
+
+    Pinned separately from the generic parity check above because deleting the last
+    pre-push hook would make that check pass vacuously, and the next demotion would
+    then land with no CI coverage and no failing test.
+    """
+    invoked = _ci_invoked_stages()
+    assert "pre-push" in invoked, (
+        "`pre-commit run --all-files --hook-stage pre-push` is not in "
+        f"{PRECOMMIT_WORKFLOW}; CI runs only {sorted(invoked)}. Anything demoted to "
+        "pre-push would stop being checked while the workflow stays green (issue #688)."
+    )
+
+
+def test_install_hook_types_cover_every_declared_stage() -> None:
+    """`pre-commit install` must wire every stage the config uses.
+
+    Without ``default_install_hook_types`` covering it, a stage is configured but never
+    fires locally: ``pre-commit install`` writes only the ``pre-commit`` hook script, so
+    the pre-push and commit-msg tiers exist on paper and run nowhere.
+    """
+    config = _load_yaml(PRECOMMIT_CONFIG)
+    installed = set(config.get("default_install_hook_types") or ["pre-commit"])
+    declared = {stage for _, stages in _hooks_with_stages() for stage in stages}
+    missing = sorted(declared - installed - {"manual"})
+    assert not missing, (
+        f"{PRECOMMIT_CONFIG.name} assigns hooks to {missing} but "
+        f"default_install_hook_types is {sorted(installed)}, so `pre-commit install` "
+        "never wires those git hooks and the tier is dead locally."
+    )

--- a/backend/tests/unit/test_speaker_threshold_cosine_space.py
+++ b/backend/tests/unit/test_speaker_threshold_cosine_space.py
@@ -1,0 +1,183 @@
+"""The speaker auto-accept gate must be written in raw-cosine space (issue #674).
+
+OpenSearch's Lucene ``cosinesimil`` space reports ``(1 + cosine) / 2``, never raw
+cosine. A raw-cosine threshold handed straight to ``min_score`` therefore gates at
+half the value it names: ``min_score=0.75`` admits everything at raw cosine
+``>= 0.50`` — the band ``core.constants`` classifies as *requires validation* — and
+``_propagate_profile_assignment`` writes those rows ``verified=True``.
+
+The repo-wide cosine invariant covers score *reads*; these tests cover the *write*
+direction, which no read-site audit can reach.
+"""
+
+from typing import cast
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.core.constants import SPEAKER_CONFIDENCE_HIGH
+from app.core.constants import SPEAKER_CONFIDENCE_MEDIUM
+from app.services.similarity_service import SimilarityService
+from app.utils.cosine_space import opensearch_score_from_raw_cosine
+from app.utils.cosine_space import raw_cosine_from_opensearch_score
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeCosinesimilIndex:
+    """Stands in for an OpenSearch index mapped ``"space_type": "cosinesimil"``.
+
+    Scores documents the way OpenSearch does — ``(1 + cosine) / 2`` — and applies
+    ``min_score`` in that same space, so what these tests measure is the gate the
+    real server would apply. The arithmetic is spelled out here rather than taken
+    from :mod:`app.utils.cosine_space` on purpose: a fake that shares the function
+    under test cannot disagree with it.
+    """
+
+    def __init__(self, raw_cosines: list[float]) -> None:
+        self._raw_cosines = list(raw_cosines)
+        self.last_body: dict | None = None
+
+    def search(self, index: str, body: dict) -> dict:
+        self.last_body = body
+        min_score = body.get("min_score")
+        hits = []
+        for speaker_id, raw_cosine in enumerate(self._raw_cosines, start=1):
+            score = (1.0 + raw_cosine) / 2.0
+            if min_score is not None and score < min_score:
+                continue
+            hits.append({"_score": score, "_source": {"speaker_id": speaker_id}})
+        return {"hits": {"hits": hits}}
+
+
+@pytest.fixture
+def fake_index(monkeypatch):
+    """Install a fake cosinesimil index and hand the factory back to the test."""
+    from app.services import opensearch_service
+
+    def _install(raw_cosines: list[float]) -> _FakeCosinesimilIndex:
+        index = _FakeCosinesimilIndex(raw_cosines)
+        monkeypatch.setattr(opensearch_service, "opensearch_client", index)
+        return index
+
+    return _install
+
+
+def _search(min_raw_cosine: float):
+    return SimilarityService.opensearch_similarity_search(
+        embedding=[0.0] * 8,
+        user_id=1,
+        index_name="speakers",
+        min_raw_cosine=min_raw_cosine,
+    )
+
+
+def test_a_raw_cosine_gate_of_075_is_sent_to_opensearch_as_min_score_0875(fake_index):
+    """The number on the wire is in cosinesimil space, not raw-cosine space."""
+    index = fake_index([0.95])
+
+    _search(SPEAKER_CONFIDENCE_HIGH)
+
+    assert SPEAKER_CONFIDENCE_HIGH == 0.75, "the constant this test is calibrated against moved"
+    assert index.last_body is not None, "no query reached OpenSearch"
+    assert index.last_body["min_score"] == pytest.approx(0.875)
+
+
+def test_a_candidate_at_raw_cosine_050_is_not_auto_accepted(fake_index):
+    """Raw cosine 0.50 is the 'requires validation' band — it must not be admitted."""
+    index = fake_index([SPEAKER_CONFIDENCE_MEDIUM, 0.80])
+
+    results = _search(SPEAKER_CONFIDENCE_HIGH)
+
+    assert [hit["speaker_id"] for hit in results] == [2]
+    assert results[0]["similarity"] == pytest.approx(0.80)
+    assert index.last_body["min_score"] == pytest.approx(0.875)
+
+
+def test_a_candidate_at_raw_cosine_080_is_auto_accepted(fake_index):
+    """The gate must not be so tight it rejects a genuine high-confidence match."""
+    fake_index([0.80])
+
+    results = _search(SPEAKER_CONFIDENCE_HIGH)
+
+    assert len(results) == 1
+    assert results[0]["similarity"] == pytest.approx(0.80)
+
+
+def test_the_returned_similarity_is_raw_cosine_not_the_opensearch_score(fake_index):
+    """The read direction stays converted — the fix must not double-convert."""
+    fake_index([0.90, 0.76])
+
+    results = _search(0.70)
+
+    assert [pytest.approx(hit["similarity"]) for hit in results] == [
+        pytest.approx(0.90),
+        pytest.approx(0.76),
+    ]
+
+
+def test_cosine_space_helpers_convert_in_both_directions():
+    assert opensearch_score_from_raw_cosine(0.75) == pytest.approx(0.875)
+    assert opensearch_score_from_raw_cosine(0.50) == pytest.approx(0.75)
+    assert opensearch_score_from_raw_cosine(-1.0) == pytest.approx(0.0)
+    assert raw_cosine_from_opensearch_score(0.875) == pytest.approx(0.75)
+    assert raw_cosine_from_opensearch_score(0.75) == pytest.approx(0.50)
+    assert raw_cosine_from_opensearch_score(
+        opensearch_score_from_raw_cosine(0.42)
+    ) == pytest.approx(0.42)
+
+
+class _StubQuery:
+    def filter(self, *args, **kwargs):
+        return self
+
+    def first(self):
+        return None
+
+    def all(self):
+        return []
+
+
+class _StubSession:
+    """Minimal Session stand-in: the propagation path under test never reaches a row."""
+
+    def query(self, *args, **kwargs):
+        return _StubQuery()
+
+    def commit(self):
+        raise AssertionError("nothing should be committed when no candidate matches")
+
+    def rollback(self):
+        raise AssertionError("propagation raised instead of completing")
+
+
+def test_profile_propagation_gates_at_the_high_confidence_constant(monkeypatch):
+    """The auto-accept caller declares its space and reuses the constant.
+
+    ``_propagate_profile_assignment`` swallows every exception, so the capture is
+    asserted after the call: an empty capture means the search was never reached
+    and the test fails rather than passing vacuously.
+    """
+    from app.services.speaker_matching_service import SpeakerMatchingService
+
+    captured: dict = {}
+
+    def fake_similarity_search(**kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(
+        SimilarityService, "opensearch_similarity_search", staticmethod(fake_similarity_search)
+    )
+    monkeypatch.setattr(
+        SpeakerMatchingService,
+        "_get_speaker_embedding_for_propagation",
+        lambda self, speaker_id: ([0.1] * 8, "stub-uuid"),
+    )
+
+    service = SpeakerMatchingService(cast("Session", _StubSession()), embedding_service=None)
+    service._propagate_profile_assignment(matched_speaker_id=1, profile_id=2, user_id=3)
+
+    assert captured, "the propagation path never reached the similarity search"
+    assert captured["min_raw_cosine"] == SPEAKER_CONFIDENCE_HIGH
+    assert "threshold" not in captured, "a bare 'threshold' kwarg names no similarity space"

--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import {execFileSync} from 'node:child_process';
 import {themes as prismThemes} from 'prism-react-renderer';
 import type {Config} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
@@ -28,7 +29,54 @@ function resolveVersion(): string {
   }
 }
 
+// Compares dotted-numeric version prefixes (major.minor.patch, ignoring any
+// pre-release/build suffix) without pulling in a semver dependency.
+function compareVersions(a: string, b: string): number {
+  const parse = (v: string): number[] => v.match(/^\d+\.\d+\.\d+/)![0].split('.').map(Number);
+  const [aParts, bParts] = [parse(a), parse(b)];
+  for (let i = 0; i < 3; i++) {
+    if (aParts[i] !== bParts[i]) return aParts[i] - bParts[i];
+  }
+  return 0;
+}
+
+// Issue #686: VERSION is bumped by release.sh's `bump` stage long before `finish`
+// publishes the GitHub Release, so between those two points VERSION names a version
+// that doesn't exist yet. resolveVersion() only validated shape, never that the
+// version was published, so the badge could render a syntactically valid lie.
+//
+// Fixed with option 2 from the issue: derive "is this ahead of the newest release"
+// locally from git tags, no network call required.
+//
+// This only works when a git checkout with tag history is reachable (the ../VERSION
+// fs-read path above — e.g. the GitHub Pages deploy in .github/workflows/deploy-docs.yml,
+// which fetches full history + tags for exactly this reason). The Docker build
+// (docs-site/Dockerfile.prod) has no .git in its build context at all — only OT_VERSION
+// is passed in — so git is unreachable there and this fails closed to "not dev": by the
+// time that image is actually published, the release pipeline's tag stage has already
+// run (build -> tag -> publish), so OT_VERSION corresponds to a real release. Also fails
+// closed to "not dev" if the current version IS the newest tag, or is somehow behind it.
+function isUnpublishedVersion(candidate: string): boolean {
+  if (!candidate) return false;
+  try {
+    const tags = execFileSync('git', ['tag', '--list', 'v[0-9]*.[0-9]*.[0-9]*'], {
+      cwd: __dirname,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+      .toString()
+      .split('\n')
+      .map((t) => t.trim().replace(/^v/, ''))
+      .filter((t) => /^\d+\.\d+\.\d+$/.test(t));
+    if (tags.length === 0) return false;
+    const newestTag = tags.reduce((best, t) => (compareVersions(t, best) > 0 ? t : best));
+    return compareVersions(candidate, newestTag) > 0;
+  } catch {
+    return false;
+  }
+}
+
 const version = resolveVersion();
+const versionIsDev = isUnpublishedVersion(version);
 const githubRepo = 'https://github.com/attevon-llc/OpenTranscribe';
 
 // When building for in-app embedding (DOCS_BASE_URL=/docs/), the NGINX proxy strips
@@ -77,6 +125,7 @@ const config: Config = {
   // Exposed to the client via useDocusaurusContext().siteConfig.customFields
   customFields: {
     version,
+    versionIsDev,
     githubRepo,
   },
 

--- a/docs-site/src/pages/index.tsx
+++ b/docs-site/src/pages/index.tsx
@@ -183,13 +183,16 @@ const useCases = [
 function Hero() {
   const {siteConfig} = useDocusaurusContext();
   const version = siteConfig.customFields?.version as string;
+  const versionIsDev = siteConfig.customFields?.versionIsDev as boolean;
   const githubRepo = siteConfig.customFields?.githubRepo as string;
 
   return (
     <header className={styles.heroBanner}>
       <div className={clsx('container', styles.heroContent)}>
         <div className={styles.heroBadges}>
-          {version && <span className={styles.badge}>{`v${version}`}</span>}
+          {version && (
+            <span className={styles.badge}>{`v${version}${versionIsDev ? '-dev' : ''}`}</span>
+          )}
           <span className={styles.badge}>AGPL-3.0</span>
           <span className={styles.badge}>Self-Hosted</span>
         </div>

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -536,6 +536,22 @@ aux-file record.
   It hard-exits if the `opentranscribe-multiarch` builder is missing (`setup-remote-builder.sh setup`).
 - `SKIP_SECURITY_SCAN=true` for quick iteration; `PLATFORMS=linux/amd64` for single-arch (no remote
   builder needed); `$0 auto` builds only git-changed components.
+- ⚠️ **"Scanned, findings tolerable" and "never scanned" are DIFFERENT outcomes and must stay
+  that way** (issue #681). `security-scan.sh` exits **1** for findings and **2** for could-not-scan
+  (unknown component, image unobtainable, a sub-scan that died without recording a verdict);
+  `run_security_scan` treats 2 as fatal **regardless of `FAIL_ON_SECURITY_ISSUES`**, because that
+  flag is a statement about which findings are acceptable to ship, not about shipping an image
+  nobody looked at. Collapsing the two into one `else` branch is what made an unscannable
+  component print `All security scans completed successfully!` — and `docs` was already in that
+  state, since it was in `BUILT_COMPONENTS` with a `security-scan.sh` arm but no registry-pull
+  branch, so the default path "scanned" an image it never fetched.
+- **The scannable component list has exactly one home**: the `SCAN_COMPONENT_*` tables in
+  `security-scan.sh`, exposed as `./scripts/security-scan.sh list-components`.
+  `docker-build-push.sh` validates `BUILT_COMPONENTS` against that before pulling anything, and
+  both its pull dispatches now have a failing `*)`. Adding a component (e.g. `lite`, issue #667)
+  means adding it there; forgetting is now loud instead of a green run over an unscanned
+  published image. Guarded by `scripts/tests/test-scan-not-a-pass.sh` (19 cases, 0.4 s, no
+  Docker/network), wired as the `scan-not-a-pass` pre-commit hook.
 - **Every path ends in `buildx --push` — there is no local-only mode.** `:latest` and `:vX.Y.Z` hit
   Docker Hub the instant the build finishes, and it then runs `push-security-reports.sh`, which
   **git-commits and pushes** `security-reports/` to whatever branch is checked out.

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -262,6 +262,12 @@ this file is for.
   `backend/tests/CLAUDE.md`.
 - **Frontend gate** — `frontend-check.sh`: `npm ci` → `svelte-kit sync` → ESLint → svelte-check → vite
   build. Also the pre-commit hook (`files: ^frontend/src/`) and the `/fix-frontend` command.
+  **Two hooks, not one, since issue #688**: `frontend-check` runs it with `--check-only` at
+  commit stage (the `vite build` — whose `prebuild` downloads fonts and shells out to
+  `docker buildx` for the FFmpeg.wasm core — measured 91.8 s of a 328 s whole-tree run), and
+  `frontend-build` runs it in full at **pre-push**. On a PR that hook is the only `vite build`
+  in CI at all, so `.github/workflows/pre-commit.yml` invokes both stages; see
+  `backend/tests/unit/test_precommit_stage_ci_parity.py`.
 - **Publish images** — `docker-build-push.sh`; prefer the skill at `.claude/skills/docker-build-push/SKILL.md`.
 - **Models** — `download-models.sh <cache-dir>` is a host wrapper that runs `download-models.py` inside
   the backend image (`DOWNLOAD_ALL_OPENSEARCH_MODELS`, `OPENSEARCH_MODELS`, `WHISPER_MODEL`).

--- a/scripts/docker-build-push.sh
+++ b/scripts/docker-build-push.sh
@@ -154,7 +154,56 @@ update_security_tools() {
     print_success "Security tool updates complete!"
 }
 
-# Function to run security scan if enabled
+# security-scan.sh's exit codes. Kept in sync with the block at the top of that
+# script; 2 means "could not scan", which is NOT a kind of finding.
+SCAN_EXIT_FINDINGS=1
+SCAN_EXIT_COULD_NOT_SCAN=2
+
+# Ask security-scan.sh what it can actually scan, and refuse anything else.
+#
+# Issue #681: the component list lived in three places that were free to
+# disagree. `docs` was in BUILT_COMPONENTS and had a security-scan.sh arm but no
+# registry-pull branch here, so in the default (registry) mode it was scanned
+# against an image that was never fetched — and any resulting failure was then
+# downgraded to a pass. A future `lite` target would have inherited exactly the
+# same hole. So the list is DERIVED from the scanner, once, up front.
+assert_components_scannable() {
+    local requested=("$@")
+
+    if [ ! -f "./scripts/security-scan.sh" ]; then
+        print_error "scripts/security-scan.sh is missing — nothing can establish these images were scanned"
+        return 1
+    fi
+
+    local known=()
+    mapfile -t known < <(./scripts/security-scan.sh list-components 2>/dev/null)
+    if [ ${#known[@]} -eq 0 ]; then
+        print_error "security-scan.sh reported no scannable components"
+        return 1
+    fi
+
+    local component candidate found rc=0
+    for component in "${requested[@]}"; do
+        found=false
+        for candidate in "${known[@]}"; do
+            if [ "${candidate}" = "${component}" ]; then
+                found=true
+                break
+            fi
+        done
+        if [ "${found}" != true ]; then
+            print_error "Component '${component}' has no security-scan.sh arm — it CANNOT be scanned"
+            print_error "  scannable components: ${known[*]}"
+            rc=1
+        fi
+    done
+    return "${rc}"
+}
+
+# Function to run security scan if enabled.
+#
+# Returns 0 (proceed), 1 (findings the caller's policy refuses to tolerate), or
+# SCAN_EXIT_COULD_NOT_SCAN (this component was never scanned).
 run_security_scan() {
     local component=$1
 
@@ -164,24 +213,43 @@ run_security_scan() {
     fi
 
     if [ ! -f "./scripts/security-scan.sh" ]; then
-        print_warning "Security scan script not found, skipping..."
-        return 0
+        # Deliberately fatal, and deliberately NOT gated on
+        # FAIL_ON_SECURITY_ISSUES. There is already an explicit, named opt-out
+        # for "I do not want a scan" — SKIP_SECURITY_SCAN — and an absent
+        # scanner is not somebody choosing it.
+        print_error "Security scan script not found — refusing to claim ${component} was scanned"
+        print_error "Set SKIP_SECURITY_SCAN=true if you genuinely intend to build without scanning"
+        return "${SCAN_EXIT_COULD_NOT_SCAN}"
     fi
 
     print_info "Running security scan for ${component}..."
-    if OUTPUT_DIR="./security-reports" FAIL_ON_CRITICAL="${FAIL_ON_CRITICAL:-false}" ./scripts/security-scan.sh "${component}"; then
+    local scan_rc=0
+    OUTPUT_DIR="./security-reports" FAIL_ON_CRITICAL="${FAIL_ON_CRITICAL:-false}" \
+        ./scripts/security-scan.sh "${component}" || scan_rc=$?
+
+    if [ "${scan_rc}" -eq 0 ]; then
         print_success "Security scan passed for ${component}"
         return 0
-    else
-        print_warning "Security scan found issues for ${component}"
-        if [ "${FAIL_ON_SECURITY_ISSUES}" = "true" ]; then
-            print_error "Failing build due to security issues (FAIL_ON_SECURITY_ISSUES=true)"
-            return 1
-        else
-            print_warning "Continuing despite security issues (set FAIL_ON_SECURITY_ISSUES=true to fail)"
-            return 0
-        fi
     fi
+
+    if [ "${scan_rc}" -ge "${SCAN_EXIT_COULD_NOT_SCAN}" ]; then
+        # NOT the findings branch. FAIL_ON_SECURITY_ISSUES is a statement about
+        # which findings are acceptable to ship; it says nothing about shipping
+        # an image nobody looked at, so it does not apply here and must not be
+        # consulted. Folding this into the branch below is the whole of #681.
+        print_error "Security scan could NOT RUN for ${component} (exit ${scan_rc})"
+        print_error "This is not a tolerable-findings result — the image was never scanned"
+        print_error "FAIL_ON_SECURITY_ISSUES does not apply: it tolerates findings, not the absence of a scan"
+        return "${SCAN_EXIT_COULD_NOT_SCAN}"
+    fi
+
+    print_warning "Security scan found issues for ${component}"
+    if [ "${FAIL_ON_SECURITY_ISSUES}" = "true" ]; then
+        print_error "Failing build due to security issues (FAIL_ON_SECURITY_ISSUES=true)"
+        return "${SCAN_EXIT_FINDINGS}"
+    fi
+    print_warning "Continuing despite security issues (set FAIL_ON_SECURITY_ISSUES=true to fail)"
+    return 0
 }
 
 # ---------------------------------------------------------------------------
@@ -372,13 +440,61 @@ build_docs() {
     printf '%s\n' "${tag_args[@]}" | grep -v '^--tag$' | sed 's/^/  - /'
 }
 
-# Function to run parallel security scans on both images
+# Turn the per-component status files into ONE verdict.
+#
+# Three outcomes, because there are three things that can happen (issue #681):
+#   0   every component was scanned and came back acceptable
+#   1   every component was SCANNED; at least one failed the caller's policy
+#   2   at least one component was NOT SCANNED — no status file at all (the
+#       subshell died before recording anything), or a could-not-scan status
+#
+# Split out of run_parallel_scans so it can be exercised directly: the
+# missing-status-file path is otherwise only reachable by killing a subshell
+# mid-run, and a branch that cannot be tested is a branch that quietly rots.
+evaluate_scan_statuses() {
+    local status_dir="$1"
+    shift
+
+    local verdict=0 component status
+    for component in "$@"; do
+        if [ ! -f "${status_dir}/${component}.status" ]; then
+            print_error "${component}: no scan status recorded — NOT SCANNED"
+            verdict="${SCAN_EXIT_COULD_NOT_SCAN}"
+            continue
+        fi
+        status=$(cat "${status_dir}/${component}.status")
+        case "${status}" in
+            0)
+                ;;
+            "${SCAN_EXIT_FINDINGS}")
+                if [ "${verdict}" -eq 0 ]; then
+                    verdict="${SCAN_EXIT_FINDINGS}"
+                fi
+                ;;
+            *)
+                print_error "${component}: security scan could not run (status '${status}') — NOT SCANNED"
+                verdict="${SCAN_EXIT_COULD_NOT_SCAN}"
+                ;;
+        esac
+    done
+    return "${verdict}"
+}
+
+# Function to run parallel security scans on the built images
 run_parallel_scans() {
     local components=("$@")
 
     if [ "${SKIP_SECURITY_SCAN}" = "true" ]; then
         print_warning "Security scanning skipped (SKIP_SECURITY_SCAN=true)"
         return 0
+    fi
+
+    # Fail before pulling or scanning anything: a component the scanner has no
+    # arm for can never produce a meaningful result, so there is no point
+    # spending a registry pull to find that out per-component later.
+    if ! assert_components_scannable "${components[@]}"; then
+        print_error "Refusing to report a security result for a component that cannot be scanned"
+        return 1
     fi
 
     print_info ""
@@ -413,30 +529,45 @@ run_parallel_scans() {
                 return 1
             fi
         }
+        # A `*)` arm is mandatory here: an unhandled component would otherwise
+        # skip the existence check entirely and be "scanned" against whatever
+        # local image happens to carry that tag.
         for component in "${components[@]}"; do
             case "$component" in
                 backend)  return_early_if_missing "${REPO_BACKEND}:${VERSION_FULL}" || return 1 ;;
                 frontend) return_early_if_missing "${REPO_FRONTEND}:${VERSION_FULL}" || return 1 ;;
+                docs)     return_early_if_missing "${REPO_DOCS}:${VERSION_FULL}" || return 1 ;;
+                *)
+                    print_error "No local-image rule for component '${component}' — cannot confirm an image exists to scan"
+                    return 1
+                    ;;
             esac
         done
     else
-        # Pull images in parallel
+        # Pull images in parallel.
+        #
+        # This was an `if backend / elif frontend` with no default, so `docs`
+        # was never pulled and the scan below ran against whatever local image
+        # carried that tag — or nothing (issue #681). A `case` with a failing
+        # `*)` makes the next component that forgets a branch loud.
         print_info "Pulling images from the registry for scanning..."
 
         for component in "${components[@]}"; do
-            if [ "$component" = "backend" ]; then
-                (
-                    docker rmi "${REPO_BACKEND}:latest" 2>/dev/null || true
-                    docker pull --platform linux/amd64 "${REPO_BACKEND}:latest"
-                ) &
-                pids+=($!)
-            elif [ "$component" = "frontend" ]; then
-                (
-                    docker rmi "${REPO_FRONTEND}:latest" 2>/dev/null || true
-                    docker pull --platform linux/amd64 "${REPO_FRONTEND}:latest"
-                ) &
-                pids+=($!)
-            fi
+            local pull_repo
+            case "$component" in
+                backend)  pull_repo="${REPO_BACKEND}" ;;
+                frontend) pull_repo="${REPO_FRONTEND}" ;;
+                docs)     pull_repo="${REPO_DOCS}" ;;
+                *)
+                    print_error "No registry-pull rule for component '${component}' — it would be scanned against a stale or absent local image"
+                    return 1
+                    ;;
+            esac
+            (
+                docker rmi "${pull_repo}:latest" 2>/dev/null || true
+                docker pull --platform linux/amd64 "${pull_repo}:latest"
+            ) &
+            pids+=($!)
         done
     fi
 
@@ -458,11 +589,17 @@ run_parallel_scans() {
     for component in "${components[@]}"; do
         (
             print_info "[${component^}] Starting security scan..."
-            if run_security_scan "$component"; then
-                echo "0" > "${status_dir}/${component}.status"
+            # `|| rc=$?` rather than `if ...; then`: the exact return code is
+            # what distinguishes "scanned, findings" from "never scanned", and
+            # collapsing it to a boolean here is what threw that away.
+            rc=0
+            run_security_scan "$component" || rc=$?
+            echo "${rc}" > "${status_dir}/${component}.status"
+            if [ "${rc}" -eq 0 ]; then
                 print_success "[${component^}] Security scan completed"
+            elif [ "${rc}" -ge "${SCAN_EXIT_COULD_NOT_SCAN}" ]; then
+                print_error "[${component^}] Security scan could NOT RUN"
             else
-                echo "1" > "${status_dir}/${component}.status"
                 print_warning "[${component^}] Security scan had issues"
             fi
         ) 2>&1 | sed "s/^/[${component^}] /" &
@@ -471,32 +608,51 @@ run_parallel_scans() {
     # Wait for all scans to complete
     wait
 
-    # Check results
-    local all_passed=true
-    for component in "${components[@]}"; do
-        if [ -f "${status_dir}/${component}.status" ]; then
-            status=$(cat "${status_dir}/${component}.status")
-            if [ "$status" != "0" ]; then
-                all_passed=false
-            fi
-        fi
-    done
+    local verdict=0
+    evaluate_scan_statuses "${status_dir}" "${components[@]}" || verdict=$?
 
     # Cleanup
     rm -rf "${status_dir}"
 
-    if [ "$all_passed" = true ]; then
+    if [ "${verdict}" -eq 0 ]; then
         print_success "All security scans completed successfully!"
-    else
-        print_warning "Some security scans had issues (see above)"
+        return 0
     fi
+
+    if [ "${verdict}" -ge "${SCAN_EXIT_COULD_NOT_SCAN}" ]; then
+        # The summary must never be able to describe an unscanned component as a
+        # success, and "carry on quietly" is a form of describing it as one:
+        # main() would print "All builds completed successfully!" right after.
+        print_error "One or more components were NOT SCANNED — refusing to report success"
+        print_error "Nothing in this run establishes those images are clean"
+        return 1
+    fi
+
+    # Every component was scanned; at least one failed the caller's policy.
+    # A status of 1 is only ever written when FAIL_ON_SECURITY_ISSUES=true, so
+    # reaching here means the operator explicitly asked for this to be fatal.
+    print_error "Security findings were not tolerated (FAIL_ON_SECURITY_ISSUES=true)"
+    return 1
 }
 
 # Function to scan only (no build, pull latest and scan)
 scan_only() {
     print_info "Running security scan only (no build)..."
+
+    # Derived, not hardcoded. This used to read `backend frontend`, which meant
+    # `$0 scan` silently never looked at the docs image even though `$0 all`
+    # builds and publishes it (issue #681).
+    local components=()
+    if [ -f "./scripts/security-scan.sh" ]; then
+        mapfile -t components < <(./scripts/security-scan.sh list-components 2>/dev/null)
+    fi
+    if [ ${#components[@]} -eq 0 ]; then
+        print_error "Could not determine the scannable component list from security-scan.sh"
+        return 1
+    fi
+
     # Reuse run_parallel_scans which handles DB updates, parallel pulls, and parallel scans
-    run_parallel_scans "backend" "frontend"
+    run_parallel_scans "${components[@]}"
 }
 
 # Function to delete old partial version tags from Docker Hub
@@ -928,5 +1084,12 @@ main() {
     fi
 }
 
-# Run main function
-main
+# Run main function — but only when EXECUTED, not when sourced.
+#
+# Sourcing is how scripts/tests/test-scan-not-a-pass.sh exercises
+# run_security_scan / evaluate_scan_statuses / run_parallel_scans directly. The
+# alternative — driving those branches through a real build — needs Docker Hub
+# credentials and multi-gigabyte images, i.e. they would not be tested at all.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    main
+fi

--- a/scripts/release/50-scan.sh
+++ b/scripts/release/50-scan.sh
@@ -5,7 +5,13 @@
 # then `docker pull` of :latest, i.e. it scans the PREVIOUS release. That is
 # correct only after a push and actively wrong as a pre-push gate.
 #
-# Exit: 0 clean · 1 blocking findings
+# Exit: 0 clean · 1 blocking findings OR could-not-scan
+#
+# security-scan.sh distinguishes those two (1 = scanned with findings, 2 = never
+# scanned; issue #681). This stage deliberately maps both onto 1, because the
+# RELEASE runner's exit codes mean something else entirely — 2 there is "misuse"
+# and 3 is "precondition unmet". Both scan outcomes are gate failures, so they
+# get the gate-failure code, with the distinction carried in the message.
 
 set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -51,6 +57,11 @@ FAIL_ON_CRITICAL="${FAIL_ON_CRITICAL:-true}" \
 OUTPUT_DIR="$OUT_DIR" \
 IMAGE_TAG="$VERSION" \
     ./scripts/security-scan.sh all || rc=$?
+
+if (( rc >= 2 )); then
+    echo -e "${RED}scan could NOT RUN (security-scan.sh exit ${rc}) — this is not 'no findings'${NC}" >&2
+    rc=1
+fi
 
 # Assert the reports describe the image we meant to scan. Reading the tag back
 # out of the artifact is the only thing that would have caught the bug above --

--- a/scripts/security-scan.sh
+++ b/scripts/security-scan.sh
@@ -23,6 +23,47 @@ OUTPUT_DIR="${OUTPUT_DIR:-./security-reports}"
 SEVERITY_THRESHOLD="${SEVERITY_THRESHOLD:-MEDIUM}"
 FAIL_ON_CRITICAL="${FAIL_ON_CRITICAL:-true}"
 
+# Exit codes. THREE outcomes, not two (issue #681).
+#
+#   0  scanned, nothing blocking
+#   1  SCANNED, and the scan found something
+#   2  COULD NOT SCAN — unknown component, image unobtainable, or a sub-scan
+#      that died without recording a verdict
+#
+# 1 and 2 must never be collapsed into a single "non-zero" branch. Tolerating
+# findings is a policy choice a caller is entitled to make
+# (FAIL_ON_SECURITY_ISSUES); "we never looked" is not a choice anybody made, so
+# a caller cannot be allowed to wave it through with the same flag. Collapsing
+# them is exactly how an unscannable component produced
+# "All security scans completed successfully!".
+readonly EXIT_FINDINGS=1
+readonly EXIT_COULD_NOT_SCAN=2
+
+# The ONE place that says what this script can scan (issue #681).
+#
+# `docs` used to be built and published by docker-build-push.sh while that
+# script's registry-pull dispatch handled only backend and frontend, because the
+# component list existed in three places that were free to disagree. Everything
+# now derives from this table: scan_component's lookup, the `all` target, the
+# `list-components` command that docker-build-push.sh validates against, and the
+# usage text. Adding a component here is the whole change; forgetting to add one
+# is now a loud failure rather than a silent green scan.
+declare -A SCAN_COMPONENT_DOCKERFILE=(
+    [backend]="backend/Dockerfile.prod"
+    [frontend]="frontend/Dockerfile.prod"
+    [docs]="docs-site/Dockerfile"
+)
+declare -A SCAN_COMPONENT_REPO=(
+    [backend]="${REPO_BACKEND}"
+    [frontend]="${REPO_FRONTEND}"
+    [docs]="${REPO_DOCS}"
+)
+
+# Sorted, one per line — the machine-readable contract other scripts consume.
+scan_components() {
+    printf '%s\n' "${!SCAN_COMPONENT_DOCKERFILE[@]}" | sort
+}
+
 # Create output directory
 mkdir -p "${OUTPUT_DIR}"
 
@@ -342,24 +383,16 @@ scan_component() {
     # .claude/commands/release.md should pass IMAGE_TAG=X.Y.Z.
     local tag="${IMAGE_TAG:-latest}"
 
-    case "${component}" in
-        backend)
-            dockerfile="backend/Dockerfile.prod"
-            image="${REPO_BACKEND}:${tag}"
-            ;;
-        frontend)
-            dockerfile="frontend/Dockerfile.prod"
-            image="${REPO_FRONTEND}:${tag}"
-            ;;
-        docs)
-            dockerfile="docs-site/Dockerfile"
-            image="${REPO_DOCS}:${tag}"
-            ;;
-        *)
-            print_error "Invalid component: ${component}"
-            return 1
-            ;;
-    esac
+    dockerfile="${SCAN_COMPONENT_DOCKERFILE[${component}]:-}"
+    local repo="${SCAN_COMPONENT_REPO[${component}]:-}"
+    if [ -z "${dockerfile}" ] || [ -z "${repo}" ]; then
+        print_error "Invalid component: ${component}"
+        print_error "Known components: $(scan_components | tr '\n' ' ')"
+        # NOT ${EXIT_FINDINGS}: nothing was examined, so there is no finding to
+        # tolerate. See the exit-code block at the top of this file.
+        return "${EXIT_COULD_NOT_SCAN}"
+    fi
+    image="${repo}:${tag}"
 
     print_header "Security Scanning: ${component}"
     print_info "Image: ${image}"
@@ -373,7 +406,8 @@ scan_component() {
         print_info "Attempting to pull from registry..."
         if ! docker pull "${image}"; then
             print_error "Failed to pull image. Please build it first."
-            return 1
+            # There is no image, so there is nothing to have findings about.
+            return "${EXIT_COULD_NOT_SCAN}"
         fi
     fi
 
@@ -457,6 +491,11 @@ scan_component() {
     # "we have no idea what that scanner found" must never read as "clean". This
     # previously fell through the `if [ -f ... ]` and scored as success, which is
     # what let a dead scanner silently pass the gate.
+    #
+    # It is also not the same thing as a finding, so it returns
+    # EXIT_COULD_NOT_SCAN rather than EXIT_FINDINGS: a caller running with
+    # FAIL_ON_SECURITY_ISSUES=false is saying "known CVEs are acceptable to me
+    # today", not "a scanner that never ran is acceptable to me today".
     local exit_code=0
     for tool in hadolint dockle sbom trivy grype; do
         if [ -f "${status_dir}/${tool}.status" ]; then
@@ -464,11 +503,13 @@ scan_component() {
             status=$(cat "${status_dir}/${tool}.status")
             if [ "$status" != "0" ]; then
                 print_warning "${component}: ${tool} reported status ${status}"
-                exit_code=1
+                if [ "${exit_code}" -eq 0 ]; then
+                    exit_code="${EXIT_FINDINGS}"
+                fi
             fi
         else
-            print_error "${component}: ${tool} produced no status — treating as FAILED"
-            exit_code=1
+            print_error "${component}: ${tool} produced no status — NOT SCANNED, not a pass"
+            exit_code="${EXIT_COULD_NOT_SCAN}"
         fi
     done
 
@@ -476,13 +517,15 @@ scan_component() {
     rm -rf "${status_dir}"
 
     echo ""
-    if [ ${exit_code} -eq 0 ]; then
+    if [ "${exit_code}" -eq 0 ]; then
         print_success "Security scan completed for ${component}"
+    elif [ "${exit_code}" -ge "${EXIT_COULD_NOT_SCAN}" ]; then
+        print_error "Security scan could NOT be completed for ${component}"
     else
         print_warning "Security scan completed with issues for ${component}"
     fi
 
-    return ${exit_code}
+    return "${exit_code}"
 }
 
 # Function to generate summary report
@@ -520,12 +563,22 @@ Tools used:
   - Grype: Fast vulnerability scanner
 
 Options:
-    backend     Scan only backend image
-    frontend    Scan only frontend image
-    docs        Scan only docs image
-    all         Scan all images (default)
-    install     Install all required tools
-    help        Show this help message
+    backend          Scan only backend image
+    frontend         Scan only frontend image
+    docs             Scan only docs image
+    all              Scan all images (default)
+    list-components  Print the scannable component names, one per line
+    install          Install all required tools
+    help             Show this help message
+
+Exit codes:
+    0   scanned; nothing blocking
+    1   SCANNED, and the scan found something
+    2   COULD NOT SCAN (unknown component, image unobtainable, or a sub-scan
+        that died without recording a verdict)
+
+    1 and 2 are deliberately distinct. A caller may choose to tolerate findings;
+    no caller may tolerate never having looked. Do not collapse them.
 
 Environment Variables:
     OUTPUT_DIR              Report output directory (default: ./security-reports)
@@ -584,6 +637,16 @@ install_all_tools() {
 
 # Main function
 main() {
+    # Answer the machine-readable query BEFORE any banner output. This is a
+    # contract docker-build-push.sh parses to derive its component list, and a
+    # decorative header on stdout corrupts it — which is not a hypothetical: the
+    # first version of this handled list-components as an ordinary case arm and
+    # returned the banner plus the list.
+    if [ "${SCAN_TARGET}" = "list-components" ]; then
+        scan_components
+        exit 0
+    fi
+
     print_header "OpenTranscribe Security Scanner"
     print_info "Output directory: ${OUTPUT_DIR}"
     print_info "Severity threshold: ${SEVERITY_THRESHOLD}"
@@ -599,17 +662,6 @@ main() {
             show_usage
             exit 0
             ;;
-        backend|frontend|docs)
-            # Check required tools
-            install_trivy
-            install_grype
-            install_syft
-            install_hadolint
-            check_dockle
-
-            scan_component "${SCAN_TARGET}"
-            exit_code=$?
-            ;;
         all)
             # Check required tools
             install_trivy
@@ -618,58 +670,85 @@ main() {
             install_hadolint
             check_dockle
 
-            # Run the three component scans in parallel so total wall time
-            # is roughly max(backend, frontend, docs) instead of the sum.
-            # Each sub-scan logs independently to the same OUTPUT_DIR with
-            # unique per-component filenames so there is no contention.
-            print_info "Running backend, frontend, and docs scans in parallel..."
-            local backend_log="${OUTPUT_DIR}/.scan-backend.log"
-            local frontend_log="${OUTPUT_DIR}/.scan-frontend.log"
-            local docs_log="${OUTPUT_DIR}/.scan-docs.log"
+            # Run the component scans in parallel so total wall time is roughly
+            # max(components) instead of the sum. Each sub-scan logs
+            # independently to the same OUTPUT_DIR with unique per-component
+            # filenames so there is no contention.
+            local all_components=()
+            mapfile -t all_components < <(scan_components)
+            print_info "Running ${all_components[*]} scans in parallel..."
 
-            ( scan_component "backend" > "${backend_log}" 2>&1 ) &
-            local backend_pid=$!
-            ( scan_component "frontend" > "${frontend_log}" 2>&1 ) &
-            local frontend_pid=$!
-            ( scan_component "docs" > "${docs_log}" 2>&1 ) &
-            local docs_pid=$!
+            local comp pids=() names=()
+            for comp in "${all_components[@]}"; do
+                ( scan_component "${comp}" > "${OUTPUT_DIR}/.scan-${comp}.log" 2>&1 ) &
+                pids+=($!)
+                names+=("${comp}")
+            done
 
-            wait "${backend_pid}"
-            backend_exit=$?
-            wait "${frontend_pid}"
-            frontend_exit=$?
-            wait "${docs_pid}"
-            docs_exit=$?
+            # `wait` must be in a `||` list: this script runs under `set -e`, so
+            # a bare `wait "$pid"` on a scan that found something aborts main on
+            # that line — skipping the log replay and the summary below.
+            local idx rc
+            exit_code=0
+            for idx in "${!pids[@]}"; do
+                rc=0
+                wait "${pids[$idx]}" || rc=$?
+                if [ "${rc}" -ge "${EXIT_COULD_NOT_SCAN}" ]; then
+                    exit_code="${EXIT_COULD_NOT_SCAN}"
+                elif [ "${rc}" -ne 0 ] && [ "${exit_code}" -eq 0 ]; then
+                    exit_code="${EXIT_FINDINGS}"
+                fi
+            done
 
-            # Replay each sub-scan's log in order so user sees normal output
-            print_info "=== backend scan output ==="
-            cat "${backend_log}"
-            print_info "=== frontend scan output ==="
-            cat "${frontend_log}"
-            print_info "=== docs scan output ==="
-            cat "${docs_log}"
-            rm -f "${backend_log}" "${frontend_log}" "${docs_log}"
-
-            exit_code=$((backend_exit + frontend_exit + docs_exit))
+            # Replay each sub-scan's log in order so user sees normal output.
+            for idx in "${!names[@]}"; do
+                print_info "=== ${names[$idx]} scan output ==="
+                cat "${OUTPUT_DIR}/.scan-${names[$idx]}.log"
+                rm -f "${OUTPUT_DIR}/.scan-${names[$idx]}.log"
+            done
             ;;
         *)
-            print_error "Invalid option: ${SCAN_TARGET}"
-            show_usage
-            exit 1
+            if ! scan_components | grep -Fqx -- "${SCAN_TARGET}"; then
+                print_error "Invalid option: ${SCAN_TARGET}"
+                show_usage
+                # Exit 2, not 1: a caller must be able to tell "this component
+                # was scanned and had findings" from "this component cannot be
+                # scanned at all". See the exit-code block at the top.
+                exit "${EXIT_COULD_NOT_SCAN}"
+            fi
+
+            # Check required tools
+            install_trivy
+            install_grype
+            install_syft
+            install_hadolint
+            check_dockle
+
+            exit_code=0
+            scan_component "${SCAN_TARGET}" || exit_code=$?
             ;;
     esac
 
     echo ""
     generate_summary
 
-    if [ ${exit_code} -eq 0 ]; then
+    if [ "${exit_code}" -eq 0 ]; then
         print_success "All security scans passed!"
         exit 0
+    elif [ "${exit_code}" -ge "${EXIT_COULD_NOT_SCAN}" ]; then
+        print_error "Security scans could NOT RUN — nothing here establishes these images are clean"
+        exit "${EXIT_COULD_NOT_SCAN}"
     else
         print_error "Security scans failed"
-        exit 1
+        exit "${EXIT_FINDINGS}"
     fi
 }
 
-# Run main function
-main
+# Run main function — but only when EXECUTED, not when sourced.
+#
+# Sourcing is how scripts/tests/test-scan-not-a-pass.sh exercises the `all`
+# aggregation (the path the release `scan` stage runs) with stubbed scanners:
+# doing it for real needs the three published multi-gigabyte images.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    main
+fi

--- a/scripts/tests/test-scan-not-a-pass.sh
+++ b/scripts/tests/test-scan-not-a-pass.sh
@@ -1,0 +1,427 @@
+#!/bin/bash
+# Regression test for issue #681 — "a component that was never scanned must never
+# read as a component that was scanned and found clean".
+#
+# The defect: scripts/docker-build-push.sh's run_security_scan collapsed TWO
+# different non-zero results from scripts/security-scan.sh into one branch —
+# "scanned, found tolerable CVEs" and "could not scan at all". With
+# FAIL_ON_SECURITY_ISSUES defaulting to false, an unscannable component returned
+# 0, its status file was written as 0, and the run ended with
+# "All security scans completed successfully!". `docs` was already in that state:
+# it was in BUILT_COMPONENTS and had a security-scan.sh arm, but the registry-pull
+# dispatch handled only backend and frontend, so the default path scanned it
+# against an image it never fetched.
+#
+# WHY THIS TEST IS SHAPED LIKE THIS
+#
+# None of these paths can be reached through a real build: that needs Docker Hub
+# credentials and multi-gigabyte images, so in practice they would not be tested
+# at all. Instead the test SOURCES docker-build-push.sh (which is why that script
+# now guards its `main` call with a BASH_SOURCE check) and drives the three
+# functions that own the decision directly:
+#
+#   run_security_scan       — does it distinguish the two failures?
+#   evaluate_scan_statuses  — does the collector distinguish them?
+#   run_parallel_scans      — can the SUMMARY still claim success?
+#
+# Two of the cases invoke the real security-scan.sh with a real unknown component
+# name; the rest use a throwaway scanner stub with a chosen exit code, so the
+# caller's branching is tested independently of the scanner's.
+#
+# Every case is either a MUST-FIRE (the defect must make it fail) or a
+# MUST-STAY-CLEAN (correct behaviour must not be broken by the fix). A gate that
+# only ever fails is as useless as one that only ever passes.
+#
+# No Docker, no network, no images, no built artifacts.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BUILD_SCRIPT="$REPO_ROOT/scripts/docker-build-push.sh"
+
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+REPORTS_DIR="$TMP_ROOT/reports"
+DOCKER_LOG="$TMP_ROOT/docker.log"
+: > "$DOCKER_LOG"
+
+pass=0
+fail=0
+ok() { echo "  ok   - $1"; pass=$((pass + 1)); }
+bad() { echo "  FAIL - $1"; fail=$((fail + 1)); }
+
+# Run a case function with docker-build-push.sh sourced, in an isolated subshell.
+#
+# Two stubs, both for things that are NOT under test here and that would
+# otherwise reach the outside world: the vulnerability-database refresh (a
+# multi-minute network download when trivy/grype are installed) and `docker`
+# itself, which is replaced by a logger so the pull dispatch can be asserted on
+# without pulling anything. `docker` is a shell function, so it is deliberately
+# invisible to security-scan.sh, which runs as a child process.
+lib_run() {
+    local fn="$1"
+    (
+        set +u  # neither script under test runs with `set -u`
+        cd "$REPO_ROOT" || exit 99
+        # shellcheck source=/dev/null
+        . "$BUILD_SCRIPT"
+        update_security_tools() { print_info "[stub] vulnerability DB update skipped"; }
+        docker() { echo "docker $*" >> "$DOCKER_LOG"; return 0; }
+        "$fn"
+    )
+}
+
+# Write a throwaway scripts/security-scan.sh that exits with a chosen code, and
+# echo the sandbox directory. run_security_scan resolves the scanner relative to
+# cwd, so a case can cd here to control exactly what the scanner reports.
+make_scanner_sandbox() {
+    local name="$1" exit_code="$2"
+    local sandbox="$TMP_ROOT/$name"
+    rm -rf "$sandbox"
+    mkdir -p "$sandbox/scripts"
+    printf '#!/bin/bash\nexit %s\n' "$exit_code" > "$sandbox/scripts/security-scan.sh"
+    chmod +x "$sandbox/scripts/security-scan.sh"
+    echo "$sandbox"
+}
+
+echo "== security-scan.sh: exit codes distinguish 'found something' from 'never looked' =="
+
+# MUST-FIRE. Before the fix this exited 1 — the same code as "scanned, has
+# findings" — which is what made the two indistinguishable to every caller.
+rc=0
+( cd "$REPO_ROOT" && OUTPUT_DIR="$REPORTS_DIR" ./scripts/security-scan.sh lite ) \
+    > "$TMP_ROOT/scan-lite.out" 2>&1 || rc=$?
+if [ "$rc" -eq 2 ]; then
+    ok "an unknown component exits 2 (could not scan), not 1 (findings)"
+else
+    bad "an unknown component exited $rc; expected 2 (could not scan)"
+fi
+
+# MUST-STAY-CLEAN: the machine-readable component contract other scripts derive
+# their lists from must actually list the three published images.
+known="$( (cd "$REPO_ROOT" && OUTPUT_DIR="$REPORTS_DIR" ./scripts/security-scan.sh list-components 2>/dev/null) | tr '\n' ' ')"
+if [ "$known" = "backend docs frontend " ]; then
+    ok "list-components reports the published components: ${known% }"
+else
+    bad "list-components reported '${known:0:120}'; expected 'backend docs frontend '"
+fi
+
+echo "== run_security_scan: the policy flag tolerates findings, never the absence of a scan =="
+
+# MUST-FIRE. This is the defect itself: FAIL_ON_SECURITY_ISSUES=false (the
+# default) used to turn "this component cannot be scanned" into a return of 0.
+case_unscannable_component_is_fatal() {
+    export FAIL_ON_SECURITY_ISSUES=false
+    export SKIP_SECURITY_SCAN=false
+    local rc=0
+    OUTPUT_DIR="$REPORTS_DIR" run_security_scan lite > "$TMP_ROOT/rss-lite.out" 2>&1 || rc=$?
+    return "$rc"
+}
+rc=0
+lib_run case_unscannable_component_is_fatal || rc=$?
+if [ "$rc" -eq 2 ]; then
+    ok "an unscannable component is fatal even with FAIL_ON_SECURITY_ISSUES=false (rc=$rc)"
+else
+    bad "an unscannable component returned $rc with FAIL_ON_SECURITY_ISSUES=false; expected 2"
+fi
+
+# MUST-FIRE, scanner-independent: a scanner exit of 2 must not be readable as a
+# finding regardless of what the real security-scan.sh does.
+case_scanner_exit_2_is_fatal() {
+    local sandbox
+    sandbox="$(make_scanner_sandbox sandbox-cannot-scan 2)"
+    cd "$sandbox" || return 99
+    export FAIL_ON_SECURITY_ISSUES=false
+    export SKIP_SECURITY_SCAN=false
+    local rc=0
+    run_security_scan backend > /dev/null 2>&1 || rc=$?
+    return "$rc"
+}
+rc=0
+lib_run case_scanner_exit_2_is_fatal || rc=$?
+if [ "$rc" -eq 2 ]; then
+    ok "a scanner exit of 2 stays fatal under FAIL_ON_SECURITY_ISSUES=false (rc=$rc)"
+else
+    bad "a scanner exit of 2 returned $rc under FAIL_ON_SECURITY_ISSUES=false; expected 2"
+fi
+
+# MUST-STAY-CLEAN: tolerating FINDINGS is a legitimate policy choice and the fix
+# must not have taken it away.
+case_findings_still_tolerated() {
+    local sandbox
+    sandbox="$(make_scanner_sandbox sandbox-findings 1)"
+    cd "$sandbox" || return 99
+    export FAIL_ON_SECURITY_ISSUES=false
+    export SKIP_SECURITY_SCAN=false
+    local rc=0
+    run_security_scan backend > /dev/null 2>&1 || rc=$?
+    return "$rc"
+}
+rc=0
+lib_run case_findings_still_tolerated || rc=$?
+if [ "$rc" -eq 0 ]; then
+    ok "findings are still tolerated when FAIL_ON_SECURITY_ISSUES=false"
+else
+    bad "findings returned $rc under FAIL_ON_SECURITY_ISSUES=false; expected 0"
+fi
+
+# MUST-STAY-CLEAN: ...and still refused when the operator asks for that.
+case_findings_refused_when_asked() {
+    local sandbox
+    sandbox="$(make_scanner_sandbox sandbox-findings-strict 1)"
+    cd "$sandbox" || return 99
+    export FAIL_ON_SECURITY_ISSUES=true
+    export SKIP_SECURITY_SCAN=false
+    local rc=0
+    run_security_scan backend > /dev/null 2>&1 || rc=$?
+    return "$rc"
+}
+rc=0
+lib_run case_findings_refused_when_asked || rc=$?
+if [ "$rc" -eq 1 ]; then
+    ok "findings are refused when FAIL_ON_SECURITY_ISSUES=true"
+else
+    bad "findings returned $rc under FAIL_ON_SECURITY_ISSUES=true; expected 1"
+fi
+
+echo "== evaluate_scan_statuses: three outcomes, not two =="
+
+make_status_dir() {
+    local name="$1"
+    local dir="$TMP_ROOT/$name"
+    rm -rf "$dir"
+    mkdir -p "$dir"
+    echo "$dir"
+}
+
+# MUST-STAY-CLEAN
+case_eval_all_clean() {
+    local d
+    d="$(make_status_dir st-clean)"
+    echo 0 > "$d/backend.status"
+    echo 0 > "$d/docs.status"
+    local rc=0
+    evaluate_scan_statuses "$d" backend docs > /dev/null 2>&1 || rc=$?
+    return "$rc"
+}
+rc=0
+lib_run case_eval_all_clean || rc=$?
+if [ "$rc" -eq 0 ]; then
+    ok "all-clean statuses evaluate to 0"
+else
+    bad "all-clean statuses evaluated to $rc; expected 0"
+fi
+
+# MUST-FIRE
+case_eval_findings() {
+    local d
+    d="$(make_status_dir st-findings)"
+    echo 0 > "$d/backend.status"
+    echo 1 > "$d/docs.status"
+    local rc=0
+    evaluate_scan_statuses "$d" backend docs > /dev/null 2>&1 || rc=$?
+    return "$rc"
+}
+rc=0
+lib_run case_eval_findings || rc=$?
+if [ "$rc" -eq 1 ]; then
+    ok "a findings status evaluates to 1 (scanned, has findings)"
+else
+    bad "a findings status evaluated to $rc; expected 1"
+fi
+
+# MUST-FIRE — the missing-file arm. This is the case that costs nothing to hit
+# in production (a subshell killed before it writes) and that previously left
+# all_passed untouched, i.e. scored as a pass.
+case_eval_missing_status() {
+    local d
+    d="$(make_status_dir st-missing)"
+    echo 0 > "$d/backend.status"
+    # docs.status deliberately absent
+    local rc=0
+    evaluate_scan_statuses "$d" backend docs > /dev/null 2>&1 || rc=$?
+    return "$rc"
+}
+rc=0
+lib_run case_eval_missing_status || rc=$?
+if [ "$rc" -eq 2 ]; then
+    ok "a MISSING status file evaluates to 'not scanned' (rc=$rc)"
+else
+    bad "a missing status file evaluated to $rc; expected 2"
+fi
+
+# MUST-FIRE
+case_eval_could_not_scan_status() {
+    local d
+    d="$(make_status_dir st-cannot)"
+    echo 0 > "$d/backend.status"
+    echo 2 > "$d/docs.status"
+    local rc=0
+    evaluate_scan_statuses "$d" backend docs > /dev/null 2>&1 || rc=$?
+    return "$rc"
+}
+rc=0
+lib_run case_eval_could_not_scan_status || rc=$?
+if [ "$rc" -eq 2 ]; then
+    ok "a could-not-scan status evaluates to 'not scanned' (rc=$rc)"
+else
+    bad "a could-not-scan status evaluated to $rc; expected 2"
+fi
+
+echo "== run_parallel_scans: the summary cannot claim success for an unscanned component =="
+
+SUCCESS_BANNER="All security scans completed successfully!"
+
+# MUST-FIRE. The headline symptom of #681, end to end.
+case_parallel_unscannable_component() {
+    export SKIP_SECURITY_SCAN=false
+    export FAIL_ON_SECURITY_ISSUES=false
+    local rc=0
+    run_parallel_scans lite > "$TMP_ROOT/parallel-lite.out" 2>&1 || rc=$?
+    return "$rc"
+}
+rc=0
+lib_run case_parallel_unscannable_component || rc=$?
+if [ "$rc" -ne 0 ]; then
+    ok "run_parallel_scans fails for a component that cannot be scanned (rc=$rc)"
+else
+    bad "run_parallel_scans returned 0 for a component that cannot be scanned"
+fi
+if grep -qF "$SUCCESS_BANNER" "$TMP_ROOT/parallel-lite.out"; then
+    bad "the summary printed '$SUCCESS_BANNER' for a component that was never scanned"
+else
+    ok "the summary does NOT claim success for a component that was never scanned"
+fi
+
+# MUST-FIRE — the second, independent gap in the same function: the registry-pull
+# dispatch handled only backend and frontend, so docs was scanned against an
+# image that was never fetched.
+case_docs_is_pulled_from_the_registry() {
+    : > "$DOCKER_LOG"
+    export SKIP_SECURITY_SCAN=false
+    run_security_scan() { return 0; }  # not what this case is about
+    local rc=0
+    run_parallel_scans docs > "$TMP_ROOT/parallel-docs.out" 2>&1 || rc=$?
+    return "$rc"
+}
+rc=0
+lib_run case_docs_is_pulled_from_the_registry || rc=$?
+if grep -q 'pull .*opentranscribe-docs:latest' "$DOCKER_LOG"; then
+    ok "the docs image is pulled from the registry before being scanned"
+else
+    bad "the docs image was never pulled — it would be scanned against a stale or absent local image"
+fi
+
+# MUST-FIRE — defence in depth: even if the up-front component validation is
+# bypassed, the pull dispatch itself must refuse an unknown component rather
+# than silently skipping the pull.
+case_pull_dispatch_refuses_unknown() {
+    : > "$DOCKER_LOG"
+    export SKIP_SECURITY_SCAN=false
+    assert_components_scannable() { return 0; }  # bypass the earlier guard
+    run_security_scan() { return 0; }
+    local rc=0
+    run_parallel_scans lite > "$TMP_ROOT/parallel-nopull.out" 2>&1 || rc=$?
+    return "$rc"
+}
+rc=0
+lib_run case_pull_dispatch_refuses_unknown || rc=$?
+if [ "$rc" -ne 0 ] && grep -q 'No registry-pull rule' "$TMP_ROOT/parallel-nopull.out"; then
+    ok "the registry-pull dispatch refuses a component it has no rule for"
+else
+    bad "the pull dispatch silently skipped an unknown component (rc=$rc)"
+fi
+
+# MUST-STAY-CLEAN: a genuinely clean run still reports success. Without this the
+# suite could be satisfied by a summary that never says anything good.
+case_parallel_all_clean_reports_success() {
+    : > "$DOCKER_LOG"
+    export SKIP_SECURITY_SCAN=false
+    run_security_scan() { return 0; }
+    local rc=0
+    run_parallel_scans backend frontend docs > "$TMP_ROOT/parallel-clean.out" 2>&1 || rc=$?
+    return "$rc"
+}
+rc=0
+lib_run case_parallel_all_clean_reports_success || rc=$?
+if [ "$rc" -eq 0 ] && grep -qF "$SUCCESS_BANNER" "$TMP_ROOT/parallel-clean.out"; then
+    ok "a genuinely clean run still reports success"
+else
+    bad "a clean run did not report success (rc=$rc)"
+fi
+
+echo "== security-scan.sh 'all': one unscannable component poisons the whole verdict =="
+
+# The `all` target is what the release scan gate (scripts/release/50-scan.sh)
+# runs. Its aggregation used to be `backend_exit + frontend_exit + docs_exit` —
+# a SUM, which cannot express three outcomes, and which the old flat
+# `exit 0 / exit 1` ending then flattened again. Measured against the
+# pre-fix code: the unscannable case below exits 1, indistinguishable from
+# findings. The clean and findings cases already behaved correctly and are here
+# as regression guards on the restructure, not as evidence of the bug.
+# All of them use stubbed scanners; doing it for real needs the three published
+# multi-gigabyte images.
+#
+# $1 = per-component exit code, as "component:code" pairs; anything unlisted is 0.
+scan_all_with() {
+    local spec="$1" out="$2"
+    (
+        set +u
+        cd "$REPO_ROOT" || exit 99
+        export OUTPUT_DIR="$TMP_ROOT/all-reports"
+        # shellcheck source=/dev/null
+        . "$REPO_ROOT/scripts/security-scan.sh" all
+        install_trivy() { :; }
+        install_grype() { :; }
+        install_syft() { :; }
+        install_hadolint() { :; }
+        check_dockle() { :; }
+        generate_summary() { :; }
+        scan_component() {
+            local want
+            for want in ${spec}; do
+                if [ "${want%%:*}" = "$1" ]; then
+                    return "${want##*:}"
+                fi
+            done
+            return 0
+        }
+        main
+    ) > "$out" 2>&1
+}
+
+rc=0
+scan_all_with "" "$TMP_ROOT/all-clean.out" || rc=$?
+if [ "$rc" -eq 0 ]; then
+    ok "'all' with every component clean exits 0"
+else
+    bad "'all' with every component clean exited $rc; expected 0"
+fi
+
+rc=0
+scan_all_with "backend:1 frontend:1" "$TMP_ROOT/all-findings.out" || rc=$?
+if [ "$rc" -eq 1 ]; then
+    ok "'all' with findings in two components exits 1, not 2 (no summing)"
+else
+    bad "'all' with findings in two components exited $rc; expected 1"
+fi
+
+rc=0
+scan_all_with "docs:2" "$TMP_ROOT/all-cannot.out" || rc=$?
+if [ "$rc" -eq 2 ]; then
+    ok "'all' with one unscannable component exits 2 (could not scan)"
+else
+    bad "'all' with one unscannable component exited $rc; expected 2"
+fi
+
+if grep -qF "All security scans passed!" "$TMP_ROOT/all-cannot.out"; then
+    bad "'all' claimed the scans passed while one component was never scanned"
+else
+    ok "'all' does not claim the scans passed when a component was never scanned"
+fi
+
+echo ""
+echo "passed: $pass   failed: $fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Nine small, independently-scoped fixes for the v0.5.0 push, each built in its own worktree and merged here as one commit per issue.

## What's in it

| Commit | Issue | What |
|---|---|---|
| `1ac75cea` | #662 | `.env.example` no longer pins the diar-native sidecar to bare GPU 0 |
| `53e51a45` | #686 | Docs badge reads `-dev` when `VERSION` is ahead of the newest release tag |
| `f81bba4f` | #671 | `transcription/` + `diarization/` CLAUDE.md rewritten around native-first diarization |
| `9135f5c8` | #681 | An unscanned component can no longer report a passing security scan |
| `225ecdd9` | #688 | Pre-commit gate tiered; **CI now runs both tiers** |
| `a8d3f65c` | #674 | Speaker auto-accept gate applied in raw-cosine space, not cosinesimil |
| `532cbe91` | #627 | Admin "Reindex all" covers the whole corpus, not just the caller's files |
| `beed4e3b` | #664 | Retention sweep and `purge_media_file` refuse a file under legal hold |
| `336331b9` | #675 | Speaker-profile rename propagates into `transcript_chunks` |
| `ec64d5b5` | — | Retrack the `min_permission` site moved by #664 (found by the integration run) |

## Verification

- **Commit-stage gate**: green, 3m05s
- **Pre-push gate** (vite build + `bandit -r backend/`): green, 1m58s
- **Backend suite**: **12,360 passed, 0 failures, 0 errors**, 226 skipped, 167.5s

The suite was run against a throwaway Postgres migrated to `v393` (the dev stack's head), with `SKIP_S3`/`SKIP_OPENSEARCH` set. **Stated gap:** OpenSearch- and MinIO-backed tests were skipped, so end-to-end index behaviour for #627/#674/#675 is not covered here — their own tests are unit/API-level with the Celery dispatch mocked and all pass. E2E was not run.

Every code lane watched its tests fail before the fix (`git archive HEAD` trees, so nothing was swapped in the shared checkout) and reports the red output in its commit body.

## Three lanes changed the shape of their own issue

- **#675** — the issue's suggested fix would have been **worse than a no-op**. `SpeakerProfile.name` is never indexed into `transcript_chunks`; per-file `Speaker.display_name` is, and shadows it. Dispatching propagation alone would have written the new name into OpenSearch while Postgres still held the old one, and the next reindex would silently revert it. The fix rewrites members and dispatches as one unit.
- **#627** — `POST /search/reindex` **is** admin-gated on master (`search.py:483`), verified against master rather than the branch. So widening it to the corpus did not turn a scoping bug into a privilege problem, and no auth change was needed.
- **#674** — the repo-wide cosine invariant covered score *reads* only. All 12 threshold *write* sites were audited; exactly one was wrong. Both directions are now named functions in `app/utils/cosine_space.py`, and the invariant in `CLAUDE.md` covers writes.

## Behaviour changes worth knowing before merging

- **#681 makes the release scan stricter.** `FAIL_ON_SECURITY_ISSUES=true` now actually fails the build (it previously warned and returned 0 — the flag never fired end-to-end), `scan` now covers the `docs` image, and a missing `security-scan.sh` is fatal rather than a silent skip. **Expect the scan stage to fail where it previously passed.**
- **#688 changes the local gate.** `pre-commit run --all-files` with no `--hook-stage` now runs the commit tier only. After merging, run **`pre-commit install --install-hooks` once, in the main checkout only** — never from a worktree, where `.git/hooks` resolves to the shared common dir. `backend/tests/unit/test_precommit_stage_ci_parity.py` fails if a hook ever sits in a stage CI does not invoke (verified falsifiable by mutation: removing the CI step fails 2 of its 3 tests).

## Follow-ups filed

#689 (P1, admin user-deletion bypasses legal hold) · #690 · #691 · #692 · **#693 (P0 — the backend suite destroys a live dev stack; hit during this work)**

Closes #662, #686, #671, #681, #674, #627, #664, #675. Refs #688 (Finding 4 still open).
