### PR TITLE
fix(diar): route on sidecar readiness, not liveness

### DIFF
--- a/backend/app/services/native_embedding_client.py
+++ b/backend/app/services/native_embedding_client.py
@@ -38,7 +38,7 @@ import logging
 import numpy as np
 
 from app.transcription.diarizer_native import post_json
-from app.transcription.diarizer_native import sidecar_healthy
+from app.transcription.diarizer_native import sidecar_ready
 
 logger = logging.getLogger(__name__)
 
@@ -62,10 +62,13 @@ _EMBED_TIMEOUT_S = 60.0
 def native_embedding_available(base_url: str | None = None) -> bool:
     """True when the sidecar can serve embeddings right now.
 
-    Shares ``diarizer_native.sidecar_healthy`` so the embedding path and the
-    diarization path agree on what "the sidecar is up" means.
+    Shares ``diarizer_native.sidecar_ready`` so the embedding path and the
+    diarization path agree on what "the sidecar can serve" means — readiness, not mere
+    liveness. ``/embed_window`` runs the same weights ``/diarize`` does, so a sidecar
+    whose models are unusable cannot serve embeddings either, however cheerfully its
+    ``/healthz`` answers 200.
     """
-    return sidecar_healthy(base_url)
+    return sidecar_ready(base_url)
 
 
 def fit_to_window(samples: np.ndarray) -> list[np.ndarray]:

--- a/backend/app/transcription/diarizer_native.py
+++ b/backend/app/transcription/diarizer_native.py
@@ -31,6 +31,7 @@ import contextlib
 import logging
 import os
 import time
+import urllib.error
 import urllib.request
 import uuid
 import wave
@@ -79,11 +80,16 @@ def default_base_url() -> str:
 
 
 def sidecar_healthy(base_url: str | None = None) -> bool:
-    """True when the diar-native sidecar answers /healthz.
+    """True when the diar-native sidecar is LIVE — the process is up and answering.
 
-    Used by ModelManager to decide, per task, whether the native engine can serve — in
-    both directions: a live sidecar that went away, and a recovered one that a worker
-    running on the PyAnnote fallback should return to.
+    ⚠️ This is liveness, NOT readiness, and the difference is not academic. diar-native's
+    ``/healthz`` returns 200 in *every* model state, including "no models" and "models
+    known to be unusable". That is deliberate on the sidecar's side: the compose
+    healthcheck gates on this endpoint, so a container that has not provisioned yet must
+    not be marked unhealthy and fail ``compose up --wait`` for the whole stack.
+
+    The consequence is that "answers /healthz" does not imply "can diarize". To decide
+    whether to route work at the sidecar, use :func:`sidecar_ready`.
     """
     url = (base_url or _DEFAULT_URL).rstrip("/")
     try:
@@ -92,6 +98,67 @@ def sidecar_healthy(base_url: str | None = None) -> bool:
         ) as resp:
             return bool(resp.status == 200)
     except Exception:  # noqa: BLE001 — unreachable for any reason means "not healthy"
+        return False
+
+
+def sidecar_status(base_url: str | None = None) -> dict:
+    """The sidecar's ``/healthz`` body, or ``{}`` if it cannot be read.
+
+    Used only to attach a REASON to a readiness failure. Never used to decide readiness:
+    the status code carries that, and parsing a body to make a routing decision would
+    reintroduce the coupling ``/readyz`` exists to remove.
+    """
+    import json
+
+    url = (base_url or _DEFAULT_URL).rstrip("/")
+    try:
+        with urllib.request.urlopen(  # noqa: S310  # nosec B310 — internal service
+            f"{url}/healthz", timeout=5
+        ) as resp:
+            body = json.loads(resp.read())
+            # A 0.2.0 sidecar answers /healthz with the bare string "ok", so the body is
+            # not guaranteed to be an object. A non-dict means "no reason available".
+            return body if isinstance(body, dict) else {}
+    except Exception:  # noqa: BLE001 — a missing reason must never fail the caller
+        return {}
+
+
+def sidecar_ready(base_url: str | None = None) -> bool:
+    """True when the sidecar can actually SERVE — models present and verified.
+
+    This is the predicate to route on. ``/readyz`` is 200 only once the models are
+    verified and 503 otherwise, so unlike :func:`sidecar_healthy` it distinguishes
+    "still provisioning" and "models broken" from "ready to work".
+
+    Before this existed, engine selection asked ``/healthz`` and therefore treated a
+    sidecar with an unusable models directory as a working one: the native engine was
+    chosen, and the failure surfaced at request time instead of at the point where the
+    in-process PyAnnote fallback was still available to choose.
+
+    **Older sidecars have no ``/readyz``** (it landed in diar-native 0.3.0) and answer
+    404. That is not "not ready" — it is "cannot say", so we fall back to liveness and
+    preserve the previous behaviour rather than disabling the native engine outright for
+    anyone still pinned to a pre-0.3.0 image.
+    """
+    url = (base_url or _DEFAULT_URL).rstrip("/")
+    try:
+        with urllib.request.urlopen(  # noqa: S310  # nosec B310 — internal service
+            f"{url}/readyz", timeout=5
+        ) as resp:
+            return bool(resp.status == 200)
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            logger.debug("diar-native sidecar has no /readyz (pre-0.3.0); falling back to /healthz")
+            return sidecar_healthy(base_url)
+        status = sidecar_status(base_url)
+        logger.warning(
+            "diar-native sidecar is up but not ready (HTTP %s, models_state=%s): %s",
+            exc.code,
+            status.get("models_state", "unknown"),
+            status.get("models_reason", "no reason given"),
+        )
+        return False
+    except Exception:  # noqa: BLE001 — unreachable for any reason means "not ready"
         return False
 
 
@@ -128,18 +195,23 @@ class NativeSpeakerDiarizer:
     # -- lifecycle ---------------------------------------------------------
 
     def load_model(self) -> None:
-        """Health-check the sidecar (weights live server-side; nothing loads here)."""
-        try:
-            with urllib.request.urlopen(  # noqa: S310  # nosec B310 — internal service
-                f"{self.base_url}/healthz", timeout=10
-            ) as resp:
-                self.is_loaded = resp.status == 200
-        except Exception as exc:  # noqa: BLE001
+        """Readiness-check the sidecar (weights live server-side; nothing loads here).
+
+        Deliberately ``sidecar_ready`` and not ``sidecar_healthy``: this method exists to
+        answer "can this object serve diarization", and a sidecar whose models directory
+        is empty or broken answers /healthz with a cheerful 200. Raising here routes the
+        caller to the PyAnnote fallback while it is still a choice.
+        """
+        if not sidecar_healthy(self.base_url):
+            raise RuntimeError(f"diar-native sidecar unavailable at {self.base_url}")
+        if not sidecar_ready(self.base_url):
+            status = sidecar_status(self.base_url)
             raise RuntimeError(
-                f"diar-native sidecar unavailable at {self.base_url}: {exc}"
-            ) from exc
-        if not self.is_loaded:
-            raise RuntimeError(f"diar-native sidecar unhealthy at {self.base_url}")
+                f"diar-native sidecar at {self.base_url} is up but not ready "
+                f"(models_state={status.get('models_state', 'unknown')}): "
+                f"{status.get('models_reason', 'no reason given')}"
+            )
+        self.is_loaded = True
         logger.info("diar-native sidecar ready at %s", self.base_url)
 
     def unload_model(self) -> None:

--- a/backend/app/transcription/model_manager.py
+++ b/backend/app/transcription/model_manager.py
@@ -135,14 +135,31 @@ class ModelManager:
         if not native_selected:
             return not native_cached
 
-        from app.transcription.diarizer_native import sidecar_healthy
+        from app.transcription.diarizer_native import sidecar_ready
 
-        healthy = sidecar_healthy()
-        if native_cached and not healthy:
-            logger.warning("diar-native sidecar is unreachable; falling back to PyAnnote")
-        elif healthy and not native_cached:
-            logger.info("diar-native sidecar is healthy again; leaving the PyAnnote fallback")
-        return native_cached == healthy
+        # Readiness, not liveness. /healthz answers 200 even when the models are absent or
+        # known-bad, so probing it here kept selecting the native engine for a sidecar that
+        # could not actually diarize, and the failure then surfaced at request time instead
+        # of here, where the PyAnnote fallback was still available to choose. /readyz is 200
+        # only once the models are verified. Pre-0.3.0 sidecars have no /readyz and fall
+        # back to liveness inside sidecar_ready, so an older pin behaves as it did before.
+        ready = sidecar_ready()
+        if native_cached and not ready:
+            # "Gone" and "up but cannot serve" are different operator problems with
+            # different fixes, so they get different messages. The extra probe only runs
+            # on the failure path, which is approximately never in normal operation.
+            from app.transcription.diarizer_native import sidecar_healthy
+
+            if sidecar_healthy():
+                logger.warning(
+                    "diar-native sidecar is up but not ready (models missing or unusable); "
+                    "falling back to PyAnnote"
+                )
+            else:
+                logger.warning("diar-native sidecar is unreachable; falling back to PyAnnote")
+        elif ready and not native_cached:
+            logger.info("diar-native sidecar is ready again; leaving the PyAnnote fallback")
+        return native_cached == ready
 
     def ensure_models_loaded(self, config: TranscriptionConfig) -> None:
         """Preload both models for concurrent mode.

--- a/backend/tests/unit/test_diar_native_readiness_gate.py
+++ b/backend/tests/unit/test_diar_native_readiness_gate.py
@@ -1,0 +1,174 @@
+"""The sidecar routing predicate must be READINESS, not liveness (diar-native #679).
+
+diar-native's ``/healthz`` returns **200 in every model state**, including "no models
+provisioned" and "models known to be unusable". That is deliberate on the sidecar's side:
+the compose healthcheck gates on that endpoint, so a container that has not provisioned
+yet must not be marked unhealthy and fail ``compose up --wait`` for the whole stack.
+
+The consequence, which this module exists to pin down, is that "answers /healthz" does not
+imply "can diarize". Until ``sidecar_ready`` existed, engine selection asked ``/healthz``,
+so a sidecar with a broken models directory read as healthy, the native engine was selected
+anyway, and the failure surfaced at request time instead of at the point where the
+in-process PyAnnote fallback was still available to choose.
+
+Measured against the real diar-native 0.3.1 image with an unmarked models directory, which
+is the exact state these servers imitate::
+
+    GET /healthz  -> 200  {"status":"ok","models_verified":false,"models_state":"unverified"}
+    GET /readyz   -> 503
+
+Every server below is a REAL ``http.server`` on a real port, following
+``test_diarizer_engine_selection.py``: the failure mode being guarded is a wrong status code
+being interpreted, so a patched exception would assert the mock rather than the behaviour.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import http.server
+import json
+import socket
+import threading
+from collections.abc import Iterator
+
+import pytest
+
+from app.services.native_embedding_client import native_embedding_available
+from app.transcription.diarizer_native import NativeSpeakerDiarizer
+from app.transcription.diarizer_native import sidecar_healthy
+from app.transcription.diarizer_native import sidecar_ready
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+# The three sidecar states that matter. `readyz` is the status code /readyz returns;
+# None means the route does not exist at all, which is what a pre-0.3.0 sidecar does.
+_UNPROVISIONED = {
+    "status": "ok",
+    "models_verified": False,
+    "models_state": "unverified",
+    "models_reason": "No provisioning marker (diar-provision.json) in /models.",
+}
+_READY = {"status": "ok", "models_verified": True, "models_state": "verified"}
+
+
+def _make_handler(readyz: int | None, health_body: dict):
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802 - stdlib handler method name
+            if self.path == "/healthz":
+                payload = json.dumps(health_body).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                self.wfile.write(payload)
+            elif self.path == "/readyz" and readyz is not None:
+                self.send_response(readyz)
+                self.end_headers()
+            else:
+                self.send_response(404)
+                self.end_headers()
+
+        def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+            pass
+
+    return _Handler
+
+
+@contextlib.contextmanager
+def _sidecar(readyz: int | None, health_body: dict) -> Iterator[str]:
+    """A real HTTP sidecar stand-in; yields its base URL."""
+    port = _free_port()
+    httpd = http.server.HTTPServer(("127.0.0.1", port), _make_handler(readyz, health_body))
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        with contextlib.suppress(Exception):
+            httpd.shutdown()
+            httpd.server_close()
+
+
+class TestReadinessIsNotLiveness:
+    def test_unprovisioned_sidecar_is_healthy_but_not_ready(self):
+        """The whole point: 200 on /healthz, 503 on /readyz, and they must disagree.
+
+        This is the case that was previously invisible. If sidecar_ready ever collapses
+        back into sidecar_healthy, this is the assertion that fails.
+        """
+        with _sidecar(readyz=503, health_body=_UNPROVISIONED) as url:
+            assert sidecar_healthy(url) is True, "liveness must still be true, by design"
+            assert sidecar_ready(url) is False, "readiness must reflect the 503"
+
+    def test_provisioned_sidecar_is_both(self):
+        with _sidecar(readyz=200, health_body=_READY) as url:
+            assert sidecar_healthy(url) is True
+            assert sidecar_ready(url) is True
+
+    def test_unreachable_sidecar_is_neither(self):
+        """Real unreachability: the server is shut down before the probe."""
+        with _sidecar(readyz=200, health_body=_READY) as url:
+            pass  # context manager has now stopped the server
+        assert sidecar_healthy(url) is False
+        assert sidecar_ready(url) is False
+
+    def test_pre_0_3_0_sidecar_without_readyz_falls_back_to_liveness(self):
+        """A 404 on /readyz means "cannot say", not "not ready".
+
+        /readyz landed in diar-native 0.3.0. Treating its absence as a negative would
+        disable the native engine outright for anyone still pinned to an older image,
+        turning a compatibility gap into an outage.
+        """
+        with _sidecar(readyz=None, health_body=_UNPROVISIONED) as url:
+            assert sidecar_ready(url) is True
+
+    def test_not_ready_is_logged_with_the_sidecar_s_own_reason(self, caplog):
+        """A silent fallback is the failure mode; the reason must reach the operator."""
+        with _sidecar(readyz=503, health_body=_UNPROVISIONED) as url, caplog.at_level("WARNING"):
+            assert sidecar_ready(url) is False
+        assert "not ready" in caplog.text
+        assert "unverified" in caplog.text
+        assert "No provisioning marker" in caplog.text
+
+
+class TestRoutingUsesReadiness:
+    def test_load_model_refuses_an_unprovisioned_sidecar(self):
+        """Refusing here routes the caller to PyAnnote while that is still a choice.
+
+        Before this change load_model checked /healthz, so it succeeded against a sidecar
+        that could not diarize and the job failed later, mid-transcription.
+        """
+        with _sidecar(readyz=503, health_body=_UNPROVISIONED) as url:
+            diarizer = NativeSpeakerDiarizer(config=None, base_url=url)
+            with pytest.raises(RuntimeError, match="not ready"):
+                diarizer.load_model()
+            assert diarizer.is_loaded is False
+
+    def test_load_model_accepts_a_ready_sidecar(self):
+        with _sidecar(readyz=200, health_body=_READY) as url:
+            diarizer = NativeSpeakerDiarizer(config=None, base_url=url)
+            diarizer.load_model()
+            assert diarizer.is_loaded is True
+
+    def test_load_model_error_carries_the_reason(self):
+        """ "Not ready" alone sends the operator to the logs; the reason should be inline."""
+        with _sidecar(readyz=503, health_body=_UNPROVISIONED) as url:
+            diarizer = NativeSpeakerDiarizer(config=None, base_url=url)
+            with pytest.raises(RuntimeError, match="No provisioning marker"):
+                diarizer.load_model()
+
+    def test_embedding_path_agrees_with_the_diarization_path(self):
+        """/embed_window runs the same weights, so it cannot serve when they are unusable.
+
+        These two predicates are shared deliberately. If they diverge, speaker embeddings
+        get routed to a sidecar the diarizer has already rejected.
+        """
+        with _sidecar(readyz=503, health_body=_UNPROVISIONED) as url:
+            assert native_embedding_available(url) is False
+        with _sidecar(readyz=200, health_body=_READY) as url:
+            assert native_embedding_available(url) is True

--- a/backend/tests/unit/test_diarizer_engine_selection.py
+++ b/backend/tests/unit/test_diarizer_engine_selection.py
@@ -222,17 +222,26 @@ class TestOverlapDiarizationEnabled:
 
 
 class TestDiarizerCurrent:
-    def test_native_selected_and_healthy_keeps_native_cached(self, monkeypatch: pytest.MonkeyPatch):
+    def test_native_selected_and_ready_keeps_native_cached(self, monkeypatch: pytest.MonkeyPatch):
+        """The routing probe is READINESS (/readyz), not liveness (/healthz).
+
+        /healthz answers 200 in every model state, including "models unusable", so it
+        cannot decide whether to send work here. See test_diar_native_readiness_gate.py.
+        """
         monkeypatch.setattr(
-            "app.transcription.diarizer_native.sidecar_healthy", lambda *a, **kw: True
+            "app.transcription.diarizer_native.sidecar_ready", lambda *a, **kw: True
         )
         config = TranscriptionConfig(diarizer_backend="native")
         cached = cast(SpeakerDiarizer, NativeSpeakerDiarizer(config))
         assert ModelManager._diarizer_current(cached, config) is True
 
-    def test_native_selected_but_unhealthy_swaps_and_logs(
+    def test_native_selected_but_unreachable_swaps_and_logs(
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ):
+        """A sidecar that is GONE must say "unreachable", not merely "not ready"."""
+        monkeypatch.setattr(
+            "app.transcription.diarizer_native.sidecar_ready", lambda *a, **kw: False
+        )
         monkeypatch.setattr(
             "app.transcription.diarizer_native.sidecar_healthy", lambda *a, **kw: False
         )
@@ -242,16 +251,41 @@ class TestDiarizerCurrent:
         assert ModelManager._diarizer_current(cached, config) is False
         assert any("unreachable" in r.message for r in caplog.records)
 
+    def test_native_selected_but_unready_says_so_rather_than_unreachable(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        """ "Gone" and "up but cannot serve" are different problems with different fixes.
+
+        Logging the second as "unreachable" would send an operator to check networking
+        when the actual fault is an unprovisioned or broken models directory.
+        """
+        monkeypatch.setattr(
+            "app.transcription.diarizer_native.sidecar_ready", lambda *a, **kw: False
+        )
+        monkeypatch.setattr(
+            "app.transcription.diarizer_native.sidecar_healthy", lambda *a, **kw: True
+        )
+        config = TranscriptionConfig(diarizer_backend="native")
+        cached = cast(SpeakerDiarizer, NativeSpeakerDiarizer(config))
+        caplog.set_level(logging.WARNING)
+        assert ModelManager._diarizer_current(cached, config) is False
+        assert any("up but not ready" in r.message for r in caplog.records)
+        assert not any("unreachable" in r.message for r in caplog.records)
+
     def test_pyannote_selected_rejects_native_cached(self, monkeypatch: pytest.MonkeyPatch):
         """Pinning pyannote explicitly means a cached native instance is always stale —
         and no sidecar probe should even run for a pinned-pyannote config."""
         probed: list[int] = []
 
-        def _fake_healthy(*_a: object, **_kw: object) -> bool:
+        def _fake_probe(*_a: object, **_kw: object) -> bool:
             probed.append(1)
             return True
 
-        monkeypatch.setattr("app.transcription.diarizer_native.sidecar_healthy", _fake_healthy)
+        # BOTH predicates, so this stays a real assertion. The routing probe moved from
+        # sidecar_healthy to sidecar_ready; patching only the old one would leave this
+        # test passing vacuously while a probe it is meant to forbid ran unnoticed.
+        monkeypatch.setattr("app.transcription.diarizer_native.sidecar_healthy", _fake_probe)
+        monkeypatch.setattr("app.transcription.diarizer_native.sidecar_ready", _fake_probe)
         config = TranscriptionConfig(diarizer_backend="pyannote")
         cached = cast(SpeakerDiarizer, NativeSpeakerDiarizer(config))
         assert ModelManager._diarizer_current(cached, config) is False


### PR DESCRIPTION
Closes the gap tracked in #679. Related to #696, but independent of it: this is correct on the 0.2.0 sidecar running today and on 0.3.x.

## The problem

diar-native's `/healthz` returns **200 in every model state**, including "no models provisioned" and "models known to be unusable". That is deliberate on the sidecar's side and it is the right call: the compose healthcheck gates on that endpoint, so a container that has not provisioned yet must not be marked unhealthy and fail `compose up --wait` for the whole stack.

The consequence is that **"answers /healthz" does not imply "can diarize"**. `sidecar_healthy()` was exactly that check, and `ModelManager` used its result per task to choose the native engine over the in-process PyAnnote fallback. So a sidecar with an unusable models directory read as healthy, the native engine was selected anyway, and the failure surfaced at request time instead of here, where the fallback was still available to choose.

Measured against the real diar-native 0.3.1 image with an unmarked models directory, which is the exact state the new tests imitate:

```
GET /healthz  -> 200  {"status":"ok","models_verified":false,"models_state":"unverified", ...}
GET /readyz   -> 503
```

## The change

`sidecar_ready()` probes `/readyz`, which is 200 only once the models are verified. The three routing decisions now use it:

| call site | was | now |
|---|---|---|
| `model_manager._diarizer_current` | `sidecar_healthy()` | `sidecar_ready()` |
| `NativeSpeakerDiarizer.load_model` | inline `/healthz` | liveness, then readiness |
| `native_embedding_client.native_embedding_available` | `sidecar_healthy()` | `sidecar_ready()` |

The embedding path shares the predicate deliberately: `/embed_window` runs the same weights, so a sidecar whose models are unusable cannot serve embeddings either.

`sidecar_healthy()` stays, now documented as liveness-only, and **the compose healthcheck stays on `/healthz`** — pointing it at `/readyz` would fail `compose up --wait` whenever provisioning has not run, which is the regression the models-state split exists to prevent.

## The 404 fallback is load-bearing, not defensive

`/readyz` landed in diar-native 0.3.0. A 404 means **"cannot say"**, not "not ready", so it falls back to liveness.

This is not hypothetical. The sidecar running right now is still 0.2.0, confirmed two ways: `/healthz` returns the bare string `ok` rather than a JSON object, and `/readyz` returns 404. Without this fallback, merging this would take diarization down on the current stack. With it, behaviour on 0.2.0 is unchanged.

## Better logs

"Unreachable" and "up but not ready" are now separate messages. They send an operator to different places, and reporting the second as unreachable sends them to check networking when the actual fault is an unprovisioned models directory. The sidecar's own `models_reason` is included, so the log says *why*.

## Tests

9 new tests in `test_diar_native_readiness_gate.py`, all against **real `http.server` instances on real ports**, following the convention already in `test_diarizer_engine_selection.py` — the failure mode being guarded is a status code being misinterpreted, so a patched exception would assert the mock rather than the behaviour.

**Verified they fail before the fix.** Collapsing `sidecar_ready` back into `sidecar_healthy` (literally the old behaviour) fails 5 of the 9, including the `load_model` and embedding-path cases. A test that was never watched failing is not evidence.

### Two existing tests changed, one of which was a real hole

`test_diarizer_engine_selection.py` patched `sidecar_healthy` as the routing seam, which has moved, so two tests needed repointing at `sidecar_ready`.

More importantly, `test_pyannote_selected_rejects_native_cached` asserts that **no probe runs** for a pinned-pyannote config. After the move it would have passed vacuously while the probe it forbids ran unnoticed. It now patches both predicates so the assertion still means something.

## Risk

Low. No API or schema change, no migration, no image rebuild required. The Dockerfile is untouched, so this does not interact with #696's digest. On a 0.2.0 sidecar the behaviour is byte-for-byte what it was; on 0.3.x it starts refusing to route work at a sidecar that cannot serve it, which is the point.

Both pre-commit tiers pass (`run --all-files` and `--hook-stage pre-push`).