### PR TITLE
fix: follow-ups from the v0.5.0 cleanup batch (stack-destroying test, legal hold, cosine space, reindex cancel)

### DIFF
--- a/backend/app/api/endpoints/admin.py
+++ b/backend/app/api/endpoints/admin.py
@@ -460,8 +460,80 @@ def _delete_user_owned_records(db: Session, user_id: int) -> None:
         logger.info(f"Deleted {len(tag_ids)} tags for user {user_id}")
 
 
+def _assert_no_files_under_legal_hold(db: Session, user_id: int) -> None:
+    """Refuse to delete an account that still owns legally-held evidence (issue #689).
+
+    ``_delete_user_media_files`` ends in a **bulk** ``query(MediaFile).delete()``. A bulk
+    delete emits one statement, loads no instances, and consults no ``legal_hold`` — so
+    it does not reach ``file_cleanup_service.purge_media_file`` and inherits none of
+    #664's refusal. Deleting a user therefore destroyed their held files, object row and
+    all, which is the one failure mode a legal hold exists to prevent, and it is
+    irreversible.
+
+    **The whole deletion is refused, not just the held files.** Deleting everything
+    *except* them would leave ``media_file`` rows owned by an account that no longer
+    exists (``media_file.user_id`` is a plain ``NO ACTION`` FK, so the ``user`` delete
+    would then fail anyway, mid-cascade); silently reassigning them to another owner
+    would invent a retention policy nobody chose. Refusing matches what the GDPR path
+    already does by accident — ``gdpr_erasure_service`` skips held files, and that same
+    FK then keeps the account alive — and what ``purge_media_file`` now does on purpose.
+
+    ``is_quarantined`` is deliberately **not** part of this check, mirroring
+    ``purge_media_file``. Quarantine is a review state an admin legitimately ends by
+    deleting the offending upload — and deleting an abusive *account* is the commonest
+    reason to have quarantined its files in the first place, so blocking on it would
+    turn a takedown into a shield. Only the unattended retention sweep refuses to touch
+    a file under review (``tasks/cleanup._select_expired_files``).
+
+    There is deliberately **no override argument**: an argument that skips the guard is
+    the guard's own failure mode. The supported path is to lift the hold first —
+    ``takedown_service.release_file(..., clear_legal_hold=True)``, exposed as
+    ``POST /api/admin/files/{file_uuid}/release`` — and then delete the account.
+
+    Args:
+        db: Database session.
+        user_id: Internal id of the account being deleted.
+
+    Raises:
+        HTTPException: 409 ``FILE_UNDER_LEGAL_HOLD``, naming how many files are held,
+            when the account owns at least one.
+    """
+    from app.services.file_cleanup_service import LEGAL_HOLD_ERROR_CODE
+
+    held_count = (
+        db.query(func.count(MediaFile.id))
+        .filter(MediaFile.user_id == user_id, MediaFile.legal_hold.is_(True))
+        .scalar()
+    ) or 0
+    if not held_count:
+        return
+
+    noun = "file" if held_count == 1 else "files"
+    message = (
+        f"refused: this account owns {held_count} {noun} under an active legal hold "
+        "and cannot be deleted. Release the hold before deleting."
+    )
+    logger.error(f"user deletion: REFUSED to delete user {user_id} — {message}")
+    raise HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail={
+            "error": LEGAL_HOLD_ERROR_CODE,
+            "message": message,
+            "files_under_legal_hold": held_count,
+        },
+    )
+
+
 def _delete_user_media_files(db: Session, user_id: int) -> None:
     """Delete all media files and related records for a user.
+
+    **A user owning any file under an active legal hold is REFUSED before anything is
+    deleted** (:func:`_assert_no_files_under_legal_hold`, issue #689). The check runs
+    here as well as in each endpoint because a guard in one caller protects one caller;
+    the endpoints call it *first* so that the two earlier passes
+    (``_delete_user_owned_records``, ``_delete_user_speakers``) have not already
+    destroyed anything by the time the refusal is raised, and this call is the backstop
+    that a future caller inherits without having to remember.
 
     **Why the children are deleted by hand here.** ``MediaFile`` declares
     ``cascade="all, delete-orphan"`` on eight relationships, but four of the
@@ -493,7 +565,12 @@ def _delete_user_media_files(db: Session, user_id: int) -> None:
     Args:
         db: Database session
         user_id: ID of the user whose media files to delete
+
+    Raises:
+        HTTPException: 409 when the user owns a file under an active legal hold.
     """
+    _assert_no_files_under_legal_hold(db, user_id)
+
     media_ids = [
         row[0] for row in db.query(MediaFile.id).filter(MediaFile.user_id == user_id).all()
     ]
@@ -847,6 +924,11 @@ def delete_admin_user(
         from app.api.endpoints.users import _assert_not_last_super_admin
 
         _assert_not_last_super_admin(db, user, ROLE_USER)
+
+        # Legally-held evidence outranks the deletion, and the refusal has to land
+        # BEFORE the first of the three cascade passes: a partial destroy followed by a
+        # 409 is worse than either outcome on its own (issue #689).
+        _assert_no_files_under_legal_hold(db, int(user_id))
 
         # Capture what the audit record needs before the row is gone: after the commit
         # the ORM object is expired, so reading user.email would re-query a deleted row.

--- a/backend/app/api/endpoints/files/crud.py
+++ b/backend/app/api/endpoints/files/crud.py
@@ -1003,6 +1003,7 @@ def delete_media_file(
 
     # Delegate the actual destroy to the single canonical implementation so the
     # interactive, bulk, retention, and orphan-cleanup paths all behave identically.
+    from app.services.file_cleanup_service import LEGAL_HOLD_ERROR_CODE
     from app.services.file_cleanup_service import purge_media_file
 
     result = purge_media_file(db, db_file)
@@ -1013,7 +1014,7 @@ def delete_media_file(
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail={
-                "error": "FILE_UNDER_LEGAL_HOLD",
+                "error": LEGAL_HOLD_ERROR_CODE,
                 "message": result.get("error"),
                 "file_id": str(db_file.uuid),
             },

--- a/backend/app/api/endpoints/search.py
+++ b/backend/app/api/endpoints/search.py
@@ -21,12 +21,16 @@ from app.core.constants import SEARCH_DEFAULT_PAGE_SIZE
 from app.core.constants import SEARCH_MAX_PAGE_SIZE
 from app.core.constants import get_speaker_index
 from app.core.constants import get_speaker_index_v4
-from app.core.redis import get_redis
 from app.db.base import get_db
 from app.models.user import User
 from app.schemas.search import SEARCH_RESULT_TYPES
 from app.schemas.search import SetEmbeddingModelSchema
 from app.services.ingest_artifacts.index_mapping import chunk_plane_clause
+from app.services.search.reindex_cancel import LEGACY_CANCEL_VALUE
+from app.services.search.reindex_cancel import cancel_requested
+from app.services.search.reindex_cancel import clear_fanout
+from app.services.search.reindex_cancel import read_fanout
+from app.services.search.reindex_cancel import request_cancel
 
 logger = logging.getLogger(__name__)
 
@@ -561,8 +565,10 @@ def trigger_reindex(
 
     return {
         # The caller's own coordinator, because that is the run the panel's
-        # progress stream and `POST /reindex/stop` are keyed to. It is absent
-        # when a named-file scope contains nothing the caller owns.
+        # progress stream is keyed to. It is absent when a named-file scope
+        # contains nothing the caller owns. `POST /reindex/stop` is NOT keyed to
+        # it — it cancels every owner in the fan-out `dispatch_reindex_for_every_owner`
+        # recorded (#691).
         "task_id": task_ids.get(current_user.id),
         "status": "started",
         "message": (
@@ -577,41 +583,63 @@ def trigger_reindex(
 def stop_reindex(
     current_user: User = Depends(get_current_admin_user),
 ) -> dict[str, Any]:
-    """Request cancellation of the CALLER'S running reindex coordinator.
+    """Cancel the re-index run this admin started — **every owner's coordinator**.
 
-    Sets a Redis flag that the reindex task checks between files.
-    The task will stop after completing the current file and restore
-    normal index settings (refresh_interval).
+    ``POST /reindex`` fans out one coordinator per owner (#627); this used to set
+    a single ``reindex_cancel:{caller id}`` flag, and each coordinator reads the
+    flag belonging to the *file's* owner. So an admin could start a
+    deployment-wide re-embed and cancel only their own share of it, with every
+    other owner's coordinator running to completion (#691). It now enumerates the
+    owner set the dispatch recorded under ``reindex_fanout:{caller id}`` and flags
+    all of them, naming each coordinator's run id so a coordinator still sitting
+    in the broker queue can honour the stop instead of clearing it on entry.
+    ``services/search/reindex_cancel.py`` holds the mechanism and its rationale.
 
-    ⚠️ **Per-owner, and ``POST /reindex`` is now per-corpus** (#627). The cancel
-    flag is ``reindex_cancel:{user_id}`` and the coordinators are one per owner,
-    so this stops the caller's run only; the other owners' coordinators run to
-    completion. The message says so rather than claiming the whole fan-out
-    stopped. Cancelling the fan-out would mean persisting the dispatched owner
-    set, which nothing does today.
+    Scoped to **this admin's own run**, not to every reindex on the deployment: a
+    concurrent run another admin started, and the per-owner coordinators
+    ``search_index_maintenance`` dispatches on its own schedule, are left alone.
+    A caller whose own coordinator is running but belongs to no recorded fan-out
+    is still flagged, so a maintenance-dispatched run stays stoppable exactly as
+    it was.
+
+    Each flagged coordinator stops after its current file completes and restores
+    normal index settings (``refresh_interval``).
 
     Returns:
-        Dict with stop status.
+        Dict with the stop status and how many coordinators were signalled.
     """
     user_id = current_user.id
 
-    if not _check_reindex_task_active(user_id):
-        return {
-            "status": "not_running",
-            "message": "No reindex task is currently running.",
-        }
-
     try:
-        redis_client = get_redis()
-        redis_client.setex(f"reindex_cancel:{user_id}", 3600, "1")
+        dispatched = read_fanout(user_id)
+        targets = dict(dispatched)
+        if user_id not in targets and _check_reindex_task_active(user_id):
+            # A run this admin did not fan out: dispatched by
+            # `search_index_maintenance`, or started before the record existed.
+            # There is no run id to name, so the flag falls back to the legacy
+            # value — truthy for the batch workers of a coordinator that is
+            # already running, which is the only kind that can exist here.
+            targets[user_id] = LEGACY_CANCEL_VALUE
 
-        logger.info(f"Reindex stop requested for user {user_id}")
+        if not any(_check_reindex_task_active(uid) for uid in targets):
+            return {
+                "status": "not_running",
+                "message": "No reindex task is currently running.",
+            }
+
+        stopped = request_cancel(targets)
+        if dispatched:
+            clear_fanout(user_id)
+
+        logger.info(f"Reindex stop requested by user {user_id} for owner(s) {stopped}")
 
         return {
             "status": "stop_requested",
+            "stopped_users": len(stopped),
             "message": (
-                "Stop signal sent for your own re-index run; it will stop after the "
-                "current file completes. Other accounts' coordinators are unaffected."
+                f"Stop signal sent to {len(stopped)} re-index coordinator(s) — the whole "
+                f"run you started, not just your own files. Each stops after the file it "
+                f"is on completes."
             ),
         }
     except HTTPException:
@@ -627,26 +655,35 @@ def stop_reindex(
         ) from e
 
 
-def _check_reindex_task_active(user_id: int) -> bool:
-    """Check if a reindex task is currently active for this user.
+def _running_reindex_run_id(user_id: int) -> str | None:
+    """The coordinator task id currently holding ``reindex_lock:{user_id}``.
 
-    Uses the ``reindex_lock:{user_id}`` Redis key that the reindex task
-    itself sets on start (NX, 1-hour TTL) and clears on finish.
-    This is a sub-millisecond Redis GET — no Celery broadcast needed.
+    The lock's *value* is the run id (``reindex_task`` sets it NX with a 1-hour
+    TTL and releases it only if it still owns it), so one sub-millisecond GET
+    answers both "is a reindex running for this owner" and "which run is it" — no
+    Celery broadcast needed.
 
     Args:
-        user_id: The user ID to check for active reindex tasks.
+        user_id: The owner to check.
 
     Returns:
-        True if a reindex task is actively running for this user.
+        The run id, or ``None`` when no reindex is running for that owner.
     """
     try:
         from app.core.redis import get_redis
 
-        return bool(get_redis().exists(f"reindex_lock:{user_id}"))
+        value = get_redis().get(f"reindex_lock:{user_id}")
     except Exception as e:
         logger.debug(f"Could not check reindex lock: {e}")
-        return False
+        return None
+    if value is None:
+        return None
+    return value.decode() if isinstance(value, bytes) else str(value)
+
+
+def _check_reindex_task_active(user_id: int) -> bool:
+    """Whether a reindex coordinator is currently running for this user."""
+    return _running_reindex_run_id(user_id) is not None
 
 
 @router.get("/degraded-embeddings")
@@ -800,17 +837,14 @@ def reindex_status(
         except Exception as e:
             logger.exception(f"Error checking index status: {e}")
 
-    # Check if a reindex task is actively running for this user
-    in_progress = _check_reindex_task_active(current_user.id)
+    # Check if a reindex task is actively running for this user, and which run.
+    running_run_id = _running_reindex_run_id(current_user.id)
+    in_progress = running_run_id is not None
 
-    # Check if stop has been requested
-    stop_requested = False
-    if in_progress:
-        try:
-            redis_client = get_redis()
-            stop_requested = bool(redis_client.get(f"reindex_cancel:{current_user.id}"))
-        except Exception as e:
-            logger.debug(f"Could not check reindex cancellation flag: {e}")
+    # Check if stop has been requested — for THIS run. A flag naming a finished
+    # run would otherwise show the panel a stop that cannot apply to what is
+    # currently indexing (#691).
+    stop_requested = in_progress and cancel_requested(current_user.id, running_run_id)
 
     current_model, current_dimension = get_search_embedding_settings()
 

--- a/backend/app/api/endpoints/speaker_update.py
+++ b/backend/app/api/endpoints/speaker_update.py
@@ -40,7 +40,10 @@ def calculate_cosine_similarity(embedding1: np.ndarray, embedding2: np.ndarray) 
         embedding2 (np.ndarray): Second voice embedding vector.
 
     Returns:
-        float: Similarity score between 0 and 1, where 1 is identical voices.
+        float: Raw cosine similarity in ``[-1, 1]``, where 1 is identical
+            voices. Negatives are real and are not clamped away (issue #690);
+            every gate downstream sits well above 0, so a dissimilar pair is
+            rejected on its value rather than on a floor.
     """
     from app.services.similarity_service import SimilarityService
 

--- a/backend/app/api/endpoints/users.py
+++ b/backend/app/api/endpoints/users.py
@@ -664,11 +664,18 @@ def delete_user(
     deleted_snapshot = DeletedUser.of(user)
 
     # Use the comprehensive cleanup from the admin endpoint to avoid orphaned records.
+    from app.api.endpoints.admin import _assert_no_files_under_legal_hold
     from app.api.endpoints.admin import _delete_user_media_files
     from app.api.endpoints.admin import _delete_user_owned_records
     from app.api.endpoints.admin import _delete_user_speakers
 
     user_id = user.id
+
+    # Before the first pass, not inside the third: this handler has no savepoint, so a
+    # refusal raised after _delete_user_owned_records would leave the session holding
+    # deletes of rows the caller was told were not deleted (issue #689).
+    _assert_no_files_under_legal_hold(db, user_id)
+
     _delete_user_owned_records(db, user_id)
     _delete_user_speakers(db, user_id)
     _delete_user_media_files(db, user_id)

--- a/backend/app/services/file_cleanup_service.py
+++ b/backend/app/services/file_cleanup_service.py
@@ -28,6 +28,13 @@ LEGAL_HOLD_REFUSAL = (
     "Release the hold before deleting."
 )
 
+#: Machine-readable code every API surface answers with when a delete is declined
+#: because of an active legal hold — the single-file interactive delete
+#: (``api/endpoints/files/crud.delete_media_file``) and the whole-account delete
+#: (``api/endpoints/admin._assert_no_files_under_legal_hold``, issue #689) alike. One
+#: constant so a client handles one refusal rather than two spellings of it.
+LEGAL_HOLD_ERROR_CODE = "FILE_UNDER_LEGAL_HOLD"
+
 
 class FileCleanupService:
     """Service for automated file cleanup and recovery operations."""

--- a/backend/app/services/search/CLAUDE.md
+++ b/backend/app/services/search/CLAUDE.md
@@ -78,7 +78,8 @@ separate and lives in the `../opensearch_service/` package (alias `speakers` →
   mixed-index survey. `model_switch.py` — the whole model switch, shared by both
   endpoints, plus the ONE reindex fan-out loop. See "Switching the embedding model"
   below. `reindex_scope.py` — which owners and which of their files a reindex must
-  cover; see "A reindex is corpus-wide" below.
+  cover; `reindex_cancel.py` — the cancel flag's key shape, the fan-out record, and
+  why the flag names a run. See "A reindex is corpus-wide" below.
 
 ## Conventions / patterns
 
@@ -553,10 +554,43 @@ explicitly did nothing at all.
   per-user gate would trade a scoping bug for a privilege one;
   `test_reindex_is_refused_for_a_plain_user` carries the two-owner corpus fixture so a dropped
   gate shows up as dispatches for *other* owners, not merely a wrong status code.
-- **Not fixed, deliberately: `POST /search/reindex/stop` is still per-owner.** The cancel flag is
-  `reindex_cancel:{user_id}` and the caller can only flag their own coordinator; the endpoint's
-  message says so. Cancelling the whole fan-out needs the dispatched owner set persisted
-  somewhere, which nothing does today.
+- **`POST /search/reindex/stop` cancels the whole run it started** (#691). It was left per-owner
+  by #627 — the caller could only flag their own coordinator while the other owners' ran to
+  completion — because cancelling a fan-out needs the dispatched owner set and nothing persisted
+  it. `dispatch_reindex_for_every_owner` now writes its `{owner: task id}` mapping to
+  `reindex_fanout:{admin id}` as well as returning it, and `stop` flags every owner in it. See
+  the next section for the two properties that make that safe.
+
+## Cancelling a fan-out: the flag NAMES the run (#691)
+
+`reindex_cancel:{user_id}` used to hold `"1"`. It now holds **the coordinator task id being
+cancelled**, and that is not decoration — without it the fix does not work on the deployment
+shape it was written for.
+
+- ⚠️ **The coordinator that most needs to see the flag has not started yet.** The fan-out
+  dispatches the caller first, so with fewer workers than owners the caller's coordinator runs
+  while owners B..N sit in the broker queue. Every coordinator **clears** the cancel flag on
+  entry — a flag left by an *earlier* run would otherwise abort the next legitimate reindex after
+  its first file — so a flag carrying only `"1"` would be erased by the very coordinator it was
+  written for. Naming the run is what distinguishes "I was cancelled before I started" (abort,
+  release the lock, index nothing) from "someone else's flag is lying around" (clear it and
+  proceed). `reindex_cancel.consume_pending_cancel` is that single decision, called once at
+  coordinator entry in place of the old unconditional clear.
+- **A second run started while one is cancelling is unaffected, by construction.** Its
+  coordinators carry fresh task ids, so the first run's flags read as stale and are cleared
+  exactly as they always were. No run can inherit another run's cancellation, and there is no
+  window to reason about.
+- **The record is per triggering admin**, so two admins' concurrent fan-outs cancel separately.
+  Overlapping *owners* are not a hazard either: `reindex_lock:{user_id}` already makes two
+  coordinators for one owner mutually exclusive — the second is skipped, never concurrent.
+- **A caller with no recorded fan-out still cancels their own coordinator**, with the legacy `"1"`
+  value. That is the `search_index_maintenance`-dispatched run, which has no admin-facing run id;
+  its behaviour is unchanged from before #691. Those automatic per-owner runs are deliberately
+  **not** swept up by an admin's stop — the button cancels the run *you* started.
+- **`reindex_fanout:*` is NOT in `app/main.py`'s startup sweep**, unlike `reindex_cancel:*`. The
+  API process restarts independently of the Celery workers still executing the fan-out, and
+  deleting the record takes the only handle `stop` has on those coordinators with it. A 1-hour
+  TTL bounds it instead.
 
 ## The bootstrap self-heals, and why it is a beat task (#625)
 

--- a/backend/app/services/search/hybrid_search_service.py
+++ b/backend/app/services/search/hybrid_search_service.py
@@ -2475,10 +2475,8 @@ class HybridSearchService:
             if is_semantic_only:
                 if "semantic" not in match_sources:
                     match_sources.append("semantic")
-                semantic_high_threshold = getattr(
-                    settings, "SEARCH_SEMANTIC_HIGH_CONFIDENCE", 0.015
-                )
-                semantic_confidence = "high" if best_score >= semantic_high_threshold else "low"
+                threshold = settings.SEARCH_SEMANTIC_HIGH_CONFIDENCE
+                semantic_confidence = "high" if best_score >= threshold else "low"
 
             # Detect metadata speaker match
             if query_lower:
@@ -2670,7 +2668,7 @@ class HybridSearchService:
         if is_semantic_only:
             if "semantic" not in match_sources:
                 match_sources.append("semantic")
-            threshold = getattr(settings, "SEARCH_SEMANTIC_HIGH_CONFIDENCE", 0.010)
+            threshold = settings.SEARCH_SEMANTIC_HIGH_CONFIDENCE
             semantic_confidence = "high" if best_score >= threshold else "low"
 
         has_both = keyword_count > 0 and semantic_count > 0

--- a/backend/app/services/search/index_health.py
+++ b/backend/app/services/search/index_health.py
@@ -204,8 +204,12 @@ def rebuild_chunks_index() -> bool:
             return False
 
         result = dispatch_reindex_for_every_owner(triggered_by=admin_ids[0])
+        # `reindex_users`, not `dispatched` — the helper has never returned a
+        # `dispatched` key, so `.get(..., 0)` silently reported "0 owners" on
+        # every repair, however many it actually fanned out to (issue #692).
+        # A direct subscript would have raised the first time this ran.
         logger.warning(
-            f"Dispatched repair reindex for {index_name}: {result.get('dispatched', 0)} owners"
+            f"Dispatched repair reindex for {index_name}: {result.get('reindex_users', 0)} owners"
         )
 
     # The index is legitimately EMPTY until the coordinators finish, so there is

--- a/backend/app/services/search/model_switch.py
+++ b/backend/app/services/search/model_switch.py
@@ -26,6 +26,7 @@ from typing import cast
 
 from app.core.constants import OPENSEARCH_EMBEDDING_MODELS
 from app.core.exceptions import SearchIndexError
+from app.services.search.reindex_cancel import record_fanout
 
 logger = logging.getLogger(__name__)
 
@@ -121,6 +122,15 @@ def dispatch_reindex_for_every_owner(
     this user owns" (``if file_uuids:``), so passing ``[]`` for an owner with
     nothing to do would re-embed their entire account.
 
+    **The dispatch is recorded, because a fan-out has to be cancellable** (#691).
+    The ``{owner: task id}`` mapping is returned *and* written to
+    ``reindex_fanout:{triggered_by}`` by ``services/search/reindex_cancel.py``.
+    Returning it and keeping no record is exactly what left
+    ``POST /search/reindex/stop`` able to flag only the calling admin's own
+    coordinator while the other owners' ran to completion. Recording it here
+    rather than in the endpoint means the model-switch re-embed is stoppable on
+    the same terms — one dispatch loop, one cancellation handle.
+
     Args:
         triggered_by: The admin performing the switch or repair, dispatched
             first so their own progress stream starts immediately.
@@ -173,6 +183,11 @@ def dispatch_reindex_for_every_owner(
         ) from e
 
     logger.info(f"Dispatched reindex for {len(tasks)} users")
+    # Persist what was dispatched so `POST /search/reindex/stop` can cancel the
+    # whole run and not just the caller's share of it (#691). Returning the
+    # mapping and keeping no record is precisely why that endpoint stayed
+    # per-owner through #627.
+    record_fanout(triggered_by, tasks)
     return {"reindex_task_ids": tasks, "reindex_users": len(tasks)}
 
 

--- a/backend/app/services/search/reindex_cancel.py
+++ b/backend/app/services/search/reindex_cancel.py
@@ -1,0 +1,265 @@
+"""Cancelling a reindex that fanned out across every owner (issue #691).
+
+``POST /search/reindex`` dispatches one ``reindex_transcripts_task`` coordinator
+per owner (#627), but ``POST /search/reindex/stop`` wrote a single
+``reindex_cancel:{user_id}`` key — the caller's own — and each coordinator reads
+the key belonging to the *file's* owner. So an admin could start a
+deployment-wide re-embed and cancel only their own share of it; every other
+owner's coordinator ran to completion. Both routes are ``get_current_admin_user``
+gated, so that was a scope mismatch between start and stop rather than an
+authorization gap — and it was *worse* than before #627, when start and stop were
+consistently per-owner and the button therefore did what it appeared to.
+
+Two things close it, and they are separable:
+
+**The dispatch records what it dispatched.** ``dispatch_reindex_for_every_owner``
+handed its ``{owner id: coordinator task id}`` mapping back to its caller and kept
+no record, so ``stop`` had nothing to enumerate — which is why #627 documented the
+gap instead of fixing it. The mapping is now also written to
+``reindex_fanout:{admin id}``, keyed on the admin who triggered the run so two
+admins' concurrent fan-outs are separate records that cancel separately.
+
+**The cancel flag names the run it cancels.** ``reindex_cancel:{user_id}`` used to
+hold ``"1"``; it now holds the coordinator task id being cancelled. That is what
+makes stopping a *queued* coordinator work, and the queued coordinator is the case
+that matters most: the fan-out dispatches the caller first, so on any deployment
+whose worker pool is smaller than the owner count the caller's coordinator runs
+while owners B..N sit in the broker queue. A flag that carried only ``"1"`` would
+be erased the moment B's coordinator started — every coordinator clears the flag
+on entry, because a flag left behind by an *earlier* run would otherwise abort the
+next legitimate reindex after its first file. Naming the run is what lets a
+coordinator tell those two cases apart: :func:`consume_pending_cancel` aborts when
+the flag names *this* run and clears-and-proceeds when it names any other.
+
+That also answers "what if a second run starts while one is cancelling": the
+second run's coordinators carry different task ids, so the first run's flags read
+as stale to them and are cleared, exactly as they always were. No run can inherit
+another run's cancellation.
+
+**Who clears what.** The flags stay **per owner** — there is deliberately no single
+shared run flag, because the first coordinator of a fan-out to finish would then
+have to either delete it (leaving the other N−1 uncancellable mid-run) or leave it
+(poisoning the next run). Each owner's coordinator clears only its own key: once on
+entry (:func:`consume_pending_cancel`) and once in the completion handler
+(:func:`clear_cancel`). ``stop`` deletes the fan-out record it has just acted on.
+
+**If a coordinator dies without clearing**, three things bound the damage, in
+order: the leftover flag names a run that no longer exists, so no other run
+honours it (:func:`cancel_requested` compares); ``app/main.py``'s startup sweep
+clears ``reindex_cancel:*`` on every API restart; and both keys carry
+``reindex_lock``'s one-hour TTL. ``reindex_fanout:*`` is deliberately **not** in
+that sweep — the API process restarts independently of the Celery workers still
+running the fan-out, and deleting the record would take the only handle ``stop``
+has on those coordinators with it. A record left over from a finished run is
+harmless for the same reason the flags are: the ids in it name nothing.
+
+⚠️ Every function here imports ``get_redis`` inside its body rather than at module
+scope. That is the same pattern ``search.py``'s ``_check_reindex_task_active``
+uses and for the same reason: a module-level ``from app.core.redis import
+get_redis`` binds the name at import time, and a test that patches
+``app.core.redis.get_redis`` would then be pointing at a client nothing here
+consults.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+#: Per-owner cancellation flag. The value names the coordinator run being
+#: cancelled (see the module docstring); ``"1"`` is the legacy/unknown-run value.
+CANCEL_KEY = "reindex_cancel:{user_id}"
+
+#: The owner set one admin's fan-out dispatched, as ``{owner id: task id}``.
+FANOUT_KEY = "reindex_fanout:{admin_id}"
+
+#: Matches ``reindex_lock``'s expiry: a flag or record that outlives the run it
+#: describes is the staleness the run-id comparison exists to survive, and an
+#: hour bounds how long one can sit around being wrong.
+CANCEL_TTL_SECONDS = 3600
+FANOUT_TTL_SECONDS = 3600
+
+#: Written when ``stop`` knows an owner is being cancelled but not which run —
+#: a coordinator dispatched by ``search_index_maintenance``, or any run that
+#: predates the fan-out record. Truthy, so the batch workers of a *running*
+#: coordinator still stop; never equal to a task id, so a *queued* coordinator
+#: treats it as stale and proceeds, which is the pre-#691 behaviour unchanged.
+LEGACY_CANCEL_VALUE = "1"
+
+
+def _decode(value: object) -> str | None:
+    """Redis returns bytes (``get_redis()`` sets no ``decode_responses``)."""
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        return value.decode()
+    return str(value)
+
+
+def cancel_target(user_id: int) -> str | None:
+    """The coordinator run id this owner's pending cancellation names.
+
+    Returns:
+        The stored value — a task id, ``LEGACY_CANCEL_VALUE``, or ``None`` when
+        no cancellation is pending.
+    """
+    from app.core.redis import get_redis
+
+    try:
+        return _decode(get_redis().get(CANCEL_KEY.format(user_id=user_id)))
+    except Exception as e:
+        # Fails OPEN, deliberately and as it always has: an unreachable Redis
+        # reads as "no cancellation" so a reindex keeps working rather than
+        # aborting mid-corpus. The opposite direction would let a Redis blip
+        # silently truncate a re-embed.
+        logger.warning(f"Could not read the reindex cancellation flag: {e}")
+        return None
+
+
+def cancel_requested(user_id: int, run_id: str | None = None) -> bool:
+    """Whether a cancellation is pending for this owner's reindex run.
+
+    ⚠️ **Pass ``run_id`` wherever you have one.** A flag naming a *different* run
+    belongs to a run that is over, and honouring it would let one run inherit
+    another's cancellation. That is reachable now that ``stop`` flags several
+    owners at once: a fan-out record that outlives its coordinators (it carries a
+    1-hour TTL) plus a later ``stop`` would otherwise write flags that abort the
+    per-owner runs ``search_index_maintenance`` had since started on its own
+    schedule.
+
+    Args:
+        user_id: The owner whose reindex is asking.
+        run_id: The asking coordinator run's task id. ``None`` means the caller
+            has no run identity, in which case any pending flag counts — the
+            pre-#691 behaviour.
+
+    Returns:
+        True when the caller should stop after the file it is on.
+    """
+    target = cancel_target(user_id)
+    if target is None:
+        return False
+    if run_id is None:
+        return True
+    return target in (run_id, LEGACY_CANCEL_VALUE)
+
+
+def clear_cancel(user_id: int) -> None:
+    """Drop this owner's cancellation flag."""
+    from app.core.redis import get_redis
+
+    try:
+        get_redis().delete(CANCEL_KEY.format(user_id=user_id))
+    except Exception as e:
+        logger.warning(f"Could not clear the reindex cancellation flag: {e}")
+
+
+def consume_pending_cancel(user_id: int, run_id: str) -> bool:
+    """Was *this* coordinator run cancelled before it managed to start?
+
+    Called once, on coordinator entry, in place of the unconditional clear that
+    used to live there. The clear still happens either way — a flag that outlives
+    its run must not abort the next one — but a flag naming ``run_id`` is a stop
+    that landed while this coordinator sat in the queue, and answering it by
+    clearing the flag and re-embedding the corpus anyway is the whole of #691 on
+    a single-worker deployment.
+
+    Args:
+        user_id: The owner whose coordinator is starting.
+        run_id: That coordinator's own task id.
+
+    Returns:
+        True when the pending cancellation names this run, i.e. the caller should
+        release its lock and stop without indexing anything.
+    """
+    target = cancel_target(user_id)
+    clear_cancel(user_id)
+    return target is not None and target == run_id
+
+
+def record_fanout(triggered_by: int, task_ids: dict[int, str]) -> None:
+    """Persist the owner set one admin's fan-out just dispatched.
+
+    Best-effort on purpose: the coordinators are already queued by the time this
+    runs, so raising here would report a re-index that is genuinely under way as
+    a failure. A record that could not be written degrades ``stop`` to its
+    pre-#691 per-owner reach, which is why the failure is logged rather than
+    swallowed.
+
+    Args:
+        triggered_by: The admin whose ``stop`` must be able to find this run.
+        task_ids: ``{owner id: coordinator task id}``, as returned by
+            ``dispatch_reindex_for_every_owner``.
+    """
+    from app.core.redis import get_redis
+
+    if not task_ids:
+        return
+    try:
+        get_redis().setex(
+            FANOUT_KEY.format(admin_id=triggered_by),
+            FANOUT_TTL_SECONDS,
+            json.dumps({str(uid): tid for uid, tid in task_ids.items()}),
+        )
+    except Exception as e:
+        logger.warning(
+            f"Could not record the reindex fan-out for admin {triggered_by}; a stop "
+            f"request will only reach their own coordinator: {e}",
+            exc_info=True,
+        )
+
+
+def read_fanout(triggered_by: int) -> dict[int, str]:
+    """The owner set this admin's most recent fan-out dispatched.
+
+    Redis errors are **not** caught: the caller (``POST /reindex/stop``) cannot
+    write cancellation flags either if Redis is down, and reporting that as a 500
+    is honest where an empty mapping would look like "you started nothing".
+
+    Returns:
+        ``{owner id: coordinator task id}``, empty when no run is recorded.
+    """
+    from app.core.redis import get_redis
+
+    raw = _decode(get_redis().get(FANOUT_KEY.format(admin_id=triggered_by)))
+    if not raw:
+        return {}
+    try:
+        stored = json.loads(raw)
+        return {int(uid): str(task_id) for uid, task_id in stored.items()}
+    except (ValueError, TypeError, AttributeError) as e:
+        logger.warning(f"Discarding an unreadable reindex fan-out record: {e}")
+        return {}
+
+
+def clear_fanout(triggered_by: int) -> None:
+    """Forget this admin's fan-out record, once it has been cancelled."""
+    from app.core.redis import get_redis
+
+    try:
+        get_redis().delete(FANOUT_KEY.format(admin_id=triggered_by))
+    except Exception as e:
+        logger.warning(f"Could not clear the reindex fan-out record: {e}")
+
+
+def request_cancel(targets: dict[int, str]) -> list[int]:
+    """Flag every owner in ``targets`` for cancellation.
+
+    Raises rather than degrading: a stop that reached only some of the run is
+    indistinguishable from one that reached all of it, and reporting success for
+    a corpus-wide re-embed that is still running is the silence #691 is about.
+
+    Args:
+        targets: ``{owner id: the coordinator run id to cancel}``.
+
+    Returns:
+        The owner ids flagged, in ascending order.
+    """
+    from app.core.redis import get_redis
+
+    redis_client = get_redis()
+    for user_id, run_id in sorted(targets.items()):
+        redis_client.setex(CANCEL_KEY.format(user_id=user_id), CANCEL_TTL_SECONDS, run_id)
+    return sorted(targets)

--- a/backend/app/services/similarity_service.py
+++ b/backend/app/services/similarity_service.py
@@ -44,7 +44,10 @@ class SimilarityService:
             embedding2: Second embedding vector (numpy array or torch tensor)
 
         Returns:
-            Cosine similarity score between 0 and 1
+            Cosine similarity in ``[-1, 1]`` — the same space as
+            :meth:`opensearch_similarity_search`'s ``similarity`` and as the
+            ``SPEAKER_CONFIDENCE_*`` constants. Negatives are real and are
+            preserved (issue #690).
         """
         # Convert to torch tensors and move to appropriate device
         if isinstance(embedding1, np.ndarray):
@@ -60,8 +63,11 @@ class SimilarityService:
             embedding1.unsqueeze(0), embedding2.unsqueeze(0), dim=1
         ).item()
 
-        # Ensure result is in valid range and return as Python float
-        return float(max(0.0, min(1.0, similarity)))
+        # Bound float32 rounding to cosine's real domain — NOT to [0, 1].
+        # Clamping the negative half to 0.0 made "opposite" and "orthogonal"
+        # indistinguishable and put this method in a different space from
+        # `opensearch_similarity_search` on the same class (issue #690).
+        return float(max(-1.0, min(1.0, similarity)))
 
     @staticmethod
     def batch_cosine_similarity(
@@ -78,7 +84,8 @@ class SimilarityService:
             target_embeddings: List of target embeddings to compare against
 
         Returns:
-            List of similarity scores in the same order as target_embeddings
+            List of cosine similarities in ``[-1, 1]``, in the same order as
+            ``target_embeddings``. Same space as :meth:`cosine_similarity`.
         """
         if not target_embeddings:
             return []
@@ -105,11 +112,11 @@ class SimilarityService:
             query_tensor.unsqueeze(0).expand(targets_matrix.size(0), -1), targets_matrix, dim=1
         )
 
-        # Convert to Python floats and ensure valid range
+        # Convert to Python floats, bounded to cosine's real domain (issue #690).
         result = []
         for sim in similarities:
             score = float(sim.item())
-            result.append(max(0.0, min(1.0, score)))
+            result.append(max(-1.0, min(1.0, score)))
 
         return result
 
@@ -121,7 +128,6 @@ class SimilarityService:
         min_raw_cosine: float = 0.7,
         max_results: int = 50,
         exclude_ids: list[int] | None = None,
-        boost_recent: bool = True,
         organization_id: int | None = None,
     ) -> list[dict[str, Any]]:
         """
@@ -144,11 +150,17 @@ class SimilarityService:
                 already in ``cosinesimil`` score space.
             max_results: Maximum number of results (increased default)
             exclude_ids: Optional list of IDs to exclude from results
-            boost_recent: Whether to boost recent embeddings in scoring
             organization_id: Active org id (None = personal) — tenant gate.
 
         Returns:
-            List of similarity matches with raw-cosine scores and metadata
+            List of similarity matches whose ``similarity`` is **raw cosine** in
+            ``[-1, 1]`` — the same space :meth:`cosine_similarity` returns.
+
+        Note:
+            There is deliberately no recency boost. A ``boost_recent`` parameter
+            was documented here as an active scoring behaviour and referenced
+            nowhere in the body, so the signature promised a feature the search
+            never had (issue #690). Ranking is pure kNN cosine.
         """
         from app.services.opensearch_service import _speaker_org_filter_clauses
         from app.services.opensearch_service import opensearch_client

--- a/backend/app/tasks/reindex_task.py
+++ b/backend/app/tasks/reindex_task.py
@@ -14,6 +14,9 @@ from app.core.constants import CPUPriority
 from app.core.redis import get_redis
 from app.db.session_utils import session_scope
 from app.services.ingest_artifacts.index_mapping import chunk_plane_clause
+from app.services.search.reindex_cancel import cancel_requested
+from app.services.search.reindex_cancel import clear_cancel
+from app.services.search.reindex_cancel import consume_pending_cancel
 from app.utils.websocket_notify import send_ws_event
 
 logger = logging.getLogger(__name__)
@@ -463,32 +466,22 @@ def _check_and_recreate_stale_index() -> None:
         logger.error(f"Failed to check/recreate stale index: {e}")
 
 
-def _is_cancellation_requested(user_id: int) -> bool:
-    """Check if a reindex cancellation has been requested via Redis.
+def _is_cancellation_requested(user_id: int, run_id: str | None = None) -> bool:
+    """Check if a reindex cancellation has been requested for THIS run.
+
+    A thin seam over ``services/search/reindex_cancel``, which owns the flag's
+    key shape and its run-naming contract (#691). Kept as a named function
+    because it is the point the batch worker's tests substitute.
 
     Args:
         user_id: The user whose reindex to check.
+        run_id: The dispatching coordinator's task id. A flag naming a different
+            run is a finished run's residue and must not stop this one.
 
     Returns:
-        True if cancellation was requested.
+        True if cancellation was requested for this run.
     """
-    try:
-        return bool(get_redis().get(f"reindex_cancel:{user_id}"))
-    except Exception as e:
-        logger.warning(f"Could not check cancellation flag: {e}")
-        return False
-
-
-def _clear_cancellation_flag(user_id: int) -> None:
-    """Clear the reindex cancellation flag in Redis.
-
-    Args:
-        user_id: The user whose cancellation flag to clear.
-    """
-    try:
-        get_redis().delete(f"reindex_cancel:{user_id}")
-    except Exception as e:
-        logger.warning(f"Could not clear cancellation flag: {e}")
+    return cancel_requested(user_id, run_id)
 
 
 _REINDEX_STATE_KEY = "reindex_state:{user_id}"
@@ -703,7 +696,17 @@ def reindex_transcripts_task(
         logger.warning(f"Reindex already running for user {user_id}, skipping")
         return {"status": "skipped", "message": "Reindex already in progress"}
 
-    _clear_cancellation_flag(user_id)
+    # A stop that landed while this coordinator sat in the broker queue names
+    # THIS run (#691), and honouring it is what makes cancelling a fan-out work
+    # on a deployment with fewer workers than owners: the caller's coordinator
+    # runs while owners B..N wait, so the flags `stop` wrote for them are read
+    # here, not by a batch worker. The flag is cleared either way — one left over
+    # from an EARLIER run must not abort this one after its first file — and
+    # naming the run is exactly what tells those two cases apart.
+    if consume_pending_cancel(user_id, task_id):
+        logger.info(f"Reindex run {task_id} for user {user_id} was cancelled before it started")
+        _release_reindex_lock(redis_lock, user_id, task_id)
+        return {"status": "cancelled", "message": "Reindex cancelled before it started"}
 
     # Clear the stale progress tracker from any previous run (failed or completed).
     # This no longer touches the coordination state: see `_clear_stale_progress`.
@@ -963,7 +966,7 @@ def reindex_batch_task(
         # Phase 2 — index. OpenSearch only; NO DB session is held here.
         for file_uuid, metadata in page_metadata:
             # Check cancellation between files
-            if _is_cancellation_requested(user_id):
+            if _is_cancellation_requested(user_id, run_id):
                 logger.info(f"Reindex batch cancelled for user {user_id}")
                 cancelled = True
                 break
@@ -1156,7 +1159,7 @@ def _handle_reindex_completion(
     # unconditionally; the lock is user-scoped and only goes if we still hold it.
     redis_client.delete(state_key, uuids_key)
     _release_reindex_lock(redis_client, user_id, run_id)
-    _clear_cancellation_flag(user_id)
+    clear_cancel(user_id)
 
     logger.info(
         f"Re-index complete for user {user_id} ({mode}): "

--- a/backend/tests/CLAUDE.md
+++ b/backend/tests/CLAUDE.md
@@ -129,6 +129,18 @@ pass everything — one of which caught exactly that: the UI-creation half match
 equality against selectors that embed the label (`"button:has-text('Create Account')"`), so it
 was finding nothing at all.
 
+- **A test that executes real infrastructure tooling must be scoped to a namespace no real
+  object can occupy — and the scoping must be asserted, not intended** (issue #693).
+  `unit/test_opentr_stop_container_scoping.py` extracts `opentr.sh`'s straggler-cleanup loop
+  and *runs* it, which is the whole value of the test — and, unscoped, ran
+  `docker stop && docker rm` over the live dev stack: **17 containers destroyed by a routine
+  `pytest tests/`**, from a file in `tests/unit/` with no marker. It now drives the loop through
+  `OPENTR_STOP_PROJECT_LABEL`/`_ALT` (defaulting, in `opentr.sh`, to the real project names) at a
+  per-test `*-pytest-<uuid4>` compose project, with three guards: a fixture that **refuses** to
+  hand the loop to a real-docker test unless every project-label filter is an overridable
+  `${...}`; a fake-`docker`-on-`PATH` test asserting the filters it actually issued name only
+  that namespace; and a test pinning the unset default to the two real names. Skipping the
+  scoping is not a smaller version of this test — it is the incident.
 - **E2E must never persist changes to dev data.** Upload tests delete what they create (API
   delete, falling back to `/force`); transcript-edit tests use the **cancel path only**.
   Cleanup must be in a `finally`, a fixture teardown that deletes, or an `addfinalizer` — **a

--- a/backend/tests/api/endpoints/test_admin_user_delete_legal_hold.py
+++ b/backend/tests/api/endpoints/test_admin_user_delete_legal_hold.py
@@ -1,0 +1,189 @@
+"""Deleting a USER must not destroy that user's legally-held files (issue #689).
+
+#664 put the hold guard inside ``file_cleanup_service.purge_media_file`` — the
+canonical per-file destroy — and on the retention sweep's candidate query. Admin
+user-deletion reaches neither: ``admin._delete_user_media_files`` ends in a **bulk**
+``db.query(MediaFile).filter(...).delete()``, which emits one statement, loads no
+instances, and consults no ``legal_hold``. So the one deletion path that destroys a
+whole account's files at once was also the one path with no hold guard at all, and the
+destruction is irreversible.
+
+The policy implemented here is **refuse the whole deletion**, matching
+``purge_media_file``'s shipped refusal. Deleting everything except the held files would
+leave ``media_file`` rows owned by a deleted account (and ``media_file.user_id`` is a
+plain ``NO ACTION`` FK, so the ``user`` delete would then fail mid-cascade anyway);
+reassigning them to another owner would invent a retention policy nobody asked for.
+
+Every test drives the real HTTP endpoints against real rows through the savepoint-rolled
+back ``db_session``. Both entry points are covered, because there are two:
+``DELETE /api/admin/users/{uuid}`` and ``DELETE /api/users/{uuid}`` call the same three
+cascade helpers.
+"""
+
+from fastapi import status
+
+from app.models.media import MediaFile
+from app.models.user import User
+from tests.user_owned_rows import make_media_file
+from tests.user_owned_rows import seed_owned_rows
+
+
+def _place_under_legal_hold(db_session, media_file: MediaFile) -> int:
+    """Put one existing file under an active legal hold.
+
+    Args:
+        db_session: The savepoint-isolated test session.
+        media_file: The file to hold.
+
+    Returns:
+        The held file's ``media_file.id``.
+    """
+    media_file.legal_hold = True
+    db_session.commit()
+    db_session.refresh(media_file)
+    return int(media_file.id)
+
+
+def test_deleting_a_user_who_owns_a_held_file_is_refused(
+    client, admin_token_headers, normal_user, db_session
+):
+    """The defect: a bulk delete destroyed held evidence along with the account.
+
+    Asserts the refusal AND that nothing was destroyed on the way to it —
+    ``assert_all_present`` re-checks every table the cascade sweeps, so a guard that
+    fired only after ``_delete_user_owned_records`` had already run would fail here
+    rather than read as a pass.
+    """
+    owned = seed_owned_rows(db_session, normal_user)
+    owned.assert_all_present(db_session)
+    held_file = db_session.query(MediaFile).filter(MediaFile.id == owned.media_file_id).one()
+    held_id = _place_under_legal_hold(db_session, held_file)
+
+    response = client.delete(f"/api/admin/users/{normal_user.uuid}", headers=admin_token_headers)
+
+    assert response.status_code == status.HTTP_409_CONFLICT, response.text
+    detail = response.json()["detail"]
+    assert detail["error"] == "FILE_UNDER_LEGAL_HOLD"
+    assert detail["files_under_legal_hold"] == 1
+    assert "legal hold" in detail["message"]
+
+    db_session.expire_all()
+    assert db_session.query(User).filter(User.id == owned.user_id).first() is not None
+    assert db_session.query(MediaFile).filter(MediaFile.id == held_id).first() is not None
+    # Nothing was deleted on the way to the refusal — a partial destroy followed by a
+    # 409 would be worse than either outcome alone.
+    owned.assert_all_present(db_session)
+
+
+def test_an_ordinary_user_with_no_held_files_is_still_deleted(
+    client, admin_token_headers, normal_user, db_session
+):
+    """CONTROL: without it, the guard is indistinguishable from a broken query.
+
+    The refusal test above is satisfied by any change that makes user deletion fail.
+    This one proves the deletion the guard protects still happens, and that the files
+    really go — ``remaining == {}`` names any table that leaked.
+    """
+    owned = seed_owned_rows(db_session, normal_user)
+    owned.assert_all_present(db_session)
+    media_file_id = owned.media_file_id
+
+    response = client.delete(f"/api/admin/users/{normal_user.uuid}", headers=admin_token_headers)
+
+    assert response.status_code == status.HTTP_200_OK, response.text
+    db_session.expire_all()
+    assert db_session.query(User).filter(User.id == owned.user_id).first() is None
+    assert db_session.query(MediaFile).filter(MediaFile.id == media_file_id).first() is None
+    assert owned.remaining(db_session) == {}
+
+
+def test_a_quarantined_file_with_no_hold_does_not_block_the_deletion(
+    client, admin_token_headers, normal_user, db_session
+):
+    """The guard is keyed on the HOLD, not on quarantine — deliberately, as in #664.
+
+    ``purge_media_file`` guards ``legal_hold`` only; the ``is_quarantined`` predicate
+    lives on the unattended retention sweep, which must never destroy a file under
+    review. An admin acting deliberately is a different actor: deleting an abusive
+    *account* is the commonest reason its files were quarantined in the first place, so
+    blocking on quarantine would turn a takedown into a shield against removal. Without
+    this test, widening the guard to ``is_quarantined`` would look like an improvement.
+    """
+    owned = seed_owned_rows(db_session, normal_user)
+    quarantined = db_session.query(MediaFile).filter(MediaFile.id == owned.media_file_id).one()
+    quarantined.is_quarantined = True
+    quarantined.quarantine_reason = "AUP review"
+    db_session.commit()
+    quarantined_id = int(quarantined.id)
+
+    response = client.delete(f"/api/admin/users/{normal_user.uuid}", headers=admin_token_headers)
+
+    assert response.status_code == status.HTTP_200_OK, response.text
+    db_session.expire_all()
+    assert db_session.query(User).filter(User.id == owned.user_id).first() is None
+    assert db_session.query(MediaFile).filter(MediaFile.id == quarantined_id).first() is None
+
+
+def test_the_refusal_counts_every_held_file(client, admin_token_headers, normal_user, db_session):
+    """The count is measured, not a hardcoded 1 — the admin needs to know the scale.
+
+    Two of the user's three files are held; the message and the structured field must
+    both say two.
+    """
+    owned = seed_owned_rows(db_session, normal_user)
+    first = db_session.query(MediaFile).filter(MediaFile.id == owned.media_file_id).one()
+    _place_under_legal_hold(db_session, first)
+    second = make_media_file(db_session, int(normal_user.id))
+    _place_under_legal_hold(db_session, second)
+    # A third, unheld file so the count cannot simply be "every file this user owns".
+    make_media_file(db_session, int(normal_user.id))
+
+    response = client.delete(f"/api/admin/users/{normal_user.uuid}", headers=admin_token_headers)
+
+    assert response.status_code == status.HTTP_409_CONFLICT, response.text
+    detail = response.json()["detail"]
+    assert detail["files_under_legal_hold"] == 2
+    assert "2 files" in detail["message"]
+    db_session.expire_all()
+    assert db_session.query(MediaFile).filter(MediaFile.user_id == owned.user_id).count() == 3
+
+
+def test_the_users_router_delete_is_refused_too(
+    client, admin_token_headers, normal_user, db_session
+):
+    """``DELETE /api/users/{uuid}`` is the second caller and has no savepoint at all.
+
+    It calls the same three cascade helpers with no ``begin_nested()`` and no
+    ``except Exception``, so a guard that only lived inside ``_delete_user_media_files``
+    would refuse here only *after* ``_delete_user_owned_records`` and
+    ``_delete_user_speakers`` had already deleted rows in the request's session.
+    """
+    owned = seed_owned_rows(db_session, normal_user)
+    owned.assert_all_present(db_session)
+    held_file = db_session.query(MediaFile).filter(MediaFile.id == owned.media_file_id).one()
+    held_id = _place_under_legal_hold(db_session, held_file)
+
+    response = client.delete(f"/api/users/{normal_user.uuid}", headers=admin_token_headers)
+
+    assert response.status_code == status.HTTP_409_CONFLICT, response.text
+    assert response.json()["detail"]["error"] == "FILE_UNDER_LEGAL_HOLD"
+
+    db_session.expire_all()
+    assert db_session.query(User).filter(User.id == owned.user_id).first() is not None
+    assert db_session.query(MediaFile).filter(MediaFile.id == held_id).first() is not None
+    owned.assert_all_present(db_session)
+
+
+def test_the_users_router_still_deletes_an_ordinary_user(
+    client, admin_token_headers, normal_user, db_session
+):
+    """CONTROL for the second entry point: 204 and the data really goes."""
+    owned = seed_owned_rows(db_session, normal_user)
+    owned.assert_all_present(db_session)
+
+    response = client.delete(f"/api/users/{normal_user.uuid}", headers=admin_token_headers)
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT, response.text
+    db_session.expire_all()
+    assert db_session.query(User).filter(User.id == owned.user_id).first() is None
+    assert owned.remaining(db_session) == {}

--- a/backend/tests/api/endpoints/test_search_admin_routes.py
+++ b/backend/tests/api/endpoints/test_search_admin_routes.py
@@ -108,7 +108,7 @@ class _RecordingSetter:
 
 
 class _StandInRedis:
-    """The three operations the reindex lock/cancel flags use, backed by a dict."""
+    """The four operations the reindex lock/cancel/fan-out keys use, backed by a dict."""
 
     def __init__(self) -> None:
         self.store: dict[str, str] = {}
@@ -121,6 +121,9 @@ class _StandInRedis:
 
     def setex(self, key: str, _ttl: int, value: str) -> None:
         self.store[key] = value
+
+    def delete(self, *keys: str) -> int:
+        return sum(1 for key in keys if self.store.pop(key, None) is not None)
 
 
 class _StandInCat:
@@ -137,9 +140,47 @@ class _StandInCat:
 
 
 @pytest.fixture
-def reindex_task():
-    """Replace the reindex task at its import site with a recorder."""
+def reindex_task(standin_redis):
+    """Replace the reindex task at its import site with a recorder.
+
+    Takes ``standin_redis`` because a dispatch now also **writes** — it records
+    the fan-out's ``{owner: task id}`` mapping so ``POST /reindex/stop`` can
+    cancel the whole run (#691). Without the stand-in that write would land in
+    whatever Redis the test environment is pointed at, i.e. the dev stack's.
+    """
+    del standin_redis  # requested for its patching, read through the endpoint
     recorder = _RecordingTask()
+    with patch("app.tasks.reindex_task.reindex_transcripts_task", recorder):
+        yield recorder
+
+
+def _coordinator_id(user_id: int) -> str:
+    """The task id ``_PerOwnerRecordingTask`` hands that owner's coordinator."""
+    return f"coordinator-for-{user_id}"
+
+
+class _PerOwnerRecordingTask:
+    """A recorder that gives each owner a DISTINCT coordinator task id.
+
+    ``_RecordingTask`` returns one id for every dispatch, which cannot show that a
+    cancel flag names *that owner's* run rather than any run at all — and naming
+    the run is the whole mechanism that lets a queued coordinator honour a stop
+    instead of clearing it on entry (#691).
+    """
+
+    def __init__(self) -> None:
+        self.dispatches: list[dict] = []
+
+    def delay(self, **kwargs) -> SimpleNamespace:
+        self.dispatches.append(kwargs)
+        return SimpleNamespace(id=_coordinator_id(kwargs["user_id"]))
+
+
+@pytest.fixture
+def fanout_reindex_task(standin_redis):
+    """``reindex_task``, but with per-owner task ids. See ``_PerOwnerRecordingTask``."""
+    del standin_redis  # requested for its patching, read through the endpoint
+    recorder = _PerOwnerRecordingTask()
     with patch("app.tasks.reindex_task.reindex_transcripts_task", recorder):
         yield recorder
 
@@ -323,17 +364,16 @@ class _StandInIndexedFiles:
 
 @pytest.fixture
 def standin_redis():
-    """Point both reindex-flag readers at one in-memory store.
+    """Point every reindex lock/cancel/fan-out reader at one in-memory store.
 
-    Two patch targets because the handler and its helper resolve ``get_redis``
-    differently: ``stop_reindex`` uses the name imported into ``search.py``,
-    while ``_check_reindex_task_active`` imports it inside the function body.
+    One patch target now covers all of them: ``_running_reindex_run_id`` and
+    ``services/search/reindex_cancel`` both import ``get_redis`` **inside** their
+    function bodies precisely so a single ``app.core.redis`` patch reaches them.
+    (``search.py`` no longer binds the name at module scope; it used to, and the
+    fixture needed two targets.)
     """
     fake = _StandInRedis()
-    with (
-        patch("app.api.endpoints.search.get_redis", return_value=fake),
-        patch("app.core.redis.get_redis", return_value=fake),
-    ):
+    with patch("app.core.redis.get_redis", return_value=fake):
         yield fake
 
 
@@ -780,6 +820,168 @@ def test_stop_is_refused_for_a_plain_user(client, user_token_headers, standin_re
     response = client.post(REINDEX_STOP, headers=user_token_headers)
     assert response.status_code == status.HTTP_403_FORBIDDEN
     assert standin_redis.store == {}
+
+
+# ---------------------------------------------------------------------------
+# POST /reindex/stop — cancelling the FAN-OUT, not just the caller's share (#691)
+# ---------------------------------------------------------------------------
+def test_stopping_a_two_owner_fanout_cancels_both_owners(
+    client, admin_token_headers, admin_user, fanout_reindex_task, two_owner_corpus, standin_redis
+):
+    """The defect, end to end: start corpus-wide, then stop, and mean it.
+
+    ``POST /reindex`` dispatches one coordinator per owner (#627); ``stop`` wrote
+    a single ``reindex_cancel:{caller}`` flag and each coordinator reads the flag
+    for the *file's* owner, so the other owners re-embedded their whole accounts
+    with no way to intervene short of restarting workers. Both routes are
+    admin-gated, so this was never an authorization gap — start and stop simply
+    disagreed about scope.
+    """
+    started = client.post(REINDEX, headers=admin_token_headers, json=None)
+    assert started.status_code == status.HTTP_200_OK
+    dispatched_for = {d["user_id"] for d in fanout_reindex_task.dispatches}
+    other_id = two_owner_corpus.owner_id
+    assert {admin_user.id, other_id} <= dispatched_for
+
+    standin_redis.store[f"reindex_lock:{admin_user.id}"] = "held"
+    standin_redis.store[f"reindex_lock:{other_id}"] = "held"
+
+    stopped = client.post(REINDEX_STOP, headers=admin_token_headers)
+
+    assert stopped.status_code == status.HTTP_200_OK
+    body = stopped.json()
+    assert body["status"] == "stop_requested"
+    # Every owner the fan-out dispatched, not merely the two the fixture created:
+    # the corpus is whatever the database holds, and all of it was queued.
+    assert body["stopped_users"] == len(dispatched_for)
+    assert standin_redis.store[f"reindex_cancel:{admin_user.id}"] == _coordinator_id(admin_user.id)
+    assert standin_redis.store[f"reindex_cancel:{other_id}"] == _coordinator_id(other_id)
+
+
+def test_a_queued_owners_coordinator_is_flagged_though_it_holds_no_lock(
+    client, admin_token_headers, admin_user, fanout_reindex_task, two_owner_corpus, standin_redis
+):
+    """The realistic shape: one worker, so only the caller's coordinator is running.
+
+    The fan-out dispatches the caller first, so owners B..N sit in the broker
+    queue holding no ``reindex_lock``. Flagging only the owners *currently*
+    executing would leave exactly those coordinators to start later and re-embed
+    the corpus — the original defect, one step further along.
+    """
+    client.post(REINDEX, headers=admin_token_headers, json=None)
+    dispatched_for = {d["user_id"] for d in fanout_reindex_task.dispatches}
+    standin_redis.store[f"reindex_lock:{admin_user.id}"] = "held"
+
+    stopped = client.post(REINDEX_STOP, headers=admin_token_headers)
+
+    assert stopped.json()["stopped_users"] == len(dispatched_for)
+    other_id = two_owner_corpus.owner_id
+    assert other_id in dispatched_for
+    assert f"reindex_lock:{other_id}" not in standin_redis.store
+    assert standin_redis.store[f"reindex_cancel:{other_id}"] == _coordinator_id(other_id)
+
+
+def test_stopping_a_single_owner_run_still_cancels_that_owner(
+    client, admin_token_headers, admin_user, fanout_reindex_task, two_owner_corpus, standin_redis
+):
+    """The control. Without it, a fix that flags every account in the deployment —
+    or one that flags nothing at all and passes on an empty two-owner store —
+    would be indistinguishable from a working one.
+
+    Naming only the admin's own file resolves to a one-owner scope, so exactly one
+    coordinator is dispatched and exactly one flag must be written.
+    """
+    started = client.post(
+        REINDEX, headers=admin_token_headers, json=[two_owner_corpus.admin_file_uuid]
+    )
+    assert started.json()["reindex_users"] == 1
+
+    standin_redis.store[f"reindex_lock:{admin_user.id}"] = "held"
+    stopped = client.post(REINDEX_STOP, headers=admin_token_headers)
+
+    assert stopped.json()["stopped_users"] == 1
+    assert standin_redis.store[f"reindex_cancel:{admin_user.id}"] == _coordinator_id(admin_user.id)
+    assert f"reindex_cancel:{two_owner_corpus.owner_id}" not in standin_redis.store
+
+
+def test_a_stop_leaves_another_admins_concurrent_fanout_untouched(
+    client, admin_token_headers, admin_user, fanout_reindex_task, two_owner_corpus, standin_redis
+):
+    """The record is per triggering admin, so two runs cancel independently.
+
+    A deployment-wide cancel flag would be simpler and would take this second run
+    down with the first — an admin repairing search would silently abort a
+    colleague's re-embed.
+    """
+    other_admin_id = 90001
+    other_admin_owner_id = 90002
+    standin_redis.store[f"reindex_fanout:{other_admin_id}"] = (
+        f'{{"{other_admin_owner_id}": "coordinator-for-{other_admin_owner_id}"}}'
+    )
+
+    client.post(REINDEX, headers=admin_token_headers, json=None)
+    standin_redis.store[f"reindex_lock:{admin_user.id}"] = "held"
+    client.post(REINDEX_STOP, headers=admin_token_headers)
+
+    # The caller's own run IS cancelled — otherwise "left the other one alone"
+    # would be satisfied by a stop that cancelled nothing at all.
+    other_id = two_owner_corpus.owner_id
+    assert standin_redis.store[f"reindex_cancel:{other_id}"] == _coordinator_id(other_id)
+    assert f"reindex_cancel:{other_admin_owner_id}" not in standin_redis.store
+    assert f"reindex_fanout:{other_admin_id}" in standin_redis.store
+
+
+def test_a_stop_is_still_possible_once_the_callers_own_coordinator_has_finished(
+    client, admin_token_headers, admin_user, fanout_reindex_task, two_owner_corpus, standin_redis
+):
+    """An admin who owns few files finishes first while the fan-out runs on.
+
+    ``not_running`` was derived from the caller's lock alone, so the button went
+    dead precisely when the rest of the corpus still needed stopping.
+    """
+    client.post(REINDEX, headers=admin_token_headers, json=None)
+    other_id = two_owner_corpus.owner_id
+    standin_redis.store[f"reindex_lock:{other_id}"] = "held"
+
+    stopped = client.post(REINDEX_STOP, headers=admin_token_headers)
+
+    assert stopped.json()["status"] == "stop_requested"
+    assert standin_redis.store[f"reindex_cancel:{other_id}"] == _coordinator_id(other_id)
+
+
+def test_a_finished_fanout_reports_not_running_and_writes_no_flags(
+    client, admin_token_headers, admin_user, fanout_reindex_task, two_owner_corpus, standin_redis
+):
+    """Every coordinator has released its lock: there is nothing left to stop.
+
+    A stray ``reindex_cancel`` key written here would be read by whichever run
+    started next — which is the staleness the run-naming exists to survive, but
+    inventing one is still wrong.
+    """
+    client.post(REINDEX, headers=admin_token_headers, json=None)
+
+    stopped = client.post(REINDEX_STOP, headers=admin_token_headers)
+
+    assert stopped.json()["status"] == "not_running"
+    assert f"reindex_cancel:{admin_user.id}" not in standin_redis.store
+    assert f"reindex_cancel:{two_owner_corpus.owner_id}" not in standin_redis.store
+
+
+def test_the_fanout_record_is_consumed_by_the_stop_that_cancels_it(
+    client, admin_token_headers, admin_user, fanout_reindex_task, two_owner_corpus, standin_redis
+):
+    """A record that outlives its cancellation re-flags owners on the next stop.
+
+    The dispatch writing it at all is half of the fix — ``stop`` had nothing to
+    enumerate before, which is why #627 documented the gap rather than closing it.
+    """
+    client.post(REINDEX, headers=admin_token_headers, json=None)
+    assert f"reindex_fanout:{admin_user.id}" in standin_redis.store
+
+    standin_redis.store[f"reindex_lock:{admin_user.id}"] = "held"
+    client.post(REINDEX_STOP, headers=admin_token_headers)
+
+    assert f"reindex_fanout:{admin_user.id}" not in standin_redis.store
 
 
 def test_stop_requires_authentication(client, standin_redis):

--- a/backend/tests/api/test_file_mutation_permissions.py
+++ b/backend/tests/api/test_file_mutation_permissions.py
@@ -241,7 +241,7 @@ MUTATING_ENDPOINTS: list[tuple[str, int]] = [
     ("files/__init__.py", 1204),
     ("files/crud.py", 874),
     ("files/crud.py", 965),
-    ("files/crud.py", 1052),
+    ("files/crud.py", 1053),
     ("files/management.py", 206),
     ("files/management.py", 258),
     ("files/management.py", 356),

--- a/backend/tests/unit/test_opentr_stop_container_scoping.py
+++ b/backend/tests/unit/test_opentr_stop_container_scoping.py
@@ -22,10 +22,41 @@ This test drives the REAL loop body (extracted from the script, not
 reimplemented) against REAL throwaway containers, so a regression back to a
 bare name-prefix match fails here before it can delete something on a real
 host again.
+
+⚠️ Driving the real loop is the whole point of this file, and it is also how
+this file destroyed a live dev stack (issue #693): run unmodified, the loop
+stops and removes every container labeled with the REAL project names --
+which on a developer's machine is the running stack, 16 containers, mid
+transcription. The loop's two project names are therefore parameterised in
+``opentr.sh`` (``OPENTR_STOP_PROJECT_LABEL`` / ``OPENTR_STOP_PROJECT_LABEL_ALT``,
+defaulting to the real literals), and every test here points them at a
+per-test ``*-pytest-<uuid4>`` namespace that no real container can carry.
+
+Three layers keep that containment honest, because a future edit that
+re-hardcodes the label would otherwise silently restore the hazard:
+
+1. ``straggler_loop_only`` -- the fixture the real-docker tests take -- refuses
+   to hand the loop out unless every project-label filter in it is an
+   overridable ``${...}`` expansion. It fails at *setup*, so those tests never
+   execute a hardcoded loop.
+   ``test_the_loop_reads_its_project_labels_from_overridable_variables``
+   asserts the same thing directly, so a regression reads as one failure
+   rather than four setup errors.
+2. ``test_the_loop_can_only_select_containers_in_the_configured_namespace``
+   runs the loop against a **fake** ``docker`` on ``PATH`` and asserts the
+   filters it actually asked for name only this test's namespace.
+3. ``test_with_the_override_unset_the_loop_targets_the_real_project_names``
+   pins the production default: unset, the loop still filters on exactly
+   ``opentranscribe`` and ``transcribe-app``.
+
+The three fake-``docker`` guards touch no daemon at all, so they are safe to
+run with a live stack up -- and they run in CI, where docker is absent.
 """
 
 from __future__ import annotations
 
+import os
+import re
 import shutil
 import subprocess
 import uuid
@@ -36,10 +67,37 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[3]
 OPENTR = REPO_ROOT / "opentr.sh"
 
-pytestmark = [
-    pytest.mark.skipif(not OPENTR.exists(), reason="opentr.sh not present in this checkout"),
-    pytest.mark.skipif(shutil.which("docker") is None, reason="docker not available"),
-]
+#: The two environment variables ``stop_all_containers``'s straggler loop reads
+#: to decide which compose project label it is allowed to match. Nothing that
+#: ships ever sets them; only this file does.
+PROJECT_LABEL_VAR = "OPENTR_STOP_PROJECT_LABEL"
+PROJECT_LABEL_ALT_VAR = "OPENTR_STOP_PROJECT_LABEL_ALT"
+
+#: The values those variables must default to when unset -- i.e. what
+#: `./opentr.sh stop` does on a real host, which this change must not alter.
+REAL_PROJECT_LABEL = "opentranscribe"
+REAL_PROJECT_LABEL_ALT = "transcribe-app"
+
+LABEL_FILTER_PREFIX = "label=com.docker.compose.project="
+
+_END_OF_RECORD = "<<<END>>>"
+
+_FAKE_DOCKER = f"""#!/bin/bash
+{{
+  for arg in "$@"; do printf '%s\\n' "$arg"; done
+  printf '%s\\n' '{_END_OF_RECORD}'
+}} >> "$FAKE_DOCKER_LOG"
+if [ "${{1:-}}" = "ps" ] && [ -n "${{FAKE_DOCKER_PS_OUTPUT:-}}" ]; then
+  printf '%s\\n' "$FAKE_DOCKER_PS_OUTPUT"
+fi
+exit 0
+"""
+
+pytestmark = pytest.mark.skipif(
+    not OPENTR.exists(), reason="opentr.sh not present in this checkout"
+)
+
+requires_docker = pytest.mark.skipif(shutil.which("docker") is None, reason="docker not available")
 
 
 def _function_body(text: str, name: str) -> str:
@@ -57,15 +115,136 @@ def _docker_available() -> bool:
         return False
 
 
-@pytest.fixture
-def straggler_loop_only() -> str:
+def _project_label_expansions(loop_text: str) -> list[str]:
+    """Whatever each ``label=com.docker.compose.project=`` filter in the loop is
+    followed by, truncated to the two characters that decide whether it is an
+    overridable ``${...}`` expansion or a hardcoded literal."""
+    return re.findall(rf"{re.escape(LABEL_FILTER_PREFIX)}(.{{0,2}})", loop_text)
+
+
+def _env_without_overrides(**overrides: str) -> dict[str, str]:
+    """A copy of the ambient environment with both override variables cleared,
+    then whatever the caller asked for put back. Clearing first means an
+    exported value in the developer's shell cannot silently widen a test's
+    namespace back out to the live stack."""
+    env = dict(os.environ)
+    env.pop(PROJECT_LABEL_VAR, None)
+    env.pop(PROJECT_LABEL_ALT_VAR, None)
+    env.update(overrides)
+    return env
+
+
+def _run_loop_with_fake_docker(
+    loop_text: str,
+    tmp_path: Path,
+    *,
+    overrides: dict[str, str],
+    ps_output: str = "",
+) -> list[list[str]]:
+    """Execute the real loop with a fake ``docker`` first on ``PATH``, and return
+    the argv of every ``docker`` invocation it made.
+
+    Nothing reaches the real daemon, so this is safe to run with a live stack up
+    -- which is exactly what makes it usable as the guard on the containment
+    the destructive tests below depend on.
+    """
+    bin_dir = tmp_path / "fakebin"
+    bin_dir.mkdir(exist_ok=True)
+    shim = bin_dir / "docker"
+    shim.write_text(_FAKE_DOCKER, encoding="utf-8")
+    shim.chmod(0o755)
+
+    log = tmp_path / "docker-calls.log"
+    log.write_text("", encoding="utf-8")
+
+    env = _env_without_overrides(**overrides)
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    env["FAKE_DOCKER_LOG"] = str(log)
+    env["FAKE_DOCKER_PS_OUTPUT"] = ps_output
+
+    subprocess.run(["bash", "-c", loop_text], capture_output=True, timeout=60, env=env, check=False)
+
+    records: list[list[str]] = []
+    current: list[str] = []
+    for line in log.read_text(encoding="utf-8").split("\n"):
+        if line == _END_OF_RECORD:
+            records.append(current)
+            current = []
+        else:
+            current.append(line)
+    return records
+
+
+def _run_real_loop(loop_text: str, namespace: tuple[str, str]) -> None:
+    """Run the loop against the real daemon, scoped to ``namespace``."""
+    primary, alternate = namespace
+    subprocess.run(
+        ["bash", "-c", loop_text],
+        capture_output=True,
+        timeout=60,
+        env=_env_without_overrides(
+            **{PROJECT_LABEL_VAR: primary, PROJECT_LABEL_ALT_VAR: alternate}
+        ),
+        check=False,
+    )
+
+
+def _extract_straggler_loop() -> str:
     """Just the 'catch stragglers' loop, isolated from the compose-down calls
     above it (which would otherwise try to reach real compose files/services
-    this test has no interest in standing up)."""
+    this test has no interest in standing up).
+
+    Raw text, with no safety precondition applied -- only ever run this under a
+    fake `docker`. The real daemon is reached through ``straggler_loop_only``."""
     body = _function_body(OPENTR.read_text(encoding="utf-8"), "stop_all_containers")
     loop_start = body.index("for container in")
     loop_end = body.index("\n}\n", loop_start)
     return body[loop_start:loop_end]
+
+
+@pytest.fixture
+def raw_straggler_loop() -> str:
+    """The loop as written, for the guard tests below, which execute it against
+    a fake `docker` and so cannot reach a real container whatever it says."""
+    return _extract_straggler_loop()
+
+
+@pytest.fixture
+def straggler_loop_only() -> str:
+    """The loop, cleared for execution against the REAL docker daemon.
+
+    Fails the test at SETUP if the loop's project-label filters are not
+    overridable -- a hardcoded filter would make every test in this file run
+    `docker stop && docker rm` over the live dev stack (issue #693), so it must
+    never be handed out."""
+    loop = _extract_straggler_loop()
+
+    expansions = _project_label_expansions(loop)
+    if not expansions:
+        pytest.fail(
+            "no 'label=com.docker.compose.project=' filter found in the straggler loop -- "
+            "it may have regressed to a bare name-prefix match, or moved"
+        )
+    hardcoded = [e for e in expansions if not e.startswith("${")]
+    if hardcoded:
+        pytest.fail(
+            "the straggler loop hardcodes a compose project label "
+            f"({hardcoded!r}) instead of reading ${{{PROJECT_LABEL_VAR}}}/"
+            f"${{{PROJECT_LABEL_ALT_VAR}}}. Refusing to run it: executing this loop "
+            "unscoped stops and removes the live dev stack (issue #693)."
+        )
+    return loop
+
+
+@pytest.fixture
+def throwaway_project_namespace() -> tuple[str, str]:
+    """A per-test pair of compose project names that no real container carries.
+
+    These stand in for ``opentranscribe`` / ``transcribe-app`` while the loop
+    runs, so 'a container belonging to this project' can be asserted on without
+    'this project' meaning the developer's running stack."""
+    token = uuid.uuid4().hex
+    return (f"opentranscribe-pytest-{token}", f"transcribe-app-pytest-{token}")
 
 
 @pytest.fixture
@@ -75,18 +254,16 @@ def throwaway_containers():
     if not _docker_available():
         pytest.skip("docker daemon not reachable")
 
-    suffix = uuid.uuid4().hex[:8]
     created: list[str] = []
 
     def _make(name: str, project_label: str | None) -> str:
-        full_name = f"{name}-{suffix}"
-        cmd = ["docker", "run", "-d", "--name", full_name]
+        cmd = ["docker", "run", "-d", "--name", name]
         if project_label is not None:
             cmd += ["--label", f"com.docker.compose.project={project_label}"]
         cmd += ["alpine:3.20", "sleep", "300"]
         subprocess.run(cmd, capture_output=True, check=True, timeout=30)
-        created.append(full_name)
-        return full_name
+        created.append(name)
+        return name
 
     yield _make
 
@@ -104,28 +281,142 @@ def _container_exists(name: str) -> bool:
     return name in result.stdout.split()
 
 
-def test_a_container_sharing_only_the_name_prefix_survives(
-    straggler_loop_only, throwaway_containers
-):
-    """The exact live defect: a container named opentranscribe-<x> that is NOT
-    labeled with this project's compose project must not be touched."""
-    unrelated = throwaway_containers(
-        "opentranscribe-unrelated-dashboard", project_label="some-other-app"
+# --------------------------------------------------------------------------
+# Containment guards -- no real docker, safe with a live stack up.
+# --------------------------------------------------------------------------
+
+
+def test_the_loop_reads_its_project_labels_from_overridable_variables(raw_straggler_loop):
+    """Fail-closed precondition, asserted in its own right so a regression reports
+    as one failure here rather than as four confusing setup errors below: every
+    compose-project filter in the loop must be an overridable ``${...}``
+    expansion. A hardcoded one puts the live dev stack back in blast range."""
+    expansions = _project_label_expansions(raw_straggler_loop)
+    assert expansions, (
+        "no 'label=com.docker.compose.project=' filter found in the straggler loop -- "
+        "it may have regressed to a bare name-prefix match, or moved"
+    )
+    assert [e for e in expansions if not e.startswith("${")] == [], (
+        "the straggler loop hardcodes a compose project label instead of reading "
+        f"${{{PROJECT_LABEL_VAR}}}/${{{PROJECT_LABEL_ALT_VAR}}} -- executing it "
+        "unscoped stops and removes the live dev stack (issue #693)"
     )
 
-    subprocess.run(["bash", "-c", straggler_loop_only], capture_output=True, timeout=60)
+
+def test_the_loop_can_only_select_containers_in_the_configured_namespace(
+    raw_straggler_loop, throwaway_project_namespace, tmp_path
+):
+    """The issue #693 guard: with the overrides set, every selection the loop
+    performs is confined to this test's namespace. Nothing else -- no real
+    project label, no unfiltered `docker ps` -- may appear."""
+    primary, alternate = throwaway_project_namespace
+    calls = _run_loop_with_fake_docker(
+        raw_straggler_loop,
+        tmp_path,
+        overrides={PROJECT_LABEL_VAR: primary, PROJECT_LABEL_ALT_VAR: alternate},
+        # A poisoned selection: if the loop ever ignored its own filters, these
+        # are the names it would act on.
+        ps_output="opentranscribe-backend\nopentranscribe-postgres",
+    )
+
+    selections = [call for call in calls if call and call[0] == "ps"]
+    assert len(selections) == 2, (
+        f"expected exactly two container selections in the straggler loop, got {selections!r}"
+    )
+
+    project_filters = {
+        arg for call in selections for arg in call if arg.startswith(LABEL_FILTER_PREFIX)
+    }
+    assert project_filters == {
+        f"{LABEL_FILTER_PREFIX}{primary}",
+        f"{LABEL_FILTER_PREFIX}{alternate}",
+    }, (
+        "the straggler loop queried docker for a compose project outside this test's "
+        f"namespace -- it can reach real containers: {project_filters!r}"
+    )
+
+    unfiltered = [
+        call for call in selections if not any(arg.startswith(LABEL_FILTER_PREFIX) for arg in call)
+    ]
+    assert unfiltered == [], (
+        f"a `docker ps` in the straggler loop carries no project-label filter: {unfiltered!r}"
+    )
+
+
+def test_with_the_override_unset_the_loop_targets_the_real_project_names(
+    raw_straggler_loop, tmp_path
+):
+    """Production default, unchanged: with neither override exported, the loop
+    filters on exactly the two real compose project names it always did."""
+    calls = _run_loop_with_fake_docker(raw_straggler_loop, tmp_path, overrides={})
+
+    selections = [call for call in calls if call and call[0] == "ps"]
+    project_filters = {
+        arg for call in selections for arg in call if arg.startswith(LABEL_FILTER_PREFIX)
+    }
+    assert project_filters == {
+        f"{LABEL_FILTER_PREFIX}{REAL_PROJECT_LABEL}",
+        f"{LABEL_FILTER_PREFIX}{REAL_PROJECT_LABEL_ALT}",
+    }, (
+        "parameterising the project label changed what `./opentr.sh stop` does by default -- "
+        f"it must be byte-identical to the previous hardcoded filters, got {project_filters!r}"
+    )
+
+
+def test_the_loop_still_stops_and_removes_whatever_it_selects(
+    raw_straggler_loop, throwaway_project_namespace, tmp_path
+):
+    """Control for the two guards above: proving the loop asks narrow questions
+    is worthless if it no longer acts on the answers."""
+    primary, alternate = throwaway_project_namespace
+    calls = _run_loop_with_fake_docker(
+        raw_straggler_loop,
+        tmp_path,
+        overrides={PROJECT_LABEL_VAR: primary, PROJECT_LABEL_ALT_VAR: alternate},
+        ps_output=f"{primary}-straggler",
+    )
+
+    assert ["stop", f"{primary}-straggler"] in calls, (
+        f"the loop selected a straggler but never stopped it: {calls!r}"
+    )
+    assert ["rm", f"{primary}-straggler"] in calls, (
+        f"the loop stopped a straggler but never removed it: {calls!r}"
+    )
+
+
+# --------------------------------------------------------------------------
+# The original four, now scoped to a throwaway project namespace.
+# --------------------------------------------------------------------------
+
+
+@requires_docker
+def test_a_container_sharing_only_the_name_prefix_survives(
+    straggler_loop_only, throwaway_project_namespace, throwaway_containers
+):
+    """The exact live defect: a container named like this project's containers
+    that is NOT labeled with this project's compose project must not be touched."""
+    primary, _ = throwaway_project_namespace
+    unrelated = throwaway_containers(
+        f"{primary}-unrelated-dashboard", project_label="some-other-app"
+    )
+
+    _run_real_loop(straggler_loop_only, throwaway_project_namespace)
 
     assert _container_exists(unrelated), (
-        "a container that only shares the 'opentranscribe-' name prefix, but belongs to a "
+        "a container that only shares the project's name prefix, but belongs to a "
         "DIFFERENT compose project, was removed -- this is the exact live incident"
     )
 
 
-def test_a_real_project_container_is_still_cleaned_up(straggler_loop_only, throwaway_containers):
+@requires_docker
+def test_a_real_project_container_is_still_cleaned_up(
+    straggler_loop_only, throwaway_project_namespace, throwaway_containers
+):
     """Control: the loop must still do its actual job for a genuine straggler."""
-    real = throwaway_containers("opentranscribe-genuine-straggler", project_label="opentranscribe")
+    primary, _ = throwaway_project_namespace
+    real = throwaway_containers(f"{primary}-genuine-straggler", project_label=primary)
 
-    subprocess.run(["bash", "-c", straggler_loop_only], capture_output=True, timeout=60)
+    _run_real_loop(straggler_loop_only, throwaway_project_namespace)
 
     assert not _container_exists(real), (
         "a container genuinely labeled as belonging to this project's compose deployment "
@@ -133,31 +424,31 @@ def test_a_real_project_container_is_still_cleaned_up(straggler_loop_only, throw
     )
 
 
+@requires_docker
 def test_the_transcribe_app_project_container_is_also_cleaned_up(
-    straggler_loop_only, throwaway_containers
+    straggler_loop_only, throwaway_project_namespace, throwaway_containers
 ):
     """The diar-native service has no explicit container_name, so its project
     is the checkout directory's basename -- must be covered too, not just
-    'opentranscribe'."""
-    diar = throwaway_containers(
-        "transcribe-app-diar-native-straggler", project_label="transcribe-app"
-    )
+    'opentranscribe'. Here that second project name is the namespace's alternate."""
+    _, alternate = throwaway_project_namespace
+    diar = throwaway_containers(f"{alternate}-diar-native-straggler", project_label=alternate)
 
-    subprocess.run(["bash", "-c", straggler_loop_only], capture_output=True, timeout=60)
+    _run_real_loop(straggler_loop_only, throwaway_project_namespace)
 
-    assert not _container_exists(diar), (
-        "a genuine transcribe-app-project straggler was not cleaned up"
-    )
+    assert not _container_exists(diar), "a genuine second-project straggler was not cleaned up"
 
 
+@requires_docker
 def test_an_unlabeled_container_sharing_the_name_prefix_survives(
-    straggler_loop_only, throwaway_containers
+    straggler_loop_only, throwaway_project_namespace, throwaway_containers
 ):
     """A container with no compose project label at all (e.g. a bare `docker run`,
     not part of any compose deployment) must not be treated as a straggler just
     because its name happens to start with the right prefix."""
-    bare = throwaway_containers("opentranscribe-bare-docker-run", project_label=None)
+    primary, _ = throwaway_project_namespace
+    bare = throwaway_containers(f"{primary}-bare-docker-run", project_label=None)
 
-    subprocess.run(["bash", "-c", straggler_loop_only], capture_output=True, timeout=60)
+    _run_real_loop(straggler_loop_only, throwaway_project_namespace)
 
     assert _container_exists(bare), "an unlabeled container was removed on name prefix alone"

--- a/backend/tests/unit/test_reindex_cancel_scope.py
+++ b/backend/tests/unit/test_reindex_cancel_scope.py
@@ -1,0 +1,342 @@
+"""The cancel flag names the run it cancels (issue #691).
+
+``POST /search/reindex`` fans out one coordinator per owner (#627) while
+``POST /search/reindex/stop`` set a single ``reindex_cancel:{caller}`` key, so an
+admin could start a deployment-wide re-embed and cancel only their own share of
+it. The endpoint half of the fix — flagging every owner in the recorded fan-out —
+is covered in ``tests/api/endpoints/test_search_admin_routes.py``. This module
+covers the half that makes it *work*: the coordinator that most needs to see the
+flag has not started yet.
+
+With fewer Celery workers than owners the caller's coordinator runs while owners
+B..N sit in the broker queue, and every coordinator clears the cancel flag on
+entry — a flag left by an earlier run must not abort the next legitimate reindex
+after its first file. A flag carrying only ``"1"`` would therefore be erased by
+the very coordinator it was written for. Naming the run is what separates "I was
+cancelled before I started" from "someone else's flag is lying around", and both
+directions are pinned here: the first as an abort, the second as a run that
+proceeds.
+
+**Nothing here reaches Redis, Postgres or OpenSearch.** The Redis client is a
+dict-backed stand-in, and the one coordinator test that is expected to *proceed*
+is stopped at its first database call by a marker exception, so no file is ever
+re-embedded.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+
+from app.services.search import reindex_cancel
+
+#: Raised in place of the coordinator's first DB access, so "it got past the
+#: cancellation check" is observable without running a real re-index.
+REACHED_FILE_SNAPSHOT = "REACHED-THE-FILE-SNAPSHOT"
+
+
+class _StandInRedis:
+    """The five operations the cancel flag, the fan-out record and the lock use."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+
+    def get(self, key: str) -> str | None:
+        return self.store.get(key)
+
+    def setex(self, key: str, _ttl: int, value: str) -> None:
+        self.store[key] = value
+
+    def set(self, key: str, value: str, nx: bool = False, ex: int | None = None) -> bool:
+        if nx and key in self.store:
+            return False
+        self.store[key] = value
+        return True
+
+    def exists(self, key: str) -> int:
+        return 1 if key in self.store else 0
+
+    def delete(self, *keys: str) -> int:
+        return sum(1 for key in keys if self.store.pop(key, None) is not None)
+
+
+@pytest.fixture
+def fake_redis():
+    """Point every ``get_redis()`` the cancel plane resolves at one dict.
+
+    ``reindex_cancel`` imports ``get_redis`` inside each function body precisely
+    so this single patch reaches it; ``reindex_task`` binds it at module import,
+    hence the second target.
+    """
+    fake = _StandInRedis()
+    with (
+        patch("app.core.redis.get_redis", return_value=fake),
+        patch("app.tasks.reindex_task.get_redis", return_value=fake),
+    ):
+        yield fake
+
+
+# ---------------------------------------------------------------------------
+# consume_pending_cancel — the one decision a coordinator makes on entry
+# ---------------------------------------------------------------------------
+def test_a_cancel_naming_this_run_is_reported_and_cleared(fake_redis):
+    """The stop landed while this coordinator was queued: it must not index."""
+    fake_redis.store["reindex_cancel:7"] = "run-A"
+
+    assert reindex_cancel.consume_pending_cancel(7, "run-A") is True
+    assert "reindex_cancel:7" not in fake_redis.store
+
+
+def test_a_cancel_naming_another_run_is_cleared_and_not_honoured(fake_redis):
+    """A flag from an earlier run is stale — clearing it is the pre-#691 behaviour.
+
+    This is the direction that keeps a *second* re-index startable while the first
+    one is still cancelling. Honouring any truthy flag here would let one run
+    inherit another's cancellation, and the panel would look permanently broken.
+    """
+    fake_redis.store["reindex_cancel:7"] = "run-A"
+
+    assert reindex_cancel.consume_pending_cancel(7, "run-B") is False
+    assert "reindex_cancel:7" not in fake_redis.store
+
+
+def test_the_legacy_flag_value_never_cancels_a_queued_run(fake_redis):
+    """``"1"`` is what ``stop`` writes when it has no run id to name.
+
+    It is truthy on purpose — the batch workers of an already-running coordinator
+    still stop on it — but it must never equal a task id, or a maintenance-era
+    flag would abort a brand new coordinator.
+    """
+    fake_redis.store["reindex_cancel:7"] = reindex_cancel.LEGACY_CANCEL_VALUE
+
+    assert reindex_cancel.consume_pending_cancel(7, "run-B") is False
+    assert "reindex_cancel:7" not in fake_redis.store
+
+
+def test_no_pending_cancel_is_not_a_cancellation(fake_redis):
+    assert reindex_cancel.consume_pending_cancel(7, "run-B") is False
+
+
+def test_a_bytes_valued_flag_still_matches_its_run(fake_redis):
+    """``get_redis()`` sets no ``decode_responses``, so values come back as bytes.
+
+    Comparing a task id against ``b"run-A"`` is always False, which would silently
+    reduce the fix to the per-owner behaviour it replaces.
+    """
+    fake_redis.store["reindex_cancel:7"] = b"run-A"  # type: ignore[assignment]
+
+    assert reindex_cancel.consume_pending_cancel(7, "run-A") is True
+
+
+# ---------------------------------------------------------------------------
+# The batch worker's read — the same run-naming rule, mid-run
+# ---------------------------------------------------------------------------
+def test_a_batch_worker_stops_on_a_flag_naming_its_own_run(fake_redis):
+    from app.tasks import reindex_task as rix
+
+    fake_redis.store["reindex_cancel:7"] = "run-mine"
+
+    assert rix._is_cancellation_requested(7, "run-mine") is True
+
+
+def test_a_batch_worker_stops_on_the_legacy_flag(fake_redis):
+    """``stop`` writes ``"1"`` for a run it has no id for — a maintenance-dispatched
+    coordinator. Its workers must still stop, exactly as before #691."""
+    from app.tasks import reindex_task as rix
+
+    fake_redis.store["reindex_cancel:7"] = reindex_cancel.LEGACY_CANCEL_VALUE
+
+    assert rix._is_cancellation_requested(7, "run-mine") is True
+
+
+def test_a_batch_worker_ignores_a_flag_naming_a_finished_run(fake_redis):
+    """Why the workers had to become run-aware as well, not just the coordinators.
+
+    ``stop`` now flags several owners from a fan-out record that carries its own
+    TTL. A record outliving its coordinators, plus a later stop, would write flags
+    for owners whose ``search_index_maintenance`` runs had since started on their
+    own schedule — cancelling a live, unrelated reindex. Before #691 ``stop``
+    could only ever flag the caller, so this could not happen.
+    """
+    from app.tasks import reindex_task as rix
+
+    fake_redis.store["reindex_cancel:7"] = "run-that-already-finished"
+
+    assert rix._is_cancellation_requested(7, "run-mine") is False
+
+
+def test_a_caller_with_no_run_identity_still_honours_any_flag(fake_redis):
+    """The legacy batch message: a pre-upgrade coordinator queued it without a
+    ``run_id``, and it must keep behaving as it did rather than becoming
+    uncancellable."""
+    from app.tasks import reindex_task as rix
+
+    fake_redis.store["reindex_cancel:7"] = "run-that-already-finished"
+
+    assert rix._is_cancellation_requested(7) is True
+
+
+# ---------------------------------------------------------------------------
+# The fan-out record — what `stop` enumerates
+# ---------------------------------------------------------------------------
+def test_the_fanout_record_round_trips_owner_ids_as_ints(fake_redis):
+    """JSON object keys are strings; the owners must come back as ints.
+
+    ``stop`` formats them straight into ``reindex_cancel:{user_id}``, so a string
+    key writes ``reindex_cancel:41`` from ``"41"`` and happens to look right —
+    until it is compared against an int elsewhere.
+    """
+    reindex_cancel.record_fanout(3, {41: "coordinator-41", 42: "coordinator-42"})
+
+    assert reindex_cancel.read_fanout(3) == {41: "coordinator-41", 42: "coordinator-42"}
+
+
+def test_an_admin_with_no_recorded_fanout_reads_an_empty_mapping(fake_redis):
+    assert reindex_cancel.read_fanout(3) == {}
+
+
+def test_an_unreadable_fanout_record_is_discarded_rather_than_raising(fake_redis):
+    """A corrupt payload must degrade `stop` to the caller, not 500 the endpoint."""
+    fake_redis.store["reindex_fanout:3"] = "{not json"
+
+    assert reindex_cancel.read_fanout(3) == {}
+
+
+def test_an_empty_dispatch_records_nothing(fake_redis):
+    """No coordinators, no record — a stale record would outlive its run."""
+    reindex_cancel.record_fanout(3, {})
+
+    assert "reindex_fanout:3" not in fake_redis.store
+
+
+def test_request_cancel_flags_every_owner_with_its_own_run_id(fake_redis):
+    flagged = reindex_cancel.request_cancel({42: "coordinator-42", 41: "coordinator-41"})
+
+    assert flagged == [41, 42]
+    assert fake_redis.store["reindex_cancel:41"] == "coordinator-41"
+    assert fake_redis.store["reindex_cancel:42"] == "coordinator-42"
+
+
+def test_clearing_the_fanout_leaves_the_cancel_flags_alone(fake_redis):
+    """The record is consumed by `stop`; the flags are consumed by the coordinators."""
+    reindex_cancel.record_fanout(3, {41: "coordinator-41"})
+    reindex_cancel.request_cancel({41: "coordinator-41"})
+
+    reindex_cancel.clear_fanout(3)
+
+    assert "reindex_fanout:3" not in fake_redis.store
+    assert fake_redis.store["reindex_cancel:41"] == "coordinator-41"
+
+
+def test_a_stored_record_carries_the_expiry_that_bounds_a_crashed_run(fake_redis):
+    """Asserted on the module constant, which the endpoint and the docs both cite.
+
+    A record with no TTL survives the coordinators it describes and a later `stop`
+    then flags owners whose runs finished hours ago.
+    """
+    assert reindex_cancel.FANOUT_TTL_SECONDS == 3600
+    assert reindex_cancel.CANCEL_TTL_SECONDS == 3600
+
+
+# ---------------------------------------------------------------------------
+# The coordinator itself — the queued-run abort, and its control
+# ---------------------------------------------------------------------------
+@contextmanager
+def _busy_index_structure_lock():
+    """Report the shared-index structure lock as held elsewhere.
+
+    ⚠️ Yielding True instead would run the real ``_check_and_recreate_stale_index``
+    and ``recreate_index_for_dimension`` against whatever OpenSearch this process
+    is configured for — and the second of those **deletes the chunks index** when
+    the stored dimension disagrees. The busy branch is a documented no-op path
+    (the run still indexes its own files; the next pass re-checks the structure),
+    so it exercises the coordinator without ever touching a cluster.
+    """
+    yield False
+
+
+def _raise_at_the_file_snapshot():
+    raise RuntimeError(REACHED_FILE_SNAPSHOT)
+
+
+def _run_coordinator(*, user_id: int, task_id: str):
+    """Run the real coordinator eagerly with every slow seam stopped short.
+
+    The DB snapshot is replaced by a marker exception, which the coordinator's own
+    handler turns into ``{"error": ...}`` — so "it proceeded" and "it aborted" are
+    two different return values from one unmodified code path.
+    """
+    from app.tasks import reindex_task as rix
+
+    # ``session_scope`` is patched at its DEFINING module, not on ``rix``: the
+    # coordinator re-imports it in its own body, so a module-attribute patch is
+    # shadowed and the real query runs against whatever database is configured.
+    with (
+        patch.object(rix, "_index_structure_lock", _busy_index_structure_lock),
+        patch.object(rix, "_ensure_neural_pipeline_ready", return_value=False),
+        patch.object(rix, "_restore_normal_mode"),
+        patch.object(rix, "_clear_stale_progress"),
+        patch("app.db.session_utils.session_scope", _raise_at_the_file_snapshot),
+    ):
+        return rix.reindex_transcripts_task.apply(
+            kwargs={"user_id": user_id}, task_id=task_id
+        ).result
+
+
+def test_a_coordinator_cancelled_while_queued_aborts_and_releases_its_lock(fake_redis):
+    """The case the per-owner flag could not express.
+
+    ``stop`` writes ``reindex_cancel:{owner} = <that owner's coordinator id>``
+    while the coordinator is still in the broker queue. Before #691 the value was
+    ``"1"``, the coordinator cleared it on entry and re-embedded the owner's whole
+    account anyway — which on a single-worker deployment is every owner but the
+    caller.
+    """
+    fake_redis.store["reindex_cancel:7"] = "run-queued"
+
+    result = _run_coordinator(user_id=7, task_id="run-queued")
+
+    assert result["status"] == "cancelled"
+    assert "reindex_cancel:7" not in fake_redis.store
+    assert "reindex_lock:7" not in fake_redis.store
+
+
+def test_a_coordinator_carrying_a_stale_flag_still_runs(fake_redis):
+    """The control: without it, "abort on any flag" would pass the test above.
+
+    A flag naming some other run is the residue of a previous reindex. Aborting on
+    it would make every reindex after a cancelled one a silent no-op, which is a
+    worse defect than the one being fixed.
+    """
+    fake_redis.store["reindex_cancel:7"] = "some-older-run"
+
+    result = _run_coordinator(user_id=7, task_id="run-fresh")
+
+    assert REACHED_FILE_SNAPSHOT in result["error"]
+    assert "reindex_cancel:7" not in fake_redis.store
+
+
+def test_an_uncancelled_coordinator_runs(fake_redis):
+    """The second control: no flag at all must behave exactly as it always has."""
+    result = _run_coordinator(user_id=7, task_id="run-fresh")
+
+    assert REACHED_FILE_SNAPSHOT in result["error"]
+
+
+def test_the_two_key_shapes_match_what_the_startup_sweep_expects(fake_redis):
+    """``app/main.py`` sweeps ``reindex_cancel:*`` on API restart, deliberately.
+
+    A cancel request is meaningless after a restart and clearing one can only
+    cause a reindex to run, never to delete. ``reindex_fanout:*`` is deliberately
+    NOT in that list — the API process restarts independently of the workers still
+    executing the fan-out, and deleting the record takes ``stop``'s only handle on
+    them with it. Both properties depend on these two prefixes staying distinct.
+    """
+    reindex_cancel.request_cancel({41: "coordinator-41"})
+    reindex_cancel.record_fanout(3, {41: "coordinator-41"})
+
+    assert reindex_cancel.CANCEL_KEY.format(user_id=41) == "reindex_cancel:41"
+    assert reindex_cancel.FANOUT_KEY.format(admin_id=3) == "reindex_fanout:3"
+    assert sorted(fake_redis.store) == ["reindex_cancel:41", "reindex_fanout:3"]

--- a/backend/tests/unit/test_reindex_run_scoped_state.py
+++ b/backend/tests/unit/test_reindex_run_scoped_state.py
@@ -278,7 +278,11 @@ def _run_batch(monkeypatch, file_ids: list[int], *args: Any) -> dict[str, Any]:
             return 7
 
     monkeypatch.setattr(reindex_task, "_load_reindex_page", _page)
-    monkeypatch.setattr(reindex_task, "_is_cancellation_requested", lambda user_id: False)  # noqa: ARG005
+    monkeypatch.setattr(
+        reindex_task,
+        "_is_cancellation_requested",
+        lambda user_id, run_id=None: False,  # noqa: ARG005
+    )
     monkeypatch.setattr(
         "app.services.search.indexing_service.TranscriptIndexingService", _FakeIndexing
     )

--- a/backend/tests/unit/test_search_index_health_repair.py
+++ b/backend/tests/unit/test_search_index_health_repair.py
@@ -550,3 +550,81 @@ def test_the_structure_lock_is_scoped_to_the_index_name():
         tl.task_lock_manager = original
 
     assert captured == [f"opensearch_index_structure_lock:{settings.OPENSEARCH_CHUNKS_INDEX}"]
+
+
+# ---------------------------------------------------------------------------
+# Anti-drift guard (issue #692): the repair path reads its dispatch result by
+# key, and `.get(key, 0)` cannot tell "the key is absent" from "the count is
+# zero". `rebuild_chunks_index` read `dispatched`, which
+# `dispatch_reindex_for_every_owner` has never returned, so the repair log
+# reported "0 owners" on every run however many it actually fanned out to.
+#
+# Structural rather than behavioural on purpose: the defect is a key that does
+# not exist, so the check that catches it is "every key read is a key
+# returned". A log-text assertion would pin one message and miss the next one.
+# ---------------------------------------------------------------------------
+
+
+def _returned_dict_keys(source: str, func_name: str) -> set[str]:
+    """Every literal key in every dict `func_name` returns."""
+    tree = ast.parse(source)
+    keys: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef) or node.name != func_name:
+            continue
+        for sub in ast.walk(node):
+            if isinstance(sub, ast.Return) and isinstance(sub.value, ast.Dict):
+                keys |= {
+                    k.value
+                    for k in sub.value.keys
+                    if isinstance(k, ast.Constant) and isinstance(k.value, str)
+                }
+    return keys
+
+
+def _keys_read_off(source: str, func_name: str, var_name: str) -> set[str]:
+    """Every literal key read via ``<var_name>.get("...")`` inside ``func_name``."""
+    tree = ast.parse(source)
+    keys: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef) or node.name != func_name:
+            continue
+        for sub in ast.walk(node):
+            if (
+                isinstance(sub, ast.Call)
+                and isinstance(sub.func, ast.Attribute)
+                and sub.func.attr == "get"
+                and isinstance(sub.func.value, ast.Name)
+                and sub.func.value.id == var_name
+                and sub.args
+                and isinstance(sub.args[0], ast.Constant)
+                and isinstance(sub.args[0].value, str)
+            ):
+                keys.add(sub.args[0].value)
+    return keys
+
+
+def test_the_repair_log_reads_only_keys_the_dispatcher_returns():
+    """A `.get()` on a key that is never returned reports its default forever."""
+    import app.services.search.index_health as health_mod
+    import app.services.search.model_switch as switch_mod
+
+    returned = _returned_dict_keys(
+        Path(switch_mod.__file__).read_text(),
+        "dispatch_reindex_for_every_owner",
+    )
+    assert returned, "could not find the dispatcher's returned keys — the guard would be vacuous"
+
+    read = _keys_read_off(
+        Path(health_mod.__file__).read_text(),
+        "rebuild_chunks_index",
+        "result",
+    )
+    assert read, "could not find any key read off the dispatch result — the guard would be vacuous"
+
+    unknown = read - returned
+    assert not unknown, (
+        f"rebuild_chunks_index reads {sorted(unknown)} off dispatch_reindex_for_every_owner's "
+        f"result, but it only ever returns {sorted(returned)}. A `.get(key, default)` on an "
+        f"absent key silently reports the default — issue #692."
+    )

--- a/backend/tests/unit/test_semantic_confidence_threshold.py
+++ b/backend/tests/unit/test_semantic_confidence_threshold.py
@@ -1,0 +1,257 @@
+"""``SEARCH_SEMANTIC_HIGH_CONFIDENCE`` has exactly one value, read from ``settings``.
+
+Two call sites in ``hybrid_search_service`` decide ``SearchHit.semantic_confidence``
+(``"high"`` / ``"low"``) for a semantic-only file:
+
+* ``_process_collapsed_results``   — the single-phase collapse path
+* ``_build_search_hit_from_bucket`` — the two-phase (non-relevance sort) path
+
+Both read the setting, and both used to read it through ``getattr(settings, ...)`` with a
+**divergent** inline fallback: ``0.015`` at the first site, ``0.010`` at the second. Because
+``SEARCH_SEMANTIC_HIGH_CONFIDENCE`` is a declared field on the ``BaseSettings`` subclass it can
+never be absent, so *both* fallbacks were unreachable and the effective threshold was ``0.010``
+at both sites. The code nonetheless read as if two different thresholds were in play, and the
+next reader to "honour" the 0.015 would have changed live ranking behaviour by accident.
+
+The guard below is source-level on purpose: a behavioural test cannot see a dead default, so
+it cannot fail when one is reintroduced. ``test_no_call_site_supplies_an_inline_default`` is the
+red-before/green-after assertion; the behavioural pair beside it pins that both sites actually
+track ``settings`` rather than a literal of their own.
+
+Pattern follows ``tests/api/test_file_mutation_permissions.py``'s ``MUTATING_ENDPOINTS``
+anti-drift guard — AST, not grep, so a mention in a docstring or comment cannot satisfy it.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+from app.core.config import Settings
+from app.core.config import settings
+from app.services.search.hybrid_search_service import HybridSearchService
+
+SETTING_NAME = "SEARCH_SEMANTIC_HIGH_CONFIDENCE"
+
+APP_DIR = pathlib.Path(__file__).resolve().parents[2] / "app"
+SERVICE_PATH = APP_DIR / "services" / "search" / "hybrid_search_service.py"
+
+# The two functions that classify a semantic-only hit's confidence. Both must read the
+# setting, and neither may carry a default of its own.
+EXPECTED_READER_FUNCTIONS = {
+    "_process_collapsed_results",
+    "_build_search_hit_from_bucket",
+}
+
+
+def _enclosing_function_by_lineno(tree: ast.AST) -> dict[int, str]:
+    """Map every line inside a function body to that function's name."""
+    spans: dict[int, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            end = node.end_lineno or node.lineno
+            for line in range(node.lineno, end + 1):
+                spans[line] = node.name
+    return spans
+
+
+def _attribute_reads(path: pathlib.Path) -> list[tuple[str, int]]:
+    """``(enclosing function, lineno)`` for each ``<something>.SETTING_NAME`` read."""
+    tree = ast.parse(path.read_text(), filename=str(path))
+    spans = _enclosing_function_by_lineno(tree)
+    return sorted(
+        (spans.get(node.lineno, "<module>"), node.lineno)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Attribute) and node.attr == SETTING_NAME
+    )
+
+
+def _getattr_reads_with_default(path: pathlib.Path) -> list[tuple[str, int, object]]:
+    """``(enclosing function, lineno, default)`` for ``getattr(x, "SETTING_NAME", <default>)``."""
+    tree = ast.parse(path.read_text(), filename=str(path))
+    spans = _enclosing_function_by_lineno(tree)
+    found: list[tuple[str, int, object]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Name) and func.id == "getattr"):
+            continue
+        if len(node.args) < 2:
+            continue
+        name_arg = node.args[1]
+        if not (isinstance(name_arg, ast.Constant) and name_arg.value == SETTING_NAME):
+            continue
+        default: object = None
+        if len(node.args) > 2:
+            default_node = node.args[2]
+            # A non-literal default is still an inline default; report it by source shape.
+            default = (
+                default_node.value
+                if isinstance(default_node, ast.Constant)
+                else ast.unparse(default_node)
+            )
+        found.append((spans.get(node.lineno, "<module>"), node.lineno, default))
+    return sorted(found, key=lambda item: item[1])
+
+
+def test_the_setting_is_declared_so_no_fallback_can_ever_be_reached():
+    """Evidence that the removed inline defaults were dead code, not live behaviour.
+
+    ``Settings`` is a ``BaseSettings`` subclass and ``SEARCH_SEMANTIC_HIGH_CONFIDENCE`` is a
+    declared field with a default, so every instance carries the attribute. A
+    ``getattr(settings, ..., <fallback>)`` therefore never returns its fallback.
+    """
+    assert SETTING_NAME in Settings.model_fields
+    assert hasattr(settings, SETTING_NAME)
+    assert Settings.model_fields[SETTING_NAME].default == pytest.approx(0.010)
+
+
+def test_no_call_site_supplies_an_inline_default():
+    """RED before the fix: both sites passed a (different) literal fallback to ``getattr``.
+
+    Fails with the exact function and line of any ``getattr(..., "SEARCH_SEMANTIC_HIGH_
+    CONFIDENCE", <default>)`` anywhere under ``app/`` — the shape that lets a second,
+    unreachable value for this threshold re-enter the codebase.
+    """
+    offenders: list[tuple[str, str, int, object]] = []
+    for path in sorted(APP_DIR.rglob("*.py")):
+        for func, lineno, default in _getattr_reads_with_default(path):
+            offenders.append((str(path.relative_to(APP_DIR)), func, lineno, default))
+
+    assert not offenders, (
+        f"{SETTING_NAME} must be read as settings.{SETTING_NAME} with no inline default. "
+        f"Offending getattr call site(s) (file, function, line, default): {offenders}. "
+        "The value lives in app/core/config.py and nowhere else."
+    )
+
+
+def test_both_confidence_call_sites_read_the_setting_directly():
+    """Anti-drift: exactly the two classification functions read the setting, via attribute.
+
+    Catches a site being deleted (losing the classification) as well as a third one appearing
+    without this guard being updated.
+    """
+    reads = _attribute_reads(SERVICE_PATH)
+    functions = {func for func, _ in reads}
+
+    assert functions == EXPECTED_READER_FUNCTIONS, (
+        f"{SETTING_NAME} attribute reads in {SERVICE_PATH.name} live in {sorted(functions)}, "
+        f"expected {sorted(EXPECTED_READER_FUNCTIONS)}. Reads found at: {reads}"
+    )
+    assert len(reads) == len(EXPECTED_READER_FUNCTIONS), (
+        f"Expected exactly one read per classification function, found {reads}"
+    )
+
+
+def _collapsed_response(score: float) -> dict:
+    """A one-file collapsed response whose single inner hit is semantic-only.
+
+    No ``highlight`` on the inner hit and an empty query mean ``_process_inner_hits`` records
+    ``keyword_count == 0``, which is the ``is_semantic_only`` branch under test.
+    """
+    return {
+        "hits": {
+            "hits": [
+                {
+                    "_score": score,
+                    "_source": {
+                        "file_uuid": "file-under-test",
+                        "file_id": 1,
+                        "title": "Quarterly planning",
+                        "speakers": [],
+                        "tags": [],
+                        "language": "en",
+                        "content_type": "audio/wav",
+                    },
+                    "inner_hits": {
+                        "segments": {
+                            "hits": {
+                                "total": {"value": 1},
+                                "hits": [
+                                    {
+                                        "_score": score,
+                                        "_source": {
+                                            "content": "we should revisit the roadmap",
+                                            "speaker": "SPEAKER_00",
+                                            "start_time": 0.0,
+                                            "end_time": 3.0,
+                                            "chunk_index": 0,
+                                        },
+                                    }
+                                ],
+                            }
+                        }
+                    },
+                }
+            ]
+        }
+    }
+
+
+def _bucket_and_phase2(score: float) -> tuple[dict, dict]:
+    """A Phase-1 bucket plus the Phase-2 lookup entry for the same file, semantic-only."""
+    bucket = {
+        "key": "file-under-test",
+        "title_kw": {"buckets": [{"key": "Quarterly planning"}]},
+        "language_kw": {"buckets": [{"key": "en"}]},
+        "content_type_kw": {"buckets": [{"key": "audio/wav"}]},
+        "speakers_kw": {"buckets": []},
+        "tags_kw": {"buckets": []},
+        "max_duration": {"value": 60.0},
+        "max_file_size": {"value": 1024},
+        "max_upload_time": {"value_as_string": "2026-01-01T00:00:00Z"},
+        "min_file_id": {"value": 1},
+    }
+    phase2 = {
+        "occurrences": [object()],
+        "title_highlighted": "",
+        "match_sources": [],
+        "keyword_count": 0,
+        "semantic_count": 1,
+        "best_score": score,
+    }
+    return bucket, phase2
+
+
+def _confidence_from_collapsed_path(score: float) -> str:
+    hits, _ = HybridSearchService()._process_collapsed_results(_collapsed_response(score), "")
+    assert len(hits) == 1, "fixture should yield exactly one collapsed file group"
+    return hits[0].semantic_confidence
+
+
+def _confidence_from_two_phase_path(score: float) -> str:
+    bucket, phase2 = _bucket_and_phase2(score)
+    hit = HybridSearchService()._build_search_hit_from_bucket(bucket, phase2, "")
+    assert hit is not None, "fixture should yield a SearchHit"
+    return hit.semantic_confidence
+
+
+@pytest.mark.parametrize("threshold", [0.010, 0.25])
+def test_both_paths_switch_at_the_same_configured_threshold(monkeypatch, threshold):
+    """Both classification paths must move together when the single setting moves.
+
+    Probed just below, exactly at, and just above the configured value. A site carrying its own
+    literal instead of the setting disagrees with the other at the ``0.25`` parametrization.
+    """
+    monkeypatch.setattr(settings, SETTING_NAME, threshold)
+    below, at, above = threshold - 0.001, threshold, threshold + 0.001
+
+    assert _confidence_from_collapsed_path(below) == "low"
+    assert _confidence_from_two_phase_path(below) == "low"
+    assert _confidence_from_collapsed_path(at) == "high"
+    assert _confidence_from_two_phase_path(at) == "high"
+    assert _confidence_from_collapsed_path(above) == "high"
+    assert _confidence_from_two_phase_path(above) == "high"
+
+
+@pytest.mark.parametrize("score", [0.005, 0.0125, 0.02])
+def test_the_two_paths_agree_on_every_probe_score(score):
+    """The two sites classify identically at the deployed threshold.
+
+    ``0.0125`` sits between the two former inline defaults (0.010 and 0.015), so this probe is
+    the one that would disagree if a site ever honoured a 0.015 of its own.
+    """
+    assert _confidence_from_collapsed_path(score) == _confidence_from_two_phase_path(score)

--- a/backend/tests/unit/test_similarity_service_cosine_range.py
+++ b/backend/tests/unit/test_similarity_service_cosine_range.py
@@ -1,0 +1,260 @@
+"""``SimilarityService`` must report one cosine space from every method (issue #690).
+
+Cosine lives in ``[-1, 1]``. ``cosine_similarity`` and ``batch_cosine_similarity``
+used to clamp to ``[0, 1]`` while ``opensearch_similarity_search`` — a method on the
+*same class* — returned the unclamped ``(2 * score) - 1`` conversion. Two callers of
+one class therefore got different ranges for the same quantity, and every negative
+collapsed to exactly ``0.0``, making "opposite" and "orthogonal" indistinguishable.
+
+The negative region is populated in practice, not theoretical, and OpenSearch really
+does return it. Measured against a live ``lucene``/``cosinesimil`` index at five
+points — cosine ``-1.0 -> 0.0``, ``-0.6 -> 0.2``, ``0.0 -> 0.5``, ``+0.6 -> 0.8``,
+``+1.0 -> 1.0`` — so ``(1 + cos) / 2`` is exact, ``2 * score - 1`` inverts it
+exactly, and a negative cosine comes back **unclamped**. Independently,
+``backend/app/services/CLAUDE.md`` records a measured different-speaker mean of
+**0.094** over 134 AMI ground-truth windows, *with real negatives*.
+
+These tests pin the restored invariant — the torch path and the OpenSearch path
+agree on the same vector pair, across the whole domain — and pin the removal of the
+``boost_recent`` parameter, which documented a recency boost that was referenced
+nowhere in the body.
+"""
+
+import ast
+import inspect
+from collections.abc import Callable
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from app.services.similarity_service import SimilarityService
+
+pytestmark = pytest.mark.unit
+
+# The query vector every pair below is scored against.
+UNIT_X = np.array([1.0, 0.0, 0.0], dtype=np.float64)
+
+# (label, other vector, exact cosine against UNIT_X). Hand-computed: every vector
+# is unit-norm, so the cosine is just its x component.
+COSINE_PAIRS = [
+    ("opposite", [-1.0, 0.0, 0.0], -1.0),
+    ("mostly opposite", [-0.6, 0.8, 0.0], -0.6),
+    ("orthogonal", [0.0, 1.0, 0.0], 0.0),
+    ("mostly aligned", [0.6, 0.8, 0.0], 0.6),
+    ("identical", [1.0, 0.0, 0.0], 1.0),
+]
+NEGATIVE_PAIRS = [pair for pair in COSINE_PAIRS if pair[2] < 0.0]
+
+
+class _FakeCosinesimilIndex:
+    """Stands in for an OpenSearch index mapped ``"space_type": "cosinesimil"``.
+
+    Scores documents the way OpenSearch does — ``(1 + cosine) / 2`` — and applies
+    ``min_score`` in that same space. The arithmetic is spelled out here rather
+    than taken from :mod:`app.utils.cosine_space` on purpose: a fake that shares
+    the function under test cannot disagree with it.
+    """
+
+    def __init__(self, raw_cosines: list[float]) -> None:
+        self._raw_cosines = list(raw_cosines)
+        self.last_body: dict | None = None
+
+    def search(self, index: str, body: dict) -> dict:
+        self.last_body = body
+        min_score = body.get("min_score")
+        hits = []
+        for speaker_id, raw_cosine in enumerate(self._raw_cosines, start=1):
+            score = (1.0 + raw_cosine) / 2.0
+            if min_score is not None and score < min_score:
+                continue
+            hits.append({"_score": score, "_source": {"speaker_id": speaker_id}})
+        return {"hits": {"hits": hits}}
+
+
+@pytest.fixture
+def fake_index(monkeypatch):
+    """Install a fake cosinesimil index and hand the factory back to the test."""
+    from app.services import opensearch_service
+
+    def _install(raw_cosines: list[float]) -> _FakeCosinesimilIndex:
+        index = _FakeCosinesimilIndex(raw_cosines)
+        monkeypatch.setattr(opensearch_service, "opensearch_client", index)
+        return index
+
+    return _install
+
+
+# ---------------------------------------------------------------------------
+# The clamp: negatives must survive both in-process paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("label", "other", "expected"), NEGATIVE_PAIRS)
+def test_cosine_similarity_preserves_a_negative_cosine(label, other, expected):
+    """A [0, 1] clamp reported 0.0 here, erasing the sign and the magnitude."""
+    result = SimilarityService.cosine_similarity(UNIT_X, np.array(other, dtype=np.float64))
+
+    assert result == pytest.approx(expected, abs=1e-6), label
+    assert result < 0.0, f"{label}: the negative half of the cosine domain was clamped away"
+
+
+def test_batch_cosine_similarity_preserves_negative_cosines():
+    """The batch path clamped identically and must move with its sibling."""
+    targets = [np.array(other, dtype=np.float64) for _, other, _ in COSINE_PAIRS]
+
+    results = SimilarityService.batch_cosine_similarity(UNIT_X, targets)
+
+    assert len(results) == len(COSINE_PAIRS)
+    assert results == [pytest.approx(expected, abs=1e-6) for _, _, expected in COSINE_PAIRS]
+    assert results[0] < 0.0, "cosine -1.0 came back non-negative"
+    assert results[1] < 0.0, "cosine -0.6 came back non-negative"
+
+
+def test_the_two_in_process_methods_report_the_same_value():
+    """One class, one space: the scalar and batch paths must not diverge."""
+    targets = [np.array(other, dtype=np.float64) for _, other, _ in COSINE_PAIRS]
+
+    batched = SimilarityService.batch_cosine_similarity(UNIT_X, targets)
+    scalar = [SimilarityService.cosine_similarity(UNIT_X, target) for target in targets]
+
+    assert len(scalar) == len(COSINE_PAIRS)
+    assert batched == [pytest.approx(value, abs=1e-6) for value in scalar]
+
+
+def test_the_clamp_still_bounds_float_rounding_to_the_cosine_domain():
+    """Removing the [0, 1] clamp must not remove bounding — only widen it."""
+    aligned = SimilarityService.cosine_similarity(UNIT_X, UNIT_X)
+    opposite = SimilarityService.cosine_similarity(UNIT_X, -UNIT_X)
+
+    assert aligned <= 1.0
+    assert opposite >= -1.0
+    assert aligned == pytest.approx(1.0, abs=1e-6)
+    assert opposite == pytest.approx(-1.0, abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# The invariant being restored: both paths agree on the SAME vector pair
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("label", "other", "expected"), COSINE_PAIRS)
+def test_the_torch_path_and_the_opensearch_path_agree_on_one_vector_pair(
+    fake_index, label, other, expected
+):
+    """The actual defect: the same pair scored two different numbers.
+
+    The in-process torch cosine and the ``cosinesimil`` round trip are two
+    implementations of one quantity. Before the fix they agreed on the positive
+    half and disagreed by the whole magnitude on the negative half — the torch
+    path saying ``0.0`` where OpenSearch said ``-0.6``.
+    """
+    other_vector = np.array(other, dtype=np.float64)
+
+    in_process = SimilarityService.cosine_similarity(UNIT_X, other_vector)
+
+    # The index holds one document, at exactly this pair's true cosine.
+    index = fake_index([expected])
+    results = SimilarityService.opensearch_similarity_search(
+        embedding=UNIT_X.tolist(),
+        user_id=1,
+        index_name="speakers",
+        # -1.0 admits the whole domain, so the gate cannot hide a disagreement.
+        min_raw_cosine=-1.0,
+    )
+
+    assert index.last_body is not None, f"{label}: no query reached OpenSearch"
+    assert len(results) == 1, f"{label}: the candidate was gated out before it could be compared"
+    assert results[0]["similarity"] == pytest.approx(in_process, abs=1e-6), (
+        f"{label}: the torch path and the OpenSearch path report different cosines"
+    )
+    assert in_process == pytest.approx(expected, abs=1e-6), label
+
+
+# ---------------------------------------------------------------------------
+# boost_recent: a documented scoring feature that never existed
+# ---------------------------------------------------------------------------
+
+
+def test_opensearch_similarity_search_has_no_boost_recent_parameter():
+    params = inspect.signature(SimilarityService.opensearch_similarity_search).parameters
+
+    # Control: prove we are inspecting the function we think we are, so the
+    # absence assertion below cannot pass against the wrong object.
+    assert "min_raw_cosine" in params
+    assert "boost_recent" not in params
+
+
+def test_passing_boost_recent_is_now_rejected(fake_index):
+    """An old call site keeping the kwarg fails loudly instead of being ignored.
+
+    Bound through a ``Callable[..., object]`` deliberately: the call this test
+    makes is one the *static* signature forbids — that is the property under
+    test — so spelling it directly would be a type error rather than a runtime
+    assertion. The rejection itself is real, and mypy still checks every other
+    call to this function in the tree.
+    """
+    fake_index([0.9])
+    search: Callable[..., object] = SimilarityService.opensearch_similarity_search
+
+    with pytest.raises(TypeError, match="boost_recent"):
+        search(embedding=[0.0] * 8, user_id=1, boost_recent=True)
+
+
+def test_the_search_still_works_without_it(fake_index):
+    """The control for the test above: the same call minus the dead kwarg passes."""
+    fake_index([0.9])
+
+    results = SimilarityService.opensearch_similarity_search(
+        embedding=[0.0] * 8,
+        user_id=1,
+    )
+
+    assert len(results) == 1
+    assert results[0]["similarity"] == pytest.approx(0.9)
+
+
+def _names_boost_recent_in_code(source: str) -> bool:
+    """True when ``boost_recent`` appears as CODE — a parameter, argument or name.
+
+    Deliberately AST-based rather than a substring search: this file and
+    ``similarity_service``'s own docstring both mention the removed parameter by
+    name to explain why it is gone, and prose about a deletion is not a call site.
+    """
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.keyword) and node.arg == "boost_recent":
+            return True
+        if isinstance(node, ast.arg) and node.arg == "boost_recent":
+            return True
+        if isinstance(node, ast.Name) and node.id == "boost_recent":
+            return True
+        if isinstance(node, ast.Attribute) and node.attr == "boost_recent":
+            return True
+    return False
+
+
+def test_the_boost_recent_detector_fires_on_real_code():
+    """Guard the guard: a scanner that matches nothing passes everything."""
+    assert _names_boost_recent_in_code("search(user_id=1, boost_recent=True)")
+    assert _names_boost_recent_in_code("def search(embedding, boost_recent=True): pass")
+    assert _names_boost_recent_in_code("x = boost_recent")
+    # ...and stays clean on prose that merely names it.
+    assert not _names_boost_recent_in_code('"""There is no boost_recent parameter."""')
+
+
+def test_no_production_call_site_names_boost_recent():
+    """A dead parameter is only gone once no code under ``app/`` references it."""
+    app_root = Path(__file__).resolve().parents[2] / "app"
+    sources = sorted(app_root.rglob("*.py"))
+
+    assert len(sources) > 100, f"the scan found only {len(sources)} files — wrong root?"
+    assert app_root / "services" / "similarity_service.py" in sources
+
+    offenders = [
+        str(path.relative_to(app_root))
+        for path in sources
+        if _names_boost_recent_in_code(path.read_text(encoding="utf-8"))
+    ]
+
+    assert offenders == []

--- a/backend/tests/unit/test_task_session_lifetime.py
+++ b/backend/tests/unit/test_task_session_lifetime.py
@@ -616,7 +616,7 @@ def reindex_env(db_session, monkeypatch):
     monkeypatch.setattr(rix, "session_scope", tracker.scope)
     monkeypatch.setattr(rix, "get_redis", lambda: _FakeRedis())
     monkeypatch.setattr(rix, "_send_reindex_progress", lambda *a, **kw: None)
-    monkeypatch.setattr(rix, "_is_cancellation_requested", lambda user_id: False)
+    monkeypatch.setattr(rix, "_is_cancellation_requested", lambda user_id, run_id=None: False)
     monkeypatch.setattr(rix, "_handle_reindex_completion", lambda *a, **kw: None)
 
     class _FakeTracker:

--- a/opentr.sh
+++ b/opentr.sh
@@ -2856,8 +2856,16 @@ stop_all_containers() {
   # explicit container_name) and "transcribe-app" (docker-compose.diar-native.yml's
   # diar-native service has no explicit container_name, so compose falls back
   # to the checkout directory's basename as the project name).
-  for container in $( { docker ps -a --filter 'label=com.docker.compose.project=opentranscribe' --format '{{.Names}}' 2>/dev/null
-                        docker ps -a --filter 'label=com.docker.compose.project=transcribe-app' --format '{{.Names}}' 2>/dev/null
+  #
+  # The two project names are parameterised ONLY so the test that drives this
+  # real loop body (backend/tests/unit/test_opentr_stop_container_scoping.py)
+  # can point it at a throwaway namespace instead of the live stack -- running
+  # the loop unmodified against a developer's daemon destroyed 16 running
+  # containers (issue #693). Nothing in this script, and nothing shipped, ever
+  # sets them: unset, both expand to the literals they replaced, so `opentr.sh
+  # stop` behaves exactly as before.
+  for container in $( { docker ps -a --filter "label=com.docker.compose.project=${OPENTR_STOP_PROJECT_LABEL:-opentranscribe}" --format '{{.Names}}' 2>/dev/null
+                        docker ps -a --filter "label=com.docker.compose.project=${OPENTR_STOP_PROJECT_LABEL_ALT:-transcribe-app}" --format '{{.Names}}' 2>/dev/null
                       } | sort -u ); do
     docker stop "$container" 2>/dev/null && docker rm "$container" 2>/dev/null || true
   done


### PR DESCRIPTION
Follow-up fixes for every issue the v0.5.0 cleanup batch (#694) surfaced, plus one defect found during a cosine-space audit. Each lane was built in its own worktree and is one commit here.

**Every lane's RED and GREEN were re-run by me independently, not accepted on report.**

## Commits

| Commit | Issue | What |
|---|---|---|
| `c1464632` | **#693** (P0) | The backend suite no longer destroys a live dev stack |
| `1d5e0cd3` | **#692** | Index-repair log reports the real owner count, not always 0 |
| `90674d40` | — | `SEARCH_SEMANTIC_HIGH_CONFIDENCE` read from one source |
| `75553ecd` | **#690** | `SimilarityService` reports one cosine space; dead `boost_recent` removed |
| `7457afe8` | **#689** (P1) | User deletion refuses an account owning legally-held files |
| `b77d7762` | Refs #689 | Retrack the `min_permission` site that commit shifted |
| `39ea50c7` | **#691** | `stop` cancels the whole reindex fan-out, not just the caller's share |

## Verification

- **Full backend suite: 12,647 tests, 12,488 passed, 0 failures, 0 errors** (159 skipped)
- **Dev stack through that run: 17 containers → 17 containers** — the #693 fix, proven
- Commit-stage gate: 26 hooks passed · push-stage gate: passed (vite build + recursive `bandit -r`)
- Merge-base is current `origin/master` (`9b1976ae`); clean merge

## #693 is the one to read closely

`test_opentr_stop_container_scoping.py` extracted the **real** `docker stop && docker rm` loop from `opentr.sh` and executed it against every container carrying the compose project label. It destroyed all 17 containers of a running dev stack during a routine `pytest tests/` — from a file in `tests/unit/` with no marker, in the default selection.

The tests are valuable (they pin a real past incident), so the loop still runs for real; only its *namespace* moved. Three layers guard it:

1. `opentr.sh`'s loop reads `${OPENTR_STOP_PROJECT_LABEL:-opentranscribe}` / `${..._ALT:-transcribe-app}`. **Nothing ships setting either**, so `opentr.sh stop` is unchanged — verified by running both loop versions against a fake `docker` and diffing the recorded argv: byte-identical.
2. The fixture **refuses at setup** to hand out a loop whose project filters aren't overridable, so a regression can't execute unscoped.
3. A fake-`docker`-on-`PATH` test asserts the filters actually issued name only the test's own `*-pytest-<uuid4>` namespace.

⚠️ The live stack's label is **`transcribe-app`**, not `opentranscribe` — the destruction came through the *second* filter.

## Three lanes changed their issue's premise

- **#691** — a naive "flag every owner" fix would have been a **no-op**. Every coordinator clears the cancel flag on entry, so a `"1"` flag is erased by the very coordinator it was written for. Cancellation is now keyed on the coordinator's run id.
- **#689** — the issue named one caller; there are **two** (`admin.py:861` and `users.py:674`). And placing the guard inside `_delete_user_media_files` would have left two prior deletions pending in the session on the `users.py` path, so the pre-flight sits at each endpoint, before anything is destroyed.
- **Semantic confidence** — my hypothesis that `search_mode="semantic"` reached the threshold was **wrong**; that mode is rejected with a 400. The unfused path is reachable in ordinary hybrid mode via `_bm25_leg_is_starved`, which is worse, not better.

## Cosine handling verified empirically

Against a live index using the production mapping (`lucene` / `cosinesimil`): cos −1.0→0.0, −0.6→0.2, 0.0→0.5, +0.6→0.8, +1.0→1.0. `(1+cos)/2` exact at all five points. All 11 read sites convert; the one `min_score` write converts; the chunk-retrieval sites carry RRF scores, not cosine.

## Still open, deliberately

- **#688** — finding 4 (the DDL two-pass split) needs a quiet-machine measurement; `Refs`, not `Closes`.
- **#695** — deleting a user orphans their MinIO objects. Verified, filed, kept out of #689: different property, destructive path, deserves its own review.

Closes #693. (The other four close from their individual commits — a comma-list in a PR body only auto-links the first.)
