### PR TITLE
chore(diar): bump the diar-native pin to 0.3.1

### DIFF
--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -16,8 +16,9 @@ FROM denoland/deno:bin AS deno-bin
 # `command:` override — see that file for why (warm ORT arena must survive worker
 # restarts, and gpu-scale runs N workers per container which makes a per-worker sidecar
 # ambiguous). Only ~419 MB of the standalone 3.46 GB image is actually needed: the
-# binary, three ORT libs (see the exclusion note below), and libopenblas0.
-FROM davidamacey/diar-native@sha256:544a6a6536464729834dd1b51dc6d76b538776da23a22682501f220cf2ff999c AS diar-native-bin
+# binary, three ORT libs (see the exclusion note below), and libopenblas0. The standalone image
+# is 2.9 GB as of diar-native 0.3.1.
+FROM davidamacey/diar-native@sha256:1a8e1491bc12bb0f2c202dece3e5902b080dc6e432e22c64686d63f61c37228f AS diar-native-bin
 
 # -----------------------------------------------------------------------------
 # Stage 1: Build Stage - Install Python dependencies with compilation

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -18,7 +18,7 @@ FROM denoland/deno:bin AS deno-bin
 # ambiguous). Only ~419 MB of the standalone 3.46 GB image is actually needed: the
 # binary, three ORT libs (see the exclusion note below), and libopenblas0. The standalone image
 # is 2.9 GB as of diar-native 0.3.1.
-FROM davidamacey/diar-native@sha256:1a8e1491bc12bb0f2c202dece3e5902b080dc6e432e22c64686d63f61c37228f AS diar-native-bin
+FROM davidamacey/diar-native@sha256:83a709be94d0ca06441fa10aea0680f53b03cc10eb3ce11c4eeb84478400567d AS diar-native-bin
 
 # -----------------------------------------------------------------------------
 # Stage 1: Build Stage - Install Python dependencies with compilation


### PR DESCRIPTION
Moves `backend/Dockerfile.prod`'s build stage from the 0.2.0-era binary to **diar-native 0.3.1**.

> **Read this as a 0.2.0 to 0.3.1 upgrade, not a patch bump.** The title says 0.3.1 because that is the version being pinned, but the pin it replaces is **0.2.0**. This crosses 0.3.0, which has a Breaking / upgrade-notes section. Those notes are the reason this is safe rather than merely small, so do not skip them on the assumption that a `chore` + patch version implies a trivial change.

Nothing from diar-native 0.3.0 or 0.3.1 reaches production until this digest moves, so this one line is what actually ships two releases of upstream work.

```
- FROM davidamacey/diar-native@sha256:544a6a65...  (0.2.0)
+ FROM davidamacey/diar-native@sha256:83a709be...  (0.3.1)
```

### Every 0.3.0 breaking note, checked against this repo's consumer code

| 0.3.0 breaking note | consumer here | verdict |
|---|---|---|
| `/healthz` body `ok` to JSON | `diarizer_native.py:91` and `:134` check `resp.status == 200` only; `docker-compose.diar-native.yml` uses `curl -sf` | safe |
| startup gate exit code 6 to 8 | no diar-server exit code is read anywhere in this repo | n/a |
| old servers silently ignore the new `device` field | we never send `device` | n/a |
| `DIAR_ORT_OPT_LEVEL` is now a floor, not an override | unset repo-wide, and the cap is arm64-only; hosts here are x86_64 | n/a |
| existing model dirs | report `stale` under `EXPORT_RECIPE_VERSION 2`; non-fatal, still serve, `/healthz` stays 200 | safe |

### The digest moved after this PR was opened

0.3.1 was rebuilt once the vendored speakrs pin was corrected to a real fork commit, so the published digest changed. The source did not: the patch regenerated byte-identically against the new pin, making it a provenance fix in the build inputs.

Both digests were then run side by side on GPU 0, same models directory, same request. The `/diarize` response is **byte-identical**: 7568 bytes, 2 speakers, 7 segments, 8 exclusive, same gender labels and confidences. The binaries differ by sha256 only because Rust release builds are not bit-reproducible.

## Diarization behaviour is unchanged

Same engine, same models, same accuracy gates. Upstream reverified DER independently on aarch64 and reproduced the logged baselines within **0.025 pp**:

| AMI-16 | measured | logged baseline |
|---|---|---|
| DER full | 13.126% | 13.102% |
| DER exclusive | 17.834% | 17.813% |

## Verified before pinning

All four paths the `COPY` lines below extract are present in the new image:

```
/usr/local/bin/diar-server                          0.3.1, 38.6 MB
/usr/local/lib/libonnxruntime.so.1.24.2
/usr/local/lib/libonnxruntime_providers_cuda.so
/usr/local/lib/libonnxruntime_providers_shared.so
```

## What this unlocks, none of it required by this PR

- **`provision-models`** — a self-hosted install can obtain and verify its own weights with the operator's own HuggingFace token (~484 MB, ~2 min, once, idempotent after that). This is the last blocker on #639.
- **`/readyz`** — 200 only when models are verified, so `sidecar_healthy()` can distinguish "still provisioning" from "broken". `/healthz` is unchanged and still returns 200 whenever the process is serving, so nothing here breaks today.

  Worth being explicit, because this bump turns a latent gap live: `/healthz` returns 200 in **every** model state by design, including unprovisioned and known-bad. `sidecar_healthy()` is exactly that check, and `ModelManager` uses its result to pick the native engine over the in-process PyAnnote fallback. So a sidecar whose models directory is unusable currently reads as healthy and gets selected anyway. That was theoretical before this PR because `/readyz` did not exist on our sidecar; after it, `/readyz` exists and we are not using it. Tracked in #679, not a blocker for this PR.
- **Per-request `device`** — embedding-only work can run on CPU in the same container (#584, #660). Gate on `/healthz` `supported_devices` before sending it: an older sidecar silently ignores the field and runs on CUDA.
- **Structured logs** — the sidecar previously emitted none at all, because it never installed a subscriber. `RUST_LOG` and `DIAR_LOG_FORMAT` now work, with per-request spans carrying request id, device and duration.

## Risk

Low. One line, same binary contract, no behaviour change. The sidecar still starts the same way (`command: ["diar-server"]`, no args) and the compose healthcheck still sees 200 from `/healthz` in every model state.

Worth knowing: the 0.3.1 image runs as **uid 10001** rather than root. This stage only `COPY --from`s files out of it, so that does not affect the resulting backend image.

Also corrects a stale comment: the standalone image is 2.9 GB, not 3.46 GB.

Upstream release: https://github.com/attevon-llc/diar-native/releases/tag/v0.3.1
