### PR TITLE
fix(docker): keep the diar-native overlay on rebuild-backend

### DIFF
--- a/backend/tests/unit/test_opentr_rebuild_backend_overlays.py
+++ b/backend/tests/unit/test_opentr_rebuild_backend_overlays.py
@@ -1,0 +1,587 @@
+"""``opentr.sh rebuild-backend`` must not drop the native-diarization overlay.
+
+``docker-compose.diar-native.yml`` is the ONLY file that mounts the ``diar-native-tmp``
+volume at ``/tmp/diar-native`` on ``celery-worker``, and that volume is how
+OpenTranscribe hands the WAV to the sidecar. ``rebuild-backend`` assembled its own
+compose chain (``docker-compose.yml`` + the dev override + GPU + NAS) and never
+included it, so a rebuild recreated the worker with **no mount at that path at all**.
+
+Measured on the live stack: the worker wrote the handoff WAV to its own filesystem,
+the sidecar could not see it, and ``/diarize`` answered ::
+
+    HTTP 422  opening /tmp/diar-native/probe.wav: No such file or directory
+
+which the worker classified as a mid-job sidecar failure and answered by falling back
+to the in-process PyAnnote fork. Diarization silently degraded — slower, and no
+speaker gender — with nothing surfaced to the user beyond one log line.
+
+Same shape as the NAS overlay bug the ``add_nas_overlay`` call site already documents:
+a rebuilt container that looks correct and is bound to the wrong storage.
+
+The fix has a second failure mode of its own, which is why the project-name tests below
+are as pointed as they are. The first version of the sidecar probe filtered on
+``${COMPOSE_PROJECT_NAME:-opentranscribe}``. ``COMPOSE_PROJECT_NAME`` is never exported
+globally by ``opentr.sh``, so compose falls back to **its** default — the directory
+basename — and on the machine that had the bug that is ``transcribe-app``. The probe
+matched 0 containers and the overlay was dropped exactly as before: a fix that was a
+no-op in production, with a green suite behind it, because the ``docker ps`` stub
+ignored the project filter and answered "yes" to any project at all.
+
+These run the REAL script with ``docker`` and ``nvidia-smi`` stubbed on ``PATH``, so
+the whole compose-chain decision is exercised in milliseconds with no daemon, no GPU
+and no containers — same convention as ``test_compose_file_selection.py``. The stub
+models the daemon's filter semantics rather than approximating them; a stub more
+permissive than the thing it stands in for cannot falsify anything.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+OPENTR = REPO_ROOT / "opentr.sh"
+COMMON = REPO_ROOT / "scripts" / "common.sh"
+
+pytestmark = pytest.mark.skipif(
+    not OPENTR.exists(), reason="opentr.sh not present in this checkout"
+)
+
+BASE = "docker-compose.yml"
+OVERRIDE = "docker-compose.override.yml"
+DIAR = "docker-compose.diar-native.yml"
+
+#: Overlays a dev checkout has on disk. Only their presence matters here — the chain
+#: is assembled from filenames, and every service list is passed explicitly.
+OVERLAYS = (BASE, OVERRIDE, DIAR, "docker-compose.gpu.yml", "docker-compose.nas.yml")
+
+#: `docker` stand-in. Records every invocation (and the sidecar-relevant environment
+#: compose would interpolate) instead of talking to a daemon.
+#:
+#: ⚠️ `docker ps` HONOURS THE PROJECT FILTER, exactly as the daemon does. The first
+#: version of this stub keyed only off the *service* filter and OT_STUB_DIAR_PRESENT,
+#: ignoring which project was asked for — so it answered "yes" to any project name at
+#: all. That made every rebuild test pass against a probe filtering on a project that
+#: does not exist on the real host, and the suite reported GREEN for a fix that was a
+#: no-op in production. A stub more permissive than the thing it stands in for cannot
+#: falsify anything. It now returns the fake container only when the requested project
+#: matches OT_STUB_DIAR_PROJECT.
+#:
+#: `docker volume ls` stays silent so fix_pipeline_scratch_permissions returns early.
+DOCKER_STUB = r"""#!/bin/bash
+printf 'ARGV: %s\n' "$*" >> "$OT_DOCKER_LOG"
+case "$1" in
+  info)
+    echo "Runtimes: runc"
+    exit 0
+    ;;
+  compose)
+    printf 'ENV: DIAR_NATIVE_IMAGE=%s\n' "${DIAR_NATIVE_IMAGE:-<unset>}" >> "$OT_DOCKER_LOG"
+    printf 'ENV: DIAR_NATIVE_MODELS_DIR=%s\n' "${DIAR_NATIVE_MODELS_DIR:-<unset>}" >> "$OT_DOCKER_LOG"
+    exit 0
+    ;;
+  ps)
+    if [[ "$*" == *"com.docker.compose.service=diar-native"* ]] \
+       && [ "${OT_STUB_DIAR_PRESENT:-0}" = "1" ]; then
+      # The project the caller filtered on, i.e. what compose would have to agree with.
+      # Assigned to a scalar FIRST on purpose: `${*#pattern}` strips the pattern from
+      # each positional parameter individually and rejoins, which yields the wrong
+      # token here. `argv` makes the removal operate on the joined string.
+      argv="$*"
+      requested="${argv#*com.docker.compose.project=}"
+      requested="${requested%% *}"
+      printf 'PROBE-PROJECT: %s\n' "$requested" >> "$OT_DOCKER_LOG"
+      if [ "$requested" = "${OT_STUB_DIAR_PROJECT:-}" ]; then
+        echo "deadbeefcafe"
+      fi
+    fi
+    exit 0
+    ;;
+esac
+exit 0
+"""
+
+#: No GPU on the test host, whatever the real host has: keeps the chain deterministic
+#: (detect_and_configure_hardware takes the CPU branch, so no GPU overlay is added).
+NVIDIA_SMI_STUB = "#!/bin/bash\nexit 1\n"
+
+
+#: Default sandbox directory name. Deliberately neither "opentranscribe" (the wrong
+#: fallback that shipped) nor "transcribe-app" (this host's real one): a probe that
+#: hardcodes either must fail here, and the only way to pass is to derive it.
+CHECKOUT_DIR_NAME = "some-ot-checkout"
+
+
+def _make_checkout(
+    tmp_path: Path, *, diar_weights: bool = False, checkout_name: str = CHECKOUT_DIR_NAME
+) -> Path:
+    """A directory shaped like a dev checkout, with the real script dropped in it."""
+    checkout = tmp_path / checkout_name
+    (checkout / "scripts").mkdir(parents=True)
+    for name in OVERLAYS:
+        (checkout / name).write_text("services: {}\n", encoding="utf-8")
+    (checkout / "VERSION").write_text("0.0.0-test\n", encoding="utf-8")
+    shutil.copy2(OPENTR, checkout / "opentr.sh")
+    (checkout / "opentr.sh").chmod(0o755)
+    shutil.copy2(COMMON, checkout / "scripts" / "common.sh")
+    if diar_weights:
+        weights = checkout / "models" / "diar-native"
+        weights.mkdir(parents=True)
+        (weights / "segmentation-3.0.onnx").write_text("onnx\n", encoding="utf-8")
+    return checkout
+
+
+def _make_stubs(tmp_path: Path) -> Path:
+    bin_dir = tmp_path / "stubbin"
+    bin_dir.mkdir()
+    docker = bin_dir / "docker"
+    docker.write_text(DOCKER_STUB, encoding="utf-8")
+    docker.chmod(0o755)
+    smi = bin_dir / "nvidia-smi"
+    smi.write_text(NVIDIA_SMI_STUB, encoding="utf-8")
+    smi.chmod(0o755)
+    return bin_dir
+
+
+def _run(
+    tmp_path: Path,
+    args: list[str],
+    *,
+    sidecar_deployed: bool = False,
+    diar_weights: bool = False,
+    pin_models_dir: bool = True,
+    checkout_name: str = CHECKOUT_DIR_NAME,
+    sidecar_project: str | None = None,
+    extra_env: dict[str, str] | None = None,
+) -> tuple[str, list[str]]:
+    """Run ``./opentr.sh <args>`` in a sandbox. Returns (stdout, docker-stub log lines).
+
+    ``sidecar_project`` is the compose project the fake diar-native container belongs
+    to. It defaults to the checkout directory name, which is what real compose would
+    use with ``COMPOSE_PROJECT_NAME`` unset — so the probe only sees the container if
+    it derives the project the same way.
+    """
+    checkout = _make_checkout(tmp_path, diar_weights=diar_weights, checkout_name=checkout_name)
+    bin_dir = _make_stubs(tmp_path)
+    log = tmp_path / "docker.log"
+    log.write_text("", encoding="utf-8")
+    env = {
+        "PATH": f"{bin_dir}:{os.environ.get('PATH', '/usr/bin:/bin')}",
+        "HOME": str(tmp_path),
+        "OT_DOCKER_LOG": str(log),
+        "OT_STUB_DIAR_PRESENT": "1" if sidecar_deployed else "0",
+        "OT_STUB_DIAR_PROJECT": sidecar_project if sidecar_project is not None else checkout_name,
+        **(extra_env or {}),
+    }
+    if pin_models_dir:
+        # Pinned so resolve_diar_native_models_dir cannot pick up this workstation's
+        # legacy sibling-repo export and make the run host-dependent. Turned OFF by
+        # the one test that asserts the script resolves the path itself.
+        env["DIAR_NATIVE_MODELS_DIR"] = str(checkout / "models" / "diar-native")
+    proc = subprocess.run(
+        ["./opentr.sh", *args],
+        cwd=str(checkout),
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=120,
+    )
+    assert proc.returncode == 0, (
+        f"./opentr.sh {' '.join(args)} exited {proc.returncode}\n"
+        f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}"
+    )
+    return proc.stdout, log.read_text(encoding="utf-8").splitlines()
+
+
+def _up_command(docker_log: list[str]) -> str:
+    """The single ``compose ... up -d --build --no-deps <services>`` line rebuild runs."""
+    ups = [
+        line
+        for line in docker_log
+        if line.startswith("ARGV: compose ") and " up -d --build --no-deps" in line
+    ]
+    assert len(ups) == 1, f"expected exactly one rebuild `up`, got {ups}"
+    return ups[0]
+
+
+def _chain(command: str) -> list[str]:
+    """The compose files, in order, from a ``-f a -f b`` command line."""
+    return re.findall(r"-f\s+(\S+)", command)
+
+
+def _dry_run_chain(stdout: str) -> list[str]:
+    """The overlay list `start --dry-run` prints, in order."""
+    files: list[str] = []
+    collecting = False
+    for line in stdout.splitlines():
+        if line.strip() == "Compose files:":
+            collecting = True
+            continue
+        if collecting:
+            stripped = line.strip()
+            if stripped.startswith("- "):
+                files.append(stripped[2:])
+            else:
+                break
+    return files
+
+
+# --------------------------------------------------------------------------- #
+# rebuild-backend: the defect
+# --------------------------------------------------------------------------- #
+
+
+def test_rebuild_backend_keeps_the_diar_native_overlay_when_the_sidecar_is_deployed(
+    tmp_path: Path,
+):
+    """The bug. Without the overlay celery-worker loses /tmp/diar-native entirely."""
+    stdout, docker_log = _run(tmp_path, ["rebuild-backend"], sidecar_deployed=True)
+    command = _up_command(docker_log)
+
+    assert DIAR in _chain(command), (
+        f"rebuild-backend dropped {DIAR} from a deployment that HAS the sidecar. "
+        f"celery-worker comes back with no mount at /tmp/diar-native, /diarize "
+        f"answers 422, and diarization silently falls back to PyAnnote. Chain: "
+        f"{_chain(command)}"
+    )
+    assert "celery-worker" in command, command
+    assert "keeping its overlay" in stdout, (
+        f"the decision must be announced, like the NAS overlay's: {stdout}"
+    )
+
+
+def test_rebuild_backend_omits_the_diar_native_overlay_with_no_sidecar_deployed(
+    tmp_path: Path,
+):
+    """Control: the fix must not be "always add it".
+
+    Loading the overlay on a deployment that never asked for the sidecar puts a
+    diar-native service (and its ~4.1 GB warm ORT arena on a GPU) into the merged
+    config of every subsequent plain `docker compose up` in that chain.
+    """
+    stdout, docker_log = _run(tmp_path, ["rebuild-backend"], sidecar_deployed=False)
+    command = _up_command(docker_log)
+
+    assert DIAR not in _chain(command), (
+        f"rebuild-backend added {DIAR} to a deployment with no sidecar container: {_chain(command)}"
+    )
+    assert _chain(command) == [BASE, OVERRIDE], _chain(command)
+    assert "keeping its overlay" not in stdout, stdout
+
+
+def test_rebuild_backend_never_lists_the_sidecar_among_the_services_it_recreates(
+    tmp_path: Path,
+):
+    """Adding the overlay must not start or restart diar-native.
+
+    `up -d --no-deps <explicit services>` is what makes the overlay safe to load:
+    diar-native is not in the list, so a rebuild cannot bring one up, and cannot
+    burn a fresh ORT warm-up on a sidecar that is already serving.
+    """
+    _, docker_log = _run(tmp_path, ["rebuild-backend"], sidecar_deployed=True)
+    command = _up_command(docker_log)
+
+    services = command.split("--no-deps", 1)[1].split()
+    assert "diar-native" not in services, f"rebuild-backend would recreate the sidecar: {services}"
+    assert "celery-worker" in services, services
+    assert "--no-deps" in command, command
+
+
+def test_rebuild_backend_pins_the_sidecar_to_the_local_dev_image(tmp_path: Path):
+    """DIAR_NATIVE_IMAGE must be exported the same way `start` does it.
+
+    The overlay defaults to the PUBLISHED backend image. On a dev checkout that image
+    does not exist locally, so the rebuilt worker and the sidecar would disagree about
+    which build they are — the reason `start` exports the local tag at all.
+    """
+    _, docker_log = _run(tmp_path, ["rebuild-backend"], sidecar_deployed=True)
+    assert "ENV: DIAR_NATIVE_IMAGE=opentranscribe-backend:latest" in docker_log, docker_log
+
+
+def test_rebuild_backend_resolves_the_models_dir_the_overlay_interpolates(tmp_path: Path):
+    """The overlay binds ${DIAR_NATIVE_MODELS_DIR} read-only at /models.
+
+    `resolve_diar_native_models_dir` has to run on the rebuild path too, or the
+    variable reaches compose unset and the sidecar's weights bind silently moves to
+    the overlay's own default. Deliberately does NOT pre-set the variable — that is
+    what makes this falsifiable: on a script that never resolves it, the stub sees
+    `<unset>`.
+    """
+    _, docker_log = _run(
+        tmp_path,
+        ["rebuild-backend"],
+        sidecar_deployed=True,
+        diar_weights=True,
+        pin_models_dir=False,
+        extra_env={"MODEL_CACHE_DIR": str(tmp_path / CHECKOUT_DIR_NAME / "models")},
+    )
+    expected = str(tmp_path / CHECKOUT_DIR_NAME / "models" / "diar-native")
+    assert f"ENV: DIAR_NATIVE_MODELS_DIR={expected}" in docker_log, docker_log
+
+
+def test_no_diar_native_suppresses_the_rebuild_autodetect(tmp_path: Path):
+    """The escape hatch, mirroring `start`'s."""
+    _, docker_log = _run(tmp_path, ["rebuild-backend", "--no-diar-native"], sidecar_deployed=True)
+    assert DIAR not in _chain(_up_command(docker_log))
+
+
+def test_with_diar_native_forces_the_overlay_when_the_sidecar_is_down(tmp_path: Path):
+    """The opposite override: keep the mount even with no container to observe."""
+    _, docker_log = _run(
+        tmp_path, ["rebuild-backend", "--with-diar-native"], sidecar_deployed=False
+    )
+    assert DIAR in _chain(_up_command(docker_log))
+
+
+def _probe_project(docker_log: list[str]) -> str:
+    """The compose project the probe actually filtered on."""
+    projects = [
+        line.split("PROBE-PROJECT: ", 1)[1]
+        for line in docker_log
+        if line.startswith("PROBE-PROJECT: ")
+    ]
+    assert projects, f"no diar-native probe was issued at all: {docker_log}"
+    return projects[0]
+
+
+def test_the_probe_resolves_the_project_from_the_checkout_directory(tmp_path: Path):
+    """The regression this file exists for, second edition.
+
+    The first fix filtered on `${COMPOSE_PROJECT_NAME:-opentranscribe}`. That variable
+    is never exported globally by opentr.sh — only locally inside the fresh-deployment
+    helpers — so compose falls back to ITS default, the **directory basename**.
+    Measured against the live daemon: the sidecar's project label is `transcribe-app`
+    (checkout `/mnt/nvm/repos/transcribe-app`), the probe asked for `opentranscribe`,
+    matched 0 containers, and the overlay was dropped. The fix was a no-op on the one
+    machine known to have the bug, and the suite was green.
+
+    The sandbox directory is deliberately named neither of those, so a probe that
+    hardcodes either value fails here and only a derived one passes.
+    """
+    _, docker_log = _run(
+        tmp_path, ["rebuild-backend"], sidecar_deployed=True, checkout_name="ot-checkout-alpha"
+    )
+    assert _probe_project(docker_log) == "ot-checkout-alpha", (
+        "the probe must resolve the compose project from the checkout directory, the "
+        "way compose itself does with COMPOSE_PROJECT_NAME unset"
+    )
+    assert DIAR in _chain(_up_command(docker_log))
+
+
+def test_an_explicit_compose_project_name_still_wins(tmp_path: Path):
+    """Control for the above: the derivation is a FALLBACK, not a replacement.
+
+    A stack started with COMPOSE_PROJECT_NAME set (every `--fresh` deployment) must be
+    probed under that name, not under its directory.
+    """
+    _, docker_log = _run(
+        tmp_path,
+        ["rebuild-backend"],
+        sidecar_deployed=True,
+        checkout_name="ot-checkout-beta",
+        sidecar_project="otfresh-demo",
+        extra_env={"COMPOSE_PROJECT_NAME": "otfresh-demo"},
+    )
+    assert _probe_project(docker_log) == "otfresh-demo", (
+        "an explicit COMPOSE_PROJECT_NAME must take precedence over the directory name"
+    )
+    assert DIAR in _chain(_up_command(docker_log))
+
+
+def test_a_sidecar_belonging_to_another_compose_project_is_not_ours(tmp_path: Path):
+    """Negative control: the probe must be scoped, not "any diar-native anywhere".
+
+    This is a real configuration on the development host — a `--fresh` stack's
+    `otfresh-demo-diar-native` runs alongside the main stack's. Counting it as ours
+    would load the overlay onto a deployment that has no sidecar of its own.
+    """
+    _, docker_log = _run(
+        tmp_path,
+        ["rebuild-backend"],
+        sidecar_deployed=True,
+        checkout_name="ot-checkout-gamma",
+        sidecar_project="otfresh-demo",
+    )
+    assert _probe_project(docker_log) == "ot-checkout-gamma", docker_log
+    assert DIAR not in _chain(_up_command(docker_log)), (
+        "another project's sidecar was mistaken for this deployment's"
+    )
+
+
+def test_the_sidecar_probe_is_label_scoped_and_state_agnostic(tmp_path: Path):
+    """How the sidecar is detected, not just that it is.
+
+    Two properties, both of which have bitten this repo:
+      * label-scoped, never a name prefix — this host runs unrelated compose stacks
+        whose container names begin `opentranscribe-`, and a prefix grep in
+        `opentr.sh stop` once destroyed one of them. The service also declares no
+        `container_name`, so a `name=^<project>-diar-native$` filter matches nothing;
+      * `-a`, so a `restarting` (crash-looping, `restart: unless-stopped`) or
+        temporarily stopped sidecar still counts as deployed.
+    """
+    _, docker_log = _run(tmp_path, ["rebuild-backend"], sidecar_deployed=True)
+    probes = [
+        line
+        for line in docker_log
+        if line.startswith("ARGV: ps ") and "com.docker.compose.service=diar-native" in line
+    ]
+    assert probes, f"no diar-native probe was issued at all: {docker_log}"
+    probe = probes[0]
+    assert "label=com.docker.compose.project=" in probe, probe
+    assert "--filter name=" not in probe, f"must not match on container name: {probe}"
+    assert "ps -a" in probe, f"probe must accept any container state: {probe}"
+    assert "status=running" not in probe, probe
+
+
+def test_the_probe_uses_the_same_project_resolution_as_the_port_preflight():
+    """One resolution, two readers — pinned so they cannot drift apart.
+
+    `preflight_ports_or_die` already had the correct expression. Nothing connected the
+    two, which is how the probe came to ship a different (wrong) one. Deliberately NOT
+    fixed by refactoring both onto a shared helper: nothing in the suite exercises
+    `preflight_ports_or_die`, so that edit could not be proven, and it guards every
+    `start`. If it is ever extracted, this test is the thing that says so.
+    """
+    source = OPENTR.read_text(encoding="utf-8")
+    resolutions = re.findall(r'"\$\{COMPOSE_PROJECT_NAME:-\$\(basename "\$\(pwd\)"\)\}"', source)
+    assert len(resolutions) == 2, (
+        f"expected diar_native_container_present and preflight_ports_or_die to use the "
+        f"identical project resolution; found {len(resolutions)} occurrences"
+    )
+    body = source.split("diar_native_container_present() {", 1)[1].split("\n}\n", 1)[0]
+    assert 'COMPOSE_PROJECT_NAME:-$(basename "$(pwd)")' in body, body
+    assert "opentranscribe" not in body, (
+        "the probe must never hardcode a project name — that fallback was the bug"
+    )
+
+
+def test_rebuild_backend_still_honours_the_nas_overlay(tmp_path: Path):
+    """Regression guard on the neighbour: the diar block sits next to add_nas_overlay."""
+    _, docker_log = _run(
+        tmp_path,
+        ["rebuild-backend", "--nas"],
+        sidecar_deployed=False,
+        extra_env={"MINIO_NAS_PATH": str(tmp_path)},
+    )
+    assert "docker-compose.nas.yml" in _chain(_up_command(docker_log))
+
+
+# --------------------------------------------------------------------------- #
+# start: must be byte-for-byte what it was before the helper was extracted
+# --------------------------------------------------------------------------- #
+
+#: The four lines `start` prints when it loads the overlay. Pinned verbatim, because
+#: `start` is the path everyone uses and a regression there is worse than the bug
+#: being fixed; the helper reuses this block rather than paraphrasing it.
+START_BANNER = (
+    "🎙️  Adding native diarization sidecar (docker-compose.diar-native.yml)",
+    "   diar-server on GPU 0 — ~4.1 GB warm ORT arena while up.",
+    "   Used when engine.diarizer_backend=native (DB) / ENGINE_DIARIZER_BACKEND=native (env);",
+    "   without the sidecar that config falls back to the in-process PyAnnote fork.",
+)
+
+AUTOLOAD_LINE = (
+    "🎙️  diar-native sidecar AUTO-LOADED (engine.diarizer_backend defaults to native; "
+    "models present). Use --no-diar-native to skip."
+)
+
+
+def test_start_autodetects_the_sidecar_from_config_not_from_a_container(tmp_path: Path):
+    """`start`'s predicate is unchanged: engine default + a populated models dir.
+
+    Note `sidecar_deployed=False` — `start` must still load the overlay with no
+    container anywhere, which is precisely why it cannot share rebuild's predicate.
+    """
+    stdout, _ = _run(
+        tmp_path, ["start", "dev", "--dry-run"], sidecar_deployed=False, diar_weights=True
+    )
+    assert _dry_run_chain(stdout) == [BASE, OVERRIDE, DIAR], stdout
+    assert AUTOLOAD_LINE in stdout, stdout
+    for line in START_BANNER:
+        assert line in stdout, f"missing banner line: {line!r}\n{stdout}"
+
+
+def test_start_does_not_autoload_the_sidecar_without_a_populated_models_dir(
+    tmp_path: Path,
+):
+    """The guard that keeps `up --wait` from failing on a checkout with no export."""
+    stdout, _ = _run(
+        tmp_path, ["start", "dev", "--dry-run"], sidecar_deployed=False, diar_weights=False
+    )
+    assert _dry_run_chain(stdout) == [BASE, OVERRIDE], stdout
+    assert AUTOLOAD_LINE not in stdout, stdout
+
+
+def test_start_with_the_explicit_flag_loads_the_overlay_without_a_models_dir(
+    tmp_path: Path,
+):
+    """`--with-diar-native` bypasses the auto-detect entirely, as it always has."""
+    stdout, _ = _run(
+        tmp_path,
+        ["start", "dev", "--with-diar-native", "--dry-run"],
+        sidecar_deployed=False,
+        diar_weights=False,
+    )
+    assert _dry_run_chain(stdout) == [BASE, OVERRIDE, DIAR], stdout
+    assert AUTOLOAD_LINE not in stdout, "explicit flag must not print the auto-load banner"
+    for line in START_BANNER:
+        assert line in stdout, f"missing banner line: {line!r}\n{stdout}"
+
+
+def test_start_no_diar_native_suppresses_the_autoload(tmp_path: Path):
+    stdout, _ = _run(
+        tmp_path,
+        ["start", "dev", "--no-diar-native", "--dry-run"],
+        sidecar_deployed=False,
+        diar_weights=True,
+    )
+    assert _dry_run_chain(stdout) == [BASE, OVERRIDE], stdout
+    assert AUTOLOAD_LINE not in stdout, stdout
+
+
+# --------------------------------------------------------------------------- #
+# Static: one decision point, not three
+# --------------------------------------------------------------------------- #
+
+
+def test_only_the_shared_helper_appends_the_diar_native_overlay():
+    """The whole point of the refactor.
+
+    Before it, `start_app` and `reset_and_init` each carried a verbatim copy of the
+    block and `rebuild-backend` carried none — which is how the paths came to
+    disagree in the first place. A fourth caller must reuse the helper, not paste it.
+    """
+    source = OPENTR.read_text(encoding="utf-8")
+    appends = [
+        line
+        for line in source.splitlines()
+        if f'COMPOSE_FILES -f {DIAR}"' in line and not line.lstrip().startswith("#")
+    ]
+    assert len(appends) == 1, (
+        f"{DIAR} is appended to COMPOSE_FILES in {len(appends)} places; it must only "
+        f"happen inside add_diar_native_overlay: {appends}"
+    )
+    assert source.count("add_diar_native_overlay start") == 2, (
+        "expected exactly the start_app and reset_and_init callers"
+    )
+    assert source.count("add_diar_native_overlay rebuild") == 1
+
+
+def test_a_fresh_stack_is_still_excluded_from_the_start_autodetect():
+    """`--fresh` keeps the sidecar opt-in, and the refactor must not lose that.
+
+    Static rather than executed: `start --fresh` refuses (exit 1) when the main
+    stack holds the standard dev ports, so a live-stack-dependent test here would
+    pass or fail on what else is running, which is not a measurement.
+    """
+    source = OPENTR.read_text(encoding="utf-8")
+    body = source.split("add_diar_native_overlay() {", 1)[1].split("\n}\n", 1)[0]
+    assert '[ -z "${FRESH_FLAG:-}" ]' in body, (
+        "the start-mode predicate no longer excludes fresh deployments; a fresh "
+        "stack would auto-load the sidecar and take a GPU nobody asked it to"
+    )

--- a/opentr.sh
+++ b/opentr.sh
@@ -177,7 +177,10 @@ show_help() {
   echo "  restart-backend     - Restart backend, all celery workers, celery-beat & flower without database reset"
   echo "  restart-frontend    - Restart frontend without affecting backend services"
   echo "  restart-all         - Restart all services without resetting database"
-  echo "  rebuild-backend [--nas]  - Rebuild backend services with code changes"
+  echo "  rebuild-backend [--nas] [--with-diar-native|--no-diar-native]"
+  echo "                           - Rebuild backend services with code changes. The"
+  echo "                             diar-native overlay is kept automatically when this"
+  echo "                             deployment already has the sidecar."
   echo "                             (pass --nas on NAS/NVMe deployments; auto-detected"
   echo "                             from MINIO_NAS_PATH/POSTGRES_DATA_PATH/OPENSEARCH_DATA_PATH"
   echo "                             env vars). --no-deps protects postgres/minio/opensearch."
@@ -533,6 +536,127 @@ add_nas_overlay() {
   echo "   MinIO media:  $NAS_PATH"
   echo "   PostgreSQL:   $PG_PATH"
   echo "   OpenSearch:   $OS_PATH"
+}
+
+# True when this compose project already has a diar-native container, in ANY state.
+#
+# Label-scoped, never name-prefix-matched: this host runs unrelated compose stacks
+# whose container names share the `opentranscribe` prefix, and a naive
+# `docker ps | grep '^opentranscribe-'` in `opentr.sh stop` once destroyed one of
+# them. The diar-native service also declares no `container_name`, so its container
+# is `<project>-diar-native-1` and a `name=^<project>-diar-native$` filter — the
+# shape the gpu-scale/gpu-split loop uses for services that DO pin a name — would
+# match nothing here.
+#
+# `-a`, i.e. any state, not `status=running`, on purpose: the sidecar is
+# `restart: unless-stopped`, so a crash-looping instance reports `restarting`, and a
+# stack whose sidecar is merely down between rebuilds is still a stack that HAS one.
+# Being over-inclusive costs one named-volume mount and two env vars on
+# celery-worker; being under-inclusive costs the silent PyAnnote fallback that
+# add_diar_native_overlay exists to prevent.
+#
+# ⚠️ THE PROJECT NAME IS DERIVED FROM THE DIRECTORY, NOT DEFAULTED TO "opentranscribe".
+# The first version of this probe used `${COMPOSE_PROJECT_NAME:-opentranscribe}` and was
+# a NO-OP on the machine that has the bug. COMPOSE_PROJECT_NAME is never exported
+# globally by this script — only locally inside the fresh-deployment helpers — so
+# compose falls back to ITS default, the directory basename. Measured against the live
+# daemon: the sidecar's `com.docker.compose.project` label is `transcribe-app` (the
+# checkout is /mnt/nvm/repos/transcribe-app), and a probe filtering on `opentranscribe`
+# matched 0 containers, dropped the overlay, and reproduced the 422 exactly.
+# `basename "$(pwd)"` is the same resolution preflight_ports_or_die already uses; a
+# checkout in a differently-named directory must keep working, so this is derived and
+# never hardcoded. (test_the_probe_resolves_the_project_from_the_checkout_directory)
+diar_native_container_present() {
+  local project="${COMPOSE_PROJECT_NAME:-$(basename "$(pwd)")}"
+  docker ps -a --format '{{.ID}}' \
+    --filter "label=com.docker.compose.project=${project}" \
+    --filter "label=com.docker.compose.service=diar-native" 2>/dev/null | grep -q .
+}
+
+# Append the native diarization sidecar overlay to $COMPOSE_FILES. Mirrors
+# add_nas_overlay: ONE place decides, so start/reset/rebuild can never disagree
+# about whether celery-worker gets the diar-native handoff volume.
+#
+# ⚠️ WHY THIS IS SHARED RATHER THAN INLINED. docker-compose.diar-native.yml is the
+# only file that mounts `diar-native-tmp` at /tmp/diar-native on celery-worker, and
+# that volume is how OpenTranscribe hands the WAV to the sidecar. `rebuild-backend`
+# used to omit the overlay, so it recreated celery-worker with NO mount at that path
+# at all; the worker wrote the WAV to its own filesystem, the sidecar could not see
+# it, and /diarize answered
+#     HTTP 422  opening /tmp/diar-native/<job>.wav: No such file or directory
+# which the worker classified as "sidecar failed mid-job" and answered by falling
+# back to the in-process PyAnnote fork — slower, no speaker gender, and NOTHING
+# surfaced to the user beyond one log line. Same bug class as the NAS overlay note
+# above: containers that look correct, bound to the wrong storage.
+#
+# $1 picks the auto-detect predicate, because "should this deployment have the
+# sidecar?" and "does this deployment have the sidecar?" are different questions:
+#
+#   start   - CONFIGURATION. engine.diarizer_backend resolves to native AND the model
+#             export exists. The right question for a stack that does not exist yet.
+#
+#   rebuild - OBSERVATION. A diar-native container already exists in this compose
+#             project. rebuild-backend recreates services in place, so the only
+#             correct answer is the one the running deployment already made; the
+#             config predicate disagrees with it in BOTH directions (a stack started
+#             with --no-diar-native would gain the overlay; a stack running the
+#             sidecar under ENGINE_DIARIZER_BACKEND=pyannote would lose it, which is
+#             the original bug). Precedent: the gpu-scale/gpu-split loop in
+#             rebuild-backend likewise rebuilds those workers only when they are up.
+#             It can never START a sidecar nobody asked for — with no container there
+#             is no overlay, and rebuild-backend passes an explicit service list with
+#             --no-deps, so `diar-native` is never brought up either way.
+#
+# Either predicate is overridden by an explicit --with-diar-native / --no-diar-native.
+add_diar_native_overlay() {
+  local mode="${1:-start}"
+
+  # Runs unconditionally (even under --no-diar-native): it EXPORTS the path
+  # docker-compose.diar-native.yml interpolates for the read-only /models bind, and
+  # its legacy-path banner is part of every start's output today.
+  resolve_diar_native_models_dir
+
+  if [ -z "${WITH_DIAR_NATIVE_FLAG:-}" ] && [ -z "${NO_DIAR_NATIVE_FLAG:-}" ]; then
+    if [ "$mode" = "rebuild" ]; then
+      if diar_native_container_present; then
+        WITH_DIAR_NATIVE_FLAG="auto"
+        echo "🎙️  diar-native sidecar is part of this deployment — keeping its overlay so celery-worker keeps /tmp/diar-native."
+      fi
+    else
+      # Native diarization sidecar auto-load: `native` is the coded default engine, so a
+      # stack without the sidecar silently serves every file from the in-process PyAnnote
+      # fallback. Mirrors the NAS auto-detect: announced, and --no-diar-native suppresses.
+      # Guarded on the models dir existing — without it the sidecar restart-loops and
+      # `up --wait` would fail the whole startup on checkouts with no local model export.
+      # Fresh stacks stay opt-in (pass --with-diar-native explicitly).
+      if [ -z "${FRESH_FLAG:-}" ] \
+         && [ "${ENGINE_DIARIZER_BACKEND:-native}" = "native" ] \
+         && [ -d "$DIAR_NATIVE_MODELS_DIR" ]; then
+        WITH_DIAR_NATIVE_FLAG="auto"
+        echo "🎙️  diar-native sidecar AUTO-LOADED (engine.diarizer_backend defaults to native; models present). Use --no-diar-native to skip."
+      fi
+    fi
+  fi
+
+  # Add the native diarization sidecar if requested
+  if [ -n "${WITH_DIAR_NATIVE_FLAG:-}" ]; then
+    if [ -f "docker-compose.diar-native.yml" ]; then
+      # The overlay defaults to the PUBLISHED backend image, which is correct for a
+      # self-hosted deployment but wrong in this checkout — dev builds the image
+      # locally as opentranscribe-backend:latest and never pushes it. Point the
+      # sidecar at the local build so it matches the workers it serves.
+      if [ "$ENVIRONMENT" = "dev" ]; then
+        export DIAR_NATIVE_IMAGE="${DIAR_NATIVE_IMAGE:-opentranscribe-backend:latest}"
+      fi
+      COMPOSE_FILES="$COMPOSE_FILES -f docker-compose.diar-native.yml"
+      echo "🎙️  Adding native diarization sidecar (docker-compose.diar-native.yml)"
+      echo "   diar-server on GPU ${DIAR_NATIVE_GPU:-${GPU_DEVICE_ID:-0}} — ~4.1 GB warm ORT arena while up."
+      echo "   Used when engine.diarizer_backend=native (DB) / ENGINE_DIARIZER_BACKEND=native (env);"
+      echo "   without the sidecar that config falls back to the in-process PyAnnote fork."
+    else
+      echo "⚠️  --with-diar-native specified but docker-compose.diar-native.yml not found"
+    fi
+  fi
 }
 
 # Append the PKI/mTLS overlay to $COMPOSE_FILES if --with-pki was passed.
@@ -1854,39 +1978,9 @@ start_app() {
     fi
   fi
 
-  # Native diarization sidecar auto-load: `native` is the coded default engine, so a
-  # stack without the sidecar silently serves every file from the in-process PyAnnote
-  # fallback. Mirrors the NAS auto-detect: announced, and --no-diar-native suppresses.
-  # Guarded on the models dir existing — without it the sidecar restart-loops and
-  # `up --wait` would fail the whole startup on checkouts with no local model export.
-  # Fresh stacks stay opt-in (pass --with-diar-native explicitly).
-  resolve_diar_native_models_dir
-  if [ -z "$WITH_DIAR_NATIVE_FLAG" ] && [ -z "$NO_DIAR_NATIVE_FLAG" ] && [ -z "$FRESH_FLAG" ] \
-     && [ "${ENGINE_DIARIZER_BACKEND:-native}" = "native" ] \
-     && [ -d "$DIAR_NATIVE_MODELS_DIR" ]; then
-    WITH_DIAR_NATIVE_FLAG="auto"
-    echo "🎙️  diar-native sidecar AUTO-LOADED (engine.diarizer_backend defaults to native; models present). Use --no-diar-native to skip."
-  fi
-
-  # Add the native diarization sidecar if requested
-  if [ -n "$WITH_DIAR_NATIVE_FLAG" ]; then
-    if [ -f "docker-compose.diar-native.yml" ]; then
-      # The overlay defaults to the PUBLISHED backend image, which is correct for a
-      # self-hosted deployment but wrong in this checkout — dev builds the image
-      # locally as opentranscribe-backend:latest and never pushes it. Point the
-      # sidecar at the local build so it matches the workers it serves.
-      if [ "$ENVIRONMENT" = "dev" ]; then
-        export DIAR_NATIVE_IMAGE="${DIAR_NATIVE_IMAGE:-opentranscribe-backend:latest}"
-      fi
-      COMPOSE_FILES="$COMPOSE_FILES -f docker-compose.diar-native.yml"
-      echo "🎙️  Adding native diarization sidecar (docker-compose.diar-native.yml)"
-      echo "   diar-server on GPU ${DIAR_NATIVE_GPU:-${GPU_DEVICE_ID:-0}} — ~4.1 GB warm ORT arena while up."
-      echo "   Used when engine.diarizer_backend=native (DB) / ENGINE_DIARIZER_BACKEND=native (env);"
-      echo "   without the sidecar that config falls back to the in-process PyAnnote fork."
-    else
-      echo "⚠️  --with-diar-native specified but docker-compose.diar-native.yml not found"
-    fi
-  fi
+  # Native diarization sidecar. Shared with rebuild-backend so a rebuild can never
+  # drop celery-worker's /tmp/diar-native handoff mount — see add_diar_native_overlay.
+  add_diar_native_overlay start
 
   # Add real GPU-backed LLM test provider if requested
   if [ -n "$WITH_LLM_TEST_FLAG" ]; then
@@ -2551,39 +2645,9 @@ reset_and_init() {
     fi
   fi
 
-  # Native diarization sidecar auto-load: `native` is the coded default engine, so a
-  # stack without the sidecar silently serves every file from the in-process PyAnnote
-  # fallback. Mirrors the NAS auto-detect: announced, and --no-diar-native suppresses.
-  # Guarded on the models dir existing — without it the sidecar restart-loops and
-  # `up --wait` would fail the whole startup on checkouts with no local model export.
-  # Fresh stacks stay opt-in (pass --with-diar-native explicitly).
-  resolve_diar_native_models_dir
-  if [ -z "$WITH_DIAR_NATIVE_FLAG" ] && [ -z "$NO_DIAR_NATIVE_FLAG" ] && [ -z "$FRESH_FLAG" ] \
-     && [ "${ENGINE_DIARIZER_BACKEND:-native}" = "native" ] \
-     && [ -d "$DIAR_NATIVE_MODELS_DIR" ]; then
-    WITH_DIAR_NATIVE_FLAG="auto"
-    echo "🎙️  diar-native sidecar AUTO-LOADED (engine.diarizer_backend defaults to native; models present). Use --no-diar-native to skip."
-  fi
-
-  # Add the native diarization sidecar if requested
-  if [ -n "$WITH_DIAR_NATIVE_FLAG" ]; then
-    if [ -f "docker-compose.diar-native.yml" ]; then
-      # The overlay defaults to the PUBLISHED backend image, which is correct for a
-      # self-hosted deployment but wrong in this checkout — dev builds the image
-      # locally as opentranscribe-backend:latest and never pushes it. Point the
-      # sidecar at the local build so it matches the workers it serves.
-      if [ "$ENVIRONMENT" = "dev" ]; then
-        export DIAR_NATIVE_IMAGE="${DIAR_NATIVE_IMAGE:-opentranscribe-backend:latest}"
-      fi
-      COMPOSE_FILES="$COMPOSE_FILES -f docker-compose.diar-native.yml"
-      echo "🎙️  Adding native diarization sidecar (docker-compose.diar-native.yml)"
-      echo "   diar-server on GPU ${DIAR_NATIVE_GPU:-${GPU_DEVICE_ID:-0}} — ~4.1 GB warm ORT arena while up."
-      echo "   Used when engine.diarizer_backend=native (DB) / ENGINE_DIARIZER_BACKEND=native (env);"
-      echo "   without the sidecar that config falls back to the in-process PyAnnote fork."
-    else
-      echo "⚠️  --with-diar-native specified but docker-compose.diar-native.yml not found"
-    fi
-  fi
+  # Native diarization sidecar. Shared with rebuild-backend so a rebuild can never
+  # drop celery-worker's /tmp/diar-native handoff mount — see add_diar_native_overlay.
+  add_diar_native_overlay start
 
   # Add real GPU-backed LLM test provider if requested
   if [ -n "$WITH_LLM_TEST_FLAG" ]; then
@@ -3155,13 +3219,24 @@ case "$1" in
     echo "🔨 Rebuilding backend services..."
     detect_and_configure_hardware
 
-    # Parse optional flags so NAS-configured deployments keep their mounts.
+    # Parse optional flags so NAS-configured deployments keep their mounts, and so
+    # the diar-native auto-detect below can be overridden either way.
     NAS_FLAG=""
+    WITH_DIAR_NATIVE_FLAG=""
+    NO_DIAR_NATIVE_FLAG=""
     shift || true  # drop "rebuild-backend"
     while [ $# -gt 0 ]; do
       case "$1" in
         --nas)
           NAS_FLAG="--nas"
+          shift
+          ;;
+        --with-diar-native)
+          WITH_DIAR_NATIVE_FLAG="--with-diar-native"
+          shift
+          ;;
+        --no-diar-native)
+          NO_DIAR_NATIVE_FLAG="--no-diar-native"
           shift
           ;;
         *)
@@ -3186,6 +3261,16 @@ case "$1" in
     # appear missing even though it's still on disk.
     add_nas_overlay
 
+    # Keep the native diarization sidecar's handoff volume on celery-worker.
+    # Without this, a rebuilt worker has NO mount at /tmp/diar-native, the sidecar
+    # cannot see the WAV it is handed, /diarize answers 422, and diarization
+    # silently degrades to the in-process PyAnnote fork -- same "correct-looking
+    # container, wrong storage" failure as the NAS note above, but with no user
+    # -visible symptom at all. `rebuild` mode keys off the sidecar container this
+    # deployment already has, so it never starts one nobody asked for; see
+    # add_diar_native_overlay for why that predicate and not the config one.
+    add_diar_native_overlay rebuild
+
     # --no-deps keeps postgres/minio/opensearch/redis containers exactly as
     # they were running. Only rebuild + recreate the services that actually
     # consume backend code -- every service in docker-compose.override.yml
@@ -3193,6 +3278,11 @@ case "$1" in
     # missing from this list for a while: it shares the image but has its own
     # entry, so it silently kept running stale code after every rebuild until
     # something recreated it another way.
+    #
+    # `diar-native` is deliberately NOT in this list even when its overlay is
+    # loaded: it runs a Rust binary out of the same image, so a Python-side change
+    # cannot affect it, and recreating it costs a fresh ~4.1 GB ORT warm-up on the
+    # GPU. Restart it explicitly when the image's diar-server binary itself changed.
     # shellcheck disable=SC2086
     docker compose $COMPOSE_FILES up -d --build --no-deps \
       backend celery-worker celery-download-worker celery-cpu-worker \


### PR DESCRIPTION
`./opentr.sh rebuild-backend` silently broke diar-native. Found the hard way while landing 0.3.1 — it degraded a working stack to the PyAnnote fallback with no user-visible error.

## The defect

`rebuild-backend` built its compose chain as `docker-compose.yml` + `override` + `add_gpu_overlay` + `add_nas_overlay`, and **never added `docker-compose.diar-native.yml`**. That overlay is what mounts `diar-native-tmp:/tmp/diar-native` into `celery-worker` (`docker-compose.diar-native.yml:101-106`) — the shared volume OT uses to hand WAV files to the sidecar.

Measured after a rebuild: `celery-worker` had **no mount at all** at `/tmp/diar-native`. OT wrote the WAV to the worker's own filesystem, the sidecar could not see it, and `/diarize` answered:

```
HTTP 422  opening /tmp/diar-native/probe.wav: No such file or directory
```

which OT swallowed as `diar-native /diarize failed mid-job (HTTP Error 422); falling back to PyAnnote`. **No error surfaced to the user** — the only tells were one log line and missing speaker gender.

## The fix

A shared `add_diar_native_overlay` helper beside `add_nas_overlay`, so one place decides. It replaced **two** verbatim copies of the block — `start_app` *and* `reset_and_init` — and is now called from `rebuild-backend` too. `rebuild-backend` also learns `--with-diar-native` / `--no-diar-native`.

**The condition is observation, not configuration**: does a `diar-native` container exist in this compose project. `rebuild-backend` recreates in place, so the only correct answer is the one the running deployment already made — the `start` predicate disagrees in both directions (a stack started `--no-diar-native` would gain the overlay; a sidecar running under `ENGINE_DIARIZER_BACKEND=pyannote` would still lose it). Precedent is the gpu-scale/gpu-split loop in the same function.

It cannot start a sidecar nobody asked for: no container ⇒ no overlay, and `up -d --no-deps` with an explicit service list never brings up `diar-native` anyway.

## ⚠️ The project name must be DERIVED — the first version of this fix was a no-op

The probe originally used `${COMPOSE_PROJECT_NAME:-opentranscribe}`. `COMPOSE_PROJECT_NAME` is unset in a normal checkout (`opentr.sh` sets it only inside fresh-deployment helpers), so compose falls back to the **directory basename**. Measured:

```
project=opentranscribe  -> 0 matches
project=transcribe-app  -> 1 match   (transcribe-app-diar-native-1)
```

The probe matched nothing and the bug reproduced exactly. It now uses `${COMPOSE_PROJECT_NAME:-$(basename "$(pwd)")}`, the same resolution `preflight_ports_or_die` already uses.

⚠️ **The gpu-scale/gpu-split loop uses the hardcoded form and is NOT the same bug** — those three services pin an explicit `container_name` built from the same expansion, so loop and compose agree. `diar-native` declares none, which is why it gets compose's `<basename>-diar-native-1` default. That asymmetry is recorded in the probe's comment.

## Verification

- **`start dev --dry-run` output is byte-identical to master** across all four cases (auto-detect, `--with-diar-native`, `--no-diar-native`, no-export). The refactor changes nothing on the path everyone uses.
- RED watched twice: once against master (7 failed), once against the first commit to prove the project-resolution tests actually catch it (5 failed, including two that had passed under a permissive stub).
- **A stub bug was found by the RED run** — the test's fake `docker ps` ignored the project filter, which is precisely why the first GREEN was misleading. The stub now honours it, and the sandbox checkout is named `some-ot-checkout` so a hardcoded project fails.
- GREEN: 19 passed. All 528 existing `opentr.sh`-touching unit tests still pass.
- `shellcheck --severity=warning` clean; both pre-commit tiers green.

Closes #700
