### PR TITLE
fix(storage): reclaim object storage, derived renders and avatars when a user is deleted

### DIFF
--- a/backend/app/api/endpoints/admin.py
+++ b/backend/app/api/endpoints/admin.py
@@ -380,6 +380,14 @@ def _delete_user_owned_records(db: Session, user_id: int) -> None:
     ``user_id`` can find them. They are ``ON DELETE SET NULL`` at the database
     level instead (``v387``), which is enforced for every deletion path including
     ones that do not exist yet.
+
+    **``SpeakerProfile.avatar_path`` objects are NOT deleted here** (issue #695). This
+    function bulk-deletes the ``speaker_profile`` rows below, so by the time it could
+    act there is nothing left to read a path off of — the same shape as
+    ``_delete_user_media_files`` and object storage. The caller reads every avatar path
+    via ``file_cleanup_service.load_account_purge_plans`` **before** this function runs
+    and destroys the objects via ``purge_account_external_copies`` after the
+    transaction commits.
     """
     # Speaker collections and their members
     sc_ids = [
@@ -561,6 +569,14 @@ def _delete_user_media_files(db: Session, user_id: int) -> None:
     "commenting is collaborative"), so another account's comment on this user's
     file would block the bulk delete. Scope both by ``media_file_id``, not by
     ``user_id``.
+
+    **Object storage is deliberately NOT touched here** (issue #695). The bulk delete
+    below is exactly why: it never loads a ``MediaFile`` instance, so there is nothing
+    to read a ``storage_path`` off of by the time this function could act on one. The
+    caller reads the storage plan with ``file_cleanup_service.load_account_purge_plans``
+    **before** calling this function, and destroys the objects with
+    ``purge_account_external_copies`` **after** its own transaction commits — see
+    ``delete_admin_user``'s docstring for the phase split and why.
 
     Args:
         db: Database session
@@ -913,7 +929,7 @@ def create_admin_user(
         ) from e
 
 
-@router.delete("/users/{user_uuid}", response_model=dict[str, str])
+@router.delete("/users/{user_uuid}", response_model=dict[str, Any])
 def delete_admin_user(
     user_uuid: str,
     request: Request,
@@ -922,17 +938,33 @@ def delete_admin_user(
 ):
     """Delete a user and all their data (admin only).
 
+    **Phase boundary (issue #695).** The three cascade helpers below delete
+    ``media_file`` (and every table hanging off it) via **bulk** SQL — one statement,
+    no instances loaded, no cascade — which never reaches ``file_cleanup_service``'s
+    object-storage/OpenSearch destroy. Left alone, every deleted account's recordings
+    stayed in MinIO forever. The fix keeps that bulk delete (it is why
+    ``_delete_user_media_files`` exists — see its docstring) but reads the storage plan
+    with ``load_account_purge_plans`` **before** the savepoint, and destroys those
+    external copies with ``purge_account_external_copies`` **after** ``db.commit()`` —
+    with no transaction open, matching ``purge_media_file``'s own phase split. Doing
+    that I/O on a live session previously wedged the DB for up to 1h26m
+    (``idle in transaction``); doing it inside the savepoint would have meant a slow
+    MinIO/OpenSearch round trip holds a lock for the whole cascade.
+
     Args:
         user_uuid: UUID of the user to delete
         db: Database session
         current_user: Current admin user
 
     Returns:
-        Success message
+        ``{"message": str, "storage_objects_failed": int}`` — the count is 0 when
+        every external object was confirmed gone.
 
     Raises:
         HTTPException: If user not found or deletion not allowed
     """
+    from app.services.file_cleanup_service import load_account_purge_plans
+    from app.services.file_cleanup_service import purge_account_external_copies
     from app.utils.uuid_helpers import get_user_by_uuid
 
     logger.info(f"Admin deleting user with UUID: {user_uuid}")
@@ -960,12 +992,16 @@ def delete_admin_user(
         # 409 is worse than either outcome on its own (issue #689).
         _assert_no_files_under_legal_hold(db, int(user_id))
 
+        # Phase 0 — read the storage/OpenSearch plan while the rows still exist and the
+        # transaction is open. Postgres reads only; no object storage touched yet.
+        purge_plan = load_account_purge_plans(db, int(user_id))
+
         # Capture what the audit record needs before the row is gone: after the commit
         # the ORM object is expired, so reading user.email would re-query a deleted row.
         deleted_snapshot = DeletedUser.of(user)
         client_ip, user_agent = _get_client_info(request)
 
-        # Delete all user data atomically using a savepoint
+        # Phase 1 — delete all user data atomically using a savepoint
         savepoint = db.begin_nested()
         try:
             _delete_user_owned_records(db, int(user_id))
@@ -979,15 +1015,23 @@ def delete_admin_user(
             raise
         db.commit()
 
+        # Phase 2 — object storage + OpenSearch. NO transaction is held here. The rows
+        # are already gone, so a failure here is NOT retryable: it must be visible
+        # (residual_errors -> PARTIAL audit outcome + ERROR log), never swallowed.
+        residual_errors = purge_account_external_copies(purge_plan)
+
         # This endpoint destroys a user, their files and their transcripts irreversibly
         # and recorded NOTHING — while its twin, DELETE /api/users/{uuid}, performs the
         # identical deletion through these same three helpers and does audit it. Emitted
         # after the commit, matching that twin, so a failed delete leaves no record of a
         # deletion that did not happen. FedRAMP AU-2/AU-12, GDPR Art. 30(2)(d).
-        audit_user_deleted(deleted_snapshot, current_user, client_ip, user_agent)
+        audit_user_deleted(deleted_snapshot, current_user, client_ip, user_agent, residual_errors)
 
         logger.info(f"User deletion completed successfully: {user_id}")
-        return {"message": "User deleted successfully"}
+        return {
+            "message": "User deleted successfully",
+            "storage_objects_failed": len(residual_errors),
+        }
 
     except HTTPException:
         raise

--- a/backend/app/api/endpoints/users.py
+++ b/backend/app/api/endpoints/users.py
@@ -668,6 +668,8 @@ def delete_user(
     from app.api.endpoints.admin import _delete_user_media_files
     from app.api.endpoints.admin import _delete_user_owned_records
     from app.api.endpoints.admin import _delete_user_speakers
+    from app.services.file_cleanup_service import load_account_purge_plans
+    from app.services.file_cleanup_service import purge_account_external_copies
 
     user_id = user.id
 
@@ -676,6 +678,12 @@ def delete_user(
     # deletes of rows the caller was told were not deleted (issue #689).
     _assert_no_files_under_legal_hold(db, user_id)
 
+    # Phase 0 — read the storage/OpenSearch plan while the rows still exist (issue
+    # #695). See admin.delete_admin_user's docstring for the full phase-boundary
+    # rationale; this handler has no savepoint, so the read happens before any bulk
+    # delete runs at all.
+    purge_plan = load_account_purge_plans(db, user_id)
+
     _delete_user_owned_records(db, user_id)
     _delete_user_speakers(db, user_id)
     _delete_user_media_files(db, user_id)
@@ -683,7 +691,12 @@ def delete_user(
     db.delete(user)
     db.commit()
 
+    # Phase 2 — object storage + OpenSearch. NO transaction is held here. The rows are
+    # already gone, so a failure here is NOT retryable: it must be visible, never
+    # swallowed.
+    residual_errors = purge_account_external_copies(purge_plan)
+
     # ADMIN_USER_DELETE existed as an event type with no emitter anywhere.
-    audit_user_deleted(deleted_snapshot, current_user, client_ip, user_agent)
+    audit_user_deleted(deleted_snapshot, current_user, client_ip, user_agent, residual_errors)
 
     return None

--- a/backend/app/services/account_security_service.py
+++ b/backend/app/services/account_security_service.py
@@ -276,16 +276,52 @@ class DeletedUser:
         return cls(uuid=str(user.uuid), email=str(user.email))
 
 
-def audit_user_deleted(user: DeletedUser, actor: User, client_ip: str, user_agent: str) -> None:
-    """Record a user deletion. ``ADMIN_USER_DELETE`` had no emitter before this."""
+def audit_user_deleted(
+    user: DeletedUser,
+    actor: User,
+    client_ip: str,
+    user_agent: str,
+    residual_errors: list[dict] | None = None,
+) -> None:
+    """Record a user deletion. ``ADMIN_USER_DELETE`` had no emitter before this.
+
+    Args:
+        user: Snapshot of the deleted account, captured before the row was gone.
+        actor: The admin who performed the deletion.
+        client_ip: Requesting client's IP.
+        user_agent: Requesting client's user agent.
+        residual_errors: Per-object failures from
+            ``file_cleanup_service.purge_account_external_copies`` (issue #695) — object
+            storage or OpenSearch documents that may still exist after the account's rows
+            were removed. Non-empty flips the outcome to ``PARTIAL`` so an incomplete
+            storage reclaim cannot audit as a clean success. ``details`` carries only
+            **counters** (``storage_objects_failed``, ``stages``), never the object keys
+            themselves — those quote filenames and storage paths and belong in the ERROR
+            log line instead, mirroring the GDPR erasure ledger's no-free-text rule.
+    """
+    residual_errors = residual_errors or []
+    details: dict[str, object] = {"target_user": user.uuid, "target_email": user.email}
+    outcome = AuditOutcome.SUCCESS
+    if residual_errors:
+        outcome = AuditOutcome.PARTIAL
+        details["storage_objects_failed"] = len(residual_errors)
+        details["stages"] = sorted({str(e.get("stage")) for e in residual_errors})
+        logger.error(
+            "user deletion for %s (%s) left %d external object(s) undeleted: %s",
+            user.uuid,
+            user.email,
+            len(residual_errors),
+            residual_errors,
+        )
+
     audit_logger.log(
         event_type=AuditEventType.ADMIN_USER_DELETE,
-        outcome=AuditOutcome.SUCCESS,
+        outcome=outcome,
         user_id=actor.id,
         username=str(actor.email),
         source_ip=client_ip,
         user_agent=user_agent,
-        details={"target_user": user.uuid, "target_email": user.email},
+        details=details,
     )
 
 

--- a/backend/app/services/file_cleanup_service.py
+++ b/backend/app/services/file_cleanup_service.py
@@ -5,6 +5,8 @@ File cleanup service for recovering stuck files and maintaining system health.
 import contextlib
 import logging
 from collections.abc import Callable
+from dataclasses import dataclass
+from dataclasses import field
 from datetime import UTC
 from datetime import datetime
 from datetime import timedelta
@@ -754,6 +756,133 @@ def _purge_external_copies(plan: dict[str, Any]) -> list[dict[str, Any]]:
         )
 
     residual.extend(_cleanup_opensearch_for_file(plan, file_uuid) or [])
+    return residual
+
+
+@dataclass(frozen=True)
+class AccountPurgePlan:
+    """Plain-data plan for destroying every external copy an ACCOUNT owns (issue #695).
+
+    Deleting a user removes ``media_file`` rows via a bulk ``query(...).delete()``
+    (``admin._delete_user_media_files``) that never loads instances and therefore never
+    reaches ``purge_media_file`` — so the objects those rows named survived every
+    account deletion forever. This is the account-scoped analogue of
+    :func:`_load_purge_plan`: read everything the external destroy needs *before* the
+    bulk delete runs, as plain data, then hand it to :func:`purge_account_external_copies`
+    with no transaction open.
+
+    Attributes:
+        files: One ``_load_purge_plan``-shaped dict per media file the account owns.
+        avatar_paths: Every non-null ``SpeakerProfile.avatar_path`` the account owns.
+            ``purge_media_file`` deliberately never touches these — profiles are
+            preserved when a single FILE is destroyed — but the account-delete path
+            destroys the profiles themselves (``_delete_user_owned_records``), and
+            nothing else has ever removed the avatar objects backing them.
+    """
+
+    files: list[dict[str, Any]] = field(default_factory=list)
+    avatar_paths: list[str] = field(default_factory=list)
+
+
+def load_account_purge_plans(db: Session, user_id: int) -> AccountPurgePlan:
+    """Read the storage/OpenSearch addresses of everything an account owns.
+
+    Two COLUMN-ONLY queries — **plain tuples, never ORM instances** — for the same
+    reason :func:`_load_purge_plan` reads plain data: an escaping instance lazy-loads,
+    which reopens a transaction in the middle of the caller's external-copy phase.
+
+    ``speaker_uuids`` is deliberately left ``[]`` on every file plan here, NOT because
+    the file's speakers should be skipped, but because the account-delete cascade
+    already removes every one of this user's speaker embeddings itself
+    (``admin._delete_user_speakers``, which runs before the bulk file delete). Reusing
+    ``_purge_external_copies`` per file would otherwise attempt the same OpenSearch
+    deletes twice — harmless (idempotent), but worth documenting so a future reader
+    does not "fix" this into a duplicate sweep.
+
+    Args:
+        db: The caller's session, used only for the reads below.
+        user_id: Internal id of the account about to be deleted.
+
+    Returns:
+        An :class:`AccountPurgePlan` naming every object this account's cascade must
+        remove from object storage and OpenSearch.
+    """
+    from app.models.media import SpeakerProfile
+
+    file_rows = (
+        db.query(
+            MediaFile.id,
+            MediaFile.uuid,
+            MediaFile.filename,
+            MediaFile.storage_path,
+            MediaFile.thumbnail_path,
+        )
+        .filter(MediaFile.user_id == user_id)
+        .all()
+    )
+    files: list[dict[str, Any]] = [
+        {
+            "file_id": int(row.id),
+            "file_uuid": str(row.uuid),
+            "owner_id": int(user_id),
+            "filename": str(row.filename) if row.filename else None,
+            "storage_path": str(row.storage_path) if row.storage_path else None,
+            "thumbnail_path": str(row.thumbnail_path) if row.thumbnail_path else None,
+            "speaker_uuids": [],
+            "speaker_read_error": None,
+        }
+        for row in file_rows
+    ]
+
+    avatar_rows = (
+        db.query(SpeakerProfile.avatar_path)
+        .filter(SpeakerProfile.user_id == user_id, SpeakerProfile.avatar_path.isnot(None))
+        .all()
+    )
+    avatar_paths = [str(row[0]) for row in avatar_rows if row[0]]
+
+    return AccountPurgePlan(files=files, avatar_paths=avatar_paths)
+
+
+def purge_account_external_copies(plan: AccountPurgePlan) -> list[dict[str, Any]]:
+    """Destroy every external copy an ACCOUNT owned. **Takes no Session, never raises.**
+
+    Runs after the account's rows are already committed (see
+    ``admin.delete_admin_user`` / ``users.delete_user``): the rows are gone, so a
+    failure here is not retryable and must be visible, never swallowed. Reuses
+    :func:`_purge_external_copies` per file rather than open-coding a second artifact
+    list, which is what gives this call thumbnail + derived-cache (including listed
+    masked variants) + OpenSearch erasure for free, in one audited implementation.
+
+    Args:
+        plan: The plain-data plan from :func:`load_account_purge_plans`.
+
+    Returns:
+        One ``{"stage", "file_uuid"|"avatar_path", "error"}`` dict per object that may
+        still exist. Empty means every object was confirmed gone.
+    """
+    residual: list[dict[str, Any]] = []
+
+    for file_plan in plan.files:
+        try:
+            residual.extend(_purge_external_copies(file_plan))
+        except Exception as e:  # noqa: BLE001 — one file must never block the rest
+            residual.append(
+                {
+                    "stage": "storage",
+                    "file_uuid": file_plan.get("file_uuid"),
+                    "error": str(e),
+                }
+            )
+
+    for avatar_path in plan.avatar_paths:
+        try:
+            from app.services.minio_service import delete_file
+
+            delete_file(avatar_path)
+        except Exception as e:  # noqa: BLE001 — one avatar must never block the rest
+            residual.append({"stage": "avatar", "avatar_path": avatar_path, "error": str(e)})
+
     return residual
 
 

--- a/backend/tests/api/endpoints/test_admin.py
+++ b/backend/tests/api/endpoints/test_admin.py
@@ -3,12 +3,40 @@
 import uuid
 from unittest.mock import patch
 
+import pytest
 from fastapi import status
 
 from app.auth.audit import AuditEventType
 from app.auth.audit import AuditOutcome
 from app.core.version import APP_VERSION
 from tests.user_owned_rows import seed_owned_rows
+
+
+@pytest.fixture(autouse=True)
+def _spy_storage_reclaim_phase(monkeypatch):
+    """Neutralize the object-storage/OpenSearch reclaim phase (issue #695).
+
+    This module's user-deletion tests seed rows through ``db_session`` (rolled back
+    at the end of the test) but never upload real objects, so letting the real
+    ``purge_account_external_copies`` run would hit a live/unreachable MinIO for
+    every plan entry. It is a SPY, not a silent stub: it asserts the plan it
+    received is shaped like an ``AccountPurgePlan`` (every file entry carries the
+    keys the real destroy depends on) before reporting a clean sweep.
+    """
+    import app.services.file_cleanup_service as fcs
+
+    calls: list[fcs.AccountPurgePlan] = []
+
+    def _spy(plan: fcs.AccountPurgePlan) -> list[dict]:
+        assert isinstance(plan, fcs.AccountPurgePlan)
+        for file_plan in plan.files:
+            assert "file_uuid" in file_plan
+            assert "storage_path" in file_plan
+        calls.append(plan)
+        return []
+
+    monkeypatch.setattr(fcs, "purge_account_external_copies", _spy)
+    yield calls
 
 
 def test_admin_stats(client, admin_token_headers):
@@ -139,7 +167,10 @@ def test_admin_users_delete(client, admin_token_headers, normal_user, db_session
 
     response = client.delete(f"/api/admin/users/{normal_user.uuid}", headers=admin_token_headers)
     assert response.status_code == status.HTTP_200_OK, response.text
-    assert response.json() == {"message": "User deleted successfully"}
+    assert response.json() == {
+        "message": "User deleted successfully",
+        "storage_objects_failed": 0,
+    }
 
     db_session.expire_all()
     assert db_session.query(User).filter(User.id == owned.user_id).first() is None

--- a/backend/tests/api/endpoints/test_admin_user_delete_legal_hold.py
+++ b/backend/tests/api/endpoints/test_admin_user_delete_legal_hold.py
@@ -20,12 +20,37 @@ back ``db_session``. Both entry points are covered, because there are two:
 cascade helpers.
 """
 
+import pytest
 from fastapi import status
 
 from app.models.media import MediaFile
 from app.models.user import User
 from tests.user_owned_rows import make_media_file
 from tests.user_owned_rows import seed_owned_rows
+
+
+@pytest.fixture(autouse=True)
+def _spy_storage_reclaim_phase(monkeypatch):
+    """Neutralize the object-storage/OpenSearch reclaim phase (issue #695).
+
+    Same rationale as ``test_admin.py``'s sibling fixture — these tests seed rows
+    but never upload real objects. A spy, not a silent stub: it asserts the plan is
+    shaped like an ``AccountPurgePlan`` before reporting a clean sweep.
+    """
+    import app.services.file_cleanup_service as fcs
+
+    calls: list[fcs.AccountPurgePlan] = []
+
+    def _spy(plan: fcs.AccountPurgePlan) -> list[dict]:
+        assert isinstance(plan, fcs.AccountPurgePlan)
+        for file_plan in plan.files:
+            assert "file_uuid" in file_plan
+            assert "storage_path" in file_plan
+        calls.append(plan)
+        return []
+
+    monkeypatch.setattr(fcs, "purge_account_external_copies", _spy)
+    yield calls
 
 
 def _place_under_legal_hold(db_session, media_file: MediaFile) -> int:

--- a/backend/tests/api/endpoints/test_user_delete_storage_reclaim.py
+++ b/backend/tests/api/endpoints/test_user_delete_storage_reclaim.py
@@ -238,14 +238,34 @@ def test_a_storage_failure_is_reported_and_does_not_silently_pass(
 
     No live MinIO needed: ``minio_service.delete_file`` is monkeypatched to raise for
     the file's key, which is enough to exercise the residual-error plumbing end to end.
+
+    The OpenSearch leg is replaced by a **spy** so this measures the STORAGE leg
+    exactly. It is not decoration: against an unreachable cluster —
+    ``SKIP_OPENSEARCH=True`` with no OpenSearch service, which is precisely how the
+    GitHub ``backend-tests`` job runs — ``_cleanup_opensearch_for_file`` contributes
+    three more residuals of its own, and the exact assertions below became
+    ``storage_objects_failed == 4`` / ``stages == ["storage", "transcript",
+    "transcript_chunks", "transcript_summaries"]``. The spy still asserts the account
+    path *routes through* that leg with this file's plan, so stubbing it cannot hide a
+    fix that stopped calling it; its own residual reporting is covered against
+    ``purge_media_file``.
     """
     import logging
 
+    import app.services.file_cleanup_service as fcs
     import app.services.minio_service as minio_mod
 
     fuuid = uuid_pkg.uuid4()
     failing_key = f"tests/issue695/{fuuid}/orig.bin"
     _make_media_file(db_session, int(normal_user.id), uuid=fuuid, storage_path=failing_key)
+
+    opensearch_calls: list[str] = []
+
+    def _spy_opensearch(target: dict, file_uuid: str) -> list[dict]:
+        opensearch_calls.append(file_uuid)
+        return []
+
+    monkeypatch.setattr(fcs, "_cleanup_opensearch_for_file", _spy_opensearch)
 
     real_delete_file = minio_mod.delete_file
 
@@ -279,6 +299,9 @@ def test_a_storage_failure_is_reported_and_does_not_silently_pass(
     assert db_session.query(User).filter(User.id == normal_user.id).first() is None
     assert db_session.query(MediaFile).filter(MediaFile.storage_path == failing_key).first() is None
 
+    assert opensearch_calls == [str(fuuid)], (
+        "the account purge no longer routes this file through the OpenSearch erasure"
+    )
     assert len(events) == 1
     assert events[0]["outcome"] is AuditOutcome.PARTIAL
     assert events[0]["details"]["storage_objects_failed"] == 1
@@ -294,12 +317,14 @@ def test_a_user_with_no_files_still_deletes_cleanly(
 ):
     """CONTROL against a plausible wrong fix (a prefix sweep), not a red/green pin.
 
-    This test CANNOT be watched red against HEAD: a user with zero files already
-    deletes cleanly on master, because there is nothing for the (missing) storage
-    phase to fail on. Its only job is to prove the real fix does not replace "do
-    nothing" with "sweep a prefix" — a `delete_prefix` call would still pass every
-    other test here while quietly deleting unrelated objects that happen to share
-    the account's user-id-keyed prefix.
+    **This test's red on pre-fix master is not evidence of the defect.** It does go
+    red there, but only on `KeyError: 'storage_objects_failed'` — a response key that
+    did not exist yet — and the behaviour it asserts (a user with zero files deletes
+    cleanly, touching no object) is already true on master, because there is nothing
+    for the missing storage phase to act on. Its only job is to prove the real fix
+    does not replace "do nothing" with "sweep a prefix": a ``delete_prefix`` call would
+    pass every other test here while quietly deleting unrelated objects that happen to
+    share the account's user-id-keyed prefix.
     """
     import app.services.minio_service as minio_mod
 
@@ -386,32 +411,30 @@ def test_the_media_file_delete_is_still_one_statement(
     assert len(statements) == 1, f"expected exactly one bulk DELETE, got {statements}"
 
 
-def test_every_caller_of_the_user_cascade_also_purges_storage():
-    """Structural backstop: any caller of ``_delete_user_media_files`` must also purge storage.
+def _calls(func_node: ast.FunctionDef | ast.AsyncFunctionDef, name: str) -> bool:
+    """True when ``func_node``'s body calls ``name`` (bare or as an attribute)."""
+    for node in ast.walk(func_node):
+        if isinstance(node, ast.Call):
+            target = node.func
+            called_name = None
+            if isinstance(target, ast.Name):
+                called_name = target.id
+            elif isinstance(target, ast.Attribute):
+                called_name = target.attr
+            if called_name == name:
+                return True
+    return False
 
-    AST over ``backend/app`` — includes a must-fire fixture (a synthetic function
-    calling the cascade helper alone) so this cannot be a detector that matches
-    nothing.
+
+def _cascade_callers_missing_purge(root: Path) -> list[str]:
+    """Every function under ``root`` that runs the cascade without the storage purge.
+
+    Module level, and taking a root, so the must-fire control below runs **this**
+    detector over a synthetic tree rather than re-implementing it — a control that
+    re-implements the thing it is controlling proves only that the copy works.
     """
-    app_root = Path(__file__).resolve().parents[3] / "app"
-    assert app_root.is_dir(), app_root
-
     offenders: list[str] = []
-
-    def _calls(func_node: ast.FunctionDef | ast.AsyncFunctionDef, name: str) -> bool:
-        for node in ast.walk(func_node):
-            if isinstance(node, ast.Call):
-                target = node.func
-                called_name = None
-                if isinstance(target, ast.Name):
-                    called_name = target.id
-                elif isinstance(target, ast.Attribute):
-                    called_name = target.attr
-                if called_name == name:
-                    return True
-        return False
-
-    for py_file in app_root.rglob("*.py"):
+    for py_file in sorted(root.rglob("*.py")):
         # No `except SyntaxError`: every file under backend/app is real, importable
         # application code, so a parse failure here is itself a finding worth
         # seeing, not something to skip past.
@@ -421,7 +444,21 @@ def test_every_caller_of_the_user_cascade_also_purges_storage():
                 if _calls(node, "_delete_user_media_files") and not _calls(
                     node, "purge_account_external_copies"
                 ):
-                    offenders.append(f"{py_file.relative_to(app_root)}::{node.name}")
+                    offenders.append(f"{py_file.relative_to(root)}::{node.name}")
+    return offenders
+
+
+def test_every_caller_of_the_user_cascade_also_purges_storage():
+    """Structural backstop: any caller of ``_delete_user_media_files`` must also purge storage.
+
+    AST over ``backend/app``. Its must-fire control is the test below, which drives the
+    same detector over a synthetic offender so this cannot be a detector matching
+    nothing.
+    """
+    app_root = Path(__file__).resolve().parents[3] / "app"
+    assert app_root.is_dir(), app_root
+
+    offenders = _cascade_callers_missing_purge(app_root)
 
     assert offenders == [], (
         "every caller of _delete_user_media_files must also call "
@@ -429,27 +466,23 @@ def test_every_caller_of_the_user_cascade_also_purges_storage():
     )
 
 
-def test_the_structural_backstop_fires_on_a_synthetic_offender(tmp_path, monkeypatch):
-    """Must-fire control for the AST backstop above.
+def test_the_structural_backstop_fires_on_a_synthetic_offender(tmp_path):
+    """Must-fire AND must-stay-clean control for the AST backstop above.
 
-    Without this, the detector could match nothing and the test above would pass
-    vacuously forever.
+    Without this the detector could match nothing and the test above would pass
+    vacuously forever. It runs ``_cascade_callers_missing_purge`` itself over a
+    two-file tree: one function that calls the cascade alone (must be reported) and
+    one that also purges (must not be).
     """
-    offender_src = "def bad_caller(db, user_id):\n    _delete_user_media_files(db, user_id)\n"
     fake_app = tmp_path / "app"
     fake_app.mkdir()
-    (fake_app / "offender.py").write_text(offender_src)
+    (fake_app / "offender.py").write_text(
+        "def bad_caller(db, user_id):\n    _delete_user_media_files(db, user_id)\n"
+    )
+    (fake_app / "compliant.py").write_text(
+        "def good_caller(db, user_id, plan):\n"
+        "    _delete_user_media_files(db, user_id)\n"
+        "    purge_account_external_copies(plan)\n"
+    )
 
-    import ast as ast_mod
-
-    tree = ast_mod.parse(offender_src)
-    found_bad_call = False
-    found_good_call = False
-    for node in ast_mod.walk(tree):
-        if isinstance(node, ast_mod.Call) and isinstance(node.func, ast_mod.Name):
-            if node.func.id == "_delete_user_media_files":
-                found_bad_call = True
-            if node.func.id == "purge_account_external_copies":
-                found_good_call = True
-    assert found_bad_call
-    assert not found_good_call
+    assert _cascade_callers_missing_purge(fake_app) == ["offender.py::bad_caller"]

--- a/backend/tests/api/endpoints/test_user_delete_storage_reclaim.py
+++ b/backend/tests/api/endpoints/test_user_delete_storage_reclaim.py
@@ -1,0 +1,455 @@
+"""Deleting a user must reclaim their object storage, not just their rows (issue #695).
+
+``_delete_user_media_files`` (``admin.py``) ends in a bulk ``query(MediaFile).delete()``
+that never touches object storage — every deleted account's recordings, thumbnails,
+derived-cache renders and speaker-profile avatars survived in MinIO forever, and the
+retention sweep can never find them because the row that named them is gone.
+
+The fix: ``file_cleanup_service.load_account_purge_plans`` reads the storage plan
+before the bulk delete, and ``purge_account_external_copies`` destroys the objects
+after the transaction commits, with no transaction open (mirroring ``purge_media_file``'s
+own phase split).
+
+Two harness facts govern the tests below:
+
+* ``db_session`` rolls back Postgres but NOT MinIO/OpenSearch — every uploaded test
+  object is cleaned up in a ``finally``.
+* In CI, object storage is unreachable but the client is REAL — tests needing live
+  MinIO are gated by ``S3_LIVE`` (the same pattern as ``tests/unit/test_multipart_upload.py``).
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import uuid as uuid_pkg
+from pathlib import Path
+
+import pytest
+from fastapi import status
+from minio.error import S3Error
+
+from app.auth.audit import AuditOutcome
+from app.core.config import settings
+from app.models.media import MediaFile
+from app.models.media import SpeakerProfile
+from app.models.user import User
+from app.services.minio_service import minio_client
+
+S3_LIVE = os.environ.get("SKIP_S3", "True").lower() != "true"
+
+pytestmark = pytest.mark.xdist_group("storage_backend")
+
+
+def _put(bucket: str, key: str, body: bytes = b"test-object-695") -> None:
+    """Upload real bytes to a real bucket, creating the bucket if needed."""
+    import io
+
+    if not minio_client.bucket_exists(bucket):
+        minio_client.make_bucket(bucket)
+    minio_client.put_object(bucket, key, io.BytesIO(body), length=len(body))
+
+
+def _exists(bucket: str, key: str) -> bool:
+    try:
+        minio_client.stat_object(bucket, key)
+        return True
+    except S3Error:
+        return False
+
+
+def _cleanup(bucket: str, key: str) -> None:
+    from contextlib import suppress
+
+    with suppress(Exception):
+        minio_client.remove_object(bucket, key)
+
+
+def _make_media_file(db_session, user_id: int, **kwargs) -> MediaFile:
+    fuuid = kwargs.pop("uuid", None) or uuid_pkg.uuid4()
+    media_file = MediaFile(
+        uuid=fuuid,
+        filename=kwargs.pop("filename", f"issue695-{fuuid.hex[:8]}.mp4"),
+        storage_path=kwargs.pop("storage_path", f"tests/issue695/{fuuid}/orig.bin"),
+        content_type="video/mp4",
+        file_size=1234,
+        user_id=user_id,
+        status="completed",
+        **kwargs,
+    )
+    db_session.add(media_file)
+    db_session.commit()
+    db_session.refresh(media_file)
+    return media_file
+
+
+@pytest.mark.skipif(not S3_LIVE, reason="needs a real MinIO (SKIP_S3=False)")
+def test_deleting_a_user_removes_their_media_object_from_real_storage(
+    client, admin_token_headers, normal_user, admin_user, db_session
+):
+    """The headline defect: the object survives the row's deletion. Not anymore."""
+    bucket = settings.MEDIA_BUCKET_NAME
+    fuuid = uuid_pkg.uuid4()
+    original_key = f"tests/issue695/{fuuid}/orig.bin"
+    thumb_key = f"tests/issue695/{fuuid}/thumb.jpg"
+    bystander_key = f"tests/issue695/bystander-{uuid_pkg.uuid4()}/orig.bin"
+
+    _put(bucket, original_key)
+    _put(bucket, thumb_key)
+    _put(bucket, bystander_key)
+
+    try:
+        _make_media_file(
+            db_session,
+            int(normal_user.id),
+            uuid=fuuid,
+            storage_path=original_key,
+            thumbnail_path=thumb_key,
+        )
+        # Bystander file belongs to a DIFFERENT user and must survive.
+        _make_media_file(db_session, int(admin_user.id), storage_path=bystander_key)
+
+        response = client.delete(
+            f"/api/admin/users/{normal_user.uuid}", headers=admin_token_headers
+        )
+        assert response.status_code == status.HTTP_200_OK, response.text
+        assert response.json()["storage_objects_failed"] == 0
+
+        assert not _exists(bucket, original_key), "original object survived the account delete"
+        assert not _exists(bucket, thumb_key), "thumbnail object survived the account delete"
+        assert _exists(bucket, bystander_key), "an UNRELATED user's object was deleted"
+    finally:
+        _cleanup(bucket, original_key)
+        _cleanup(bucket, thumb_key)
+        _cleanup(bucket, bystander_key)
+
+
+@pytest.mark.skipif(not S3_LIVE, reason="needs a real MinIO (SKIP_S3=False)")
+def test_the_users_router_delete_removes_the_objects_too(
+    client, admin_token_headers, normal_user, db_session
+):
+    """``DELETE /api/users/{uuid}`` is the second caller — #689 had the same two-caller shape."""
+    bucket = settings.MEDIA_BUCKET_NAME
+    fuuid = uuid_pkg.uuid4()
+    original_key = f"tests/issue695/{fuuid}/orig.bin"
+
+    _put(bucket, original_key)
+
+    try:
+        _make_media_file(db_session, int(normal_user.id), uuid=fuuid, storage_path=original_key)
+
+        response = client.delete(f"/api/users/{normal_user.uuid}", headers=admin_token_headers)
+        assert response.status_code == status.HTTP_204_NO_CONTENT, response.text
+
+        assert not _exists(bucket, original_key)
+    finally:
+        _cleanup(bucket, original_key)
+
+
+@pytest.mark.skipif(not S3_LIVE, reason="needs a real MinIO (SKIP_S3=False)")
+def test_the_derived_cache_renders_are_removed(
+    client, admin_token_headers, normal_user, db_session
+):
+    """The most discriminating test: a storage_path-only fix leaves this behind.
+
+    Thumbnails and ``storage_path`` are named on the row; the derived-cache burned-in
+    render is NOT — its fingerprinted variant can only be found by LISTING the bucket
+    (``VideoProcessingService._masked_video_cache_keys``). A fix that deletes only
+    ``storage_path`` and ``thumbnail_path`` passes every other test here and still
+    leaves a video of the transcript in storage.
+    """
+    bucket = "processed-videos"
+    fuuid = uuid_pkg.uuid4()
+    original_key = f"tests/issue695/{fuuid}/orig.bin"
+
+    media_file = _make_media_file(
+        db_session,
+        int(normal_user.id),
+        uuid=fuuid,
+        storage_path=original_key,
+        filename="issue695.mp4",
+    )
+    file_id = int(media_file.id)
+    base = "issue695"
+
+    plain_key = f"derived/{file_id}_{base}_with_speakers.mp4"
+    fingerprinted_key = f"derived/{file_id}_{base}_with_speakers_rab12cd.mp4"
+
+    other_media_file = _make_media_file(
+        db_session, int(normal_user.id), storage_path=f"tests/issue695/{uuid_pkg.uuid4()}/orig.bin"
+    )
+    other_media_file_id = int(other_media_file.id)
+    neighbour_key = f"derived/{other_media_file_id}_{base}_with_speakers.mp4"
+
+    _put(bucket, plain_key)
+    _put(bucket, fingerprinted_key)
+    _put(bucket, neighbour_key)
+
+    try:
+        response = client.delete(
+            f"/api/admin/users/{normal_user.uuid}", headers=admin_token_headers
+        )
+        assert response.status_code == status.HTTP_200_OK, response.text
+
+        assert not _exists(bucket, plain_key), "unfingerprinted derived render survived"
+        assert not _exists(bucket, fingerprinted_key), "fingerprinted derived render survived"
+        assert _exists(bucket, neighbour_key), (
+            "a NEIGHBOURING file's derived render was destroyed — the prefix must be "
+            "id-scoped, not filename-scoped"
+        )
+    finally:
+        _cleanup(bucket, plain_key)
+        _cleanup(bucket, fingerprinted_key)
+        _cleanup(bucket, neighbour_key)
+
+
+@pytest.mark.skipif(not S3_LIVE, reason="needs a real MinIO (SKIP_S3=False)")
+def test_the_speaker_profile_avatar_goes_with_the_account(
+    client, admin_token_headers, normal_user, db_session
+):
+    """``SpeakerProfile.avatar_path`` is orphaned by the ADMIN path too (issue #695)."""
+    bucket = settings.MEDIA_BUCKET_NAME
+    avatar_key = f"tests/issue695/avatars/{uuid_pkg.uuid4()}.jpg"
+    _put(bucket, avatar_key)
+
+    profile = SpeakerProfile(
+        uuid=uuid_pkg.uuid4(),
+        user_id=int(normal_user.id),
+        name=f"Profile {uuid_pkg.uuid4().hex[:8]}",
+        avatar_path=avatar_key,
+    )
+    db_session.add(profile)
+    db_session.commit()
+
+    try:
+        response = client.delete(
+            f"/api/admin/users/{normal_user.uuid}", headers=admin_token_headers
+        )
+        assert response.status_code == status.HTTP_200_OK, response.text
+        assert not _exists(bucket, avatar_key)
+    finally:
+        _cleanup(bucket, avatar_key)
+
+
+def test_a_storage_failure_is_reported_and_does_not_silently_pass(
+    client, admin_token_headers, normal_user, db_session, monkeypatch, caplog
+):
+    """A failed delete is NOT retryable (the row is already gone) so it must be visible.
+
+    No live MinIO needed: ``minio_service.delete_file`` is monkeypatched to raise for
+    the file's key, which is enough to exercise the residual-error plumbing end to end.
+    """
+    import logging
+
+    import app.services.minio_service as minio_mod
+
+    fuuid = uuid_pkg.uuid4()
+    failing_key = f"tests/issue695/{fuuid}/orig.bin"
+    _make_media_file(db_session, int(normal_user.id), uuid=fuuid, storage_path=failing_key)
+
+    real_delete_file = minio_mod.delete_file
+
+    def _boom(object_name: str):
+        if object_name == failing_key:
+            raise RuntimeError(f"simulated MinIO outage for {object_name}")
+        return real_delete_file(object_name)
+
+    monkeypatch.setattr(minio_mod, "delete_file", _boom)
+
+    from app.services import account_security_service as acct_module
+
+    events: list[dict] = []
+    real_log = acct_module.audit_logger.log
+
+    def _spy_log(**kw):
+        events.append(kw)
+        return real_log(**kw)
+
+    monkeypatch.setattr(acct_module.audit_logger, "log", _spy_log)
+
+    with caplog.at_level(logging.WARNING):
+        response = client.delete(
+            f"/api/admin/users/{normal_user.uuid}", headers=admin_token_headers
+        )
+
+    assert response.status_code == status.HTTP_200_OK, response.text
+    assert response.json()["storage_objects_failed"] == 1
+
+    db_session.expire_all()
+    assert db_session.query(User).filter(User.id == normal_user.id).first() is None
+    assert db_session.query(MediaFile).filter(MediaFile.storage_path == failing_key).first() is None
+
+    assert len(events) == 1
+    assert events[0]["outcome"] is AuditOutcome.PARTIAL
+    assert events[0]["details"]["storage_objects_failed"] == 1
+    assert events[0]["details"]["stages"] == ["storage"]
+    # No object key in the audit `details` (mirrors the GDPR erasure ledger's no-free-text
+    # rule) — the key belongs only in the ERROR log line.
+    assert failing_key not in str(events[0]["details"])
+    assert any(failing_key in record.message for record in caplog.records)
+
+
+def test_a_user_with_no_files_still_deletes_cleanly(
+    client, admin_token_headers, normal_user, monkeypatch
+):
+    """CONTROL against a plausible wrong fix (a prefix sweep), not a red/green pin.
+
+    This test CANNOT be watched red against HEAD: a user with zero files already
+    deletes cleanly on master, because there is nothing for the (missing) storage
+    phase to fail on. Its only job is to prove the real fix does not replace "do
+    nothing" with "sweep a prefix" — a `delete_prefix` call would still pass every
+    other test here while quietly deleting unrelated objects that happen to share
+    the account's user-id-keyed prefix.
+    """
+    import app.services.minio_service as minio_mod
+
+    calls: list[str] = []
+    monkeypatch.setattr(minio_mod, "delete_file", lambda path: calls.append(path))
+
+    response = client.delete(f"/api/admin/users/{normal_user.uuid}", headers=admin_token_headers)
+    assert response.status_code == status.HTTP_200_OK, response.text
+    assert response.json()["storage_objects_failed"] == 0
+    assert calls == []
+
+
+def test_the_objects_are_removed_only_after_the_rows_are_committed(
+    client, admin_token_headers, normal_user, db_session, monkeypatch
+):
+    """Pins the phase boundary: storage deletes only follow a commit.
+
+    Under ``db_session`` this asserts CALL ORDER only, not durability — the savepoint
+    harness intercepts real commits, so this cannot observe whether Postgres itself
+    made the row-delete durable, only that the code path calls ``commit()`` before it
+    calls ``delete_file()``.
+    """
+    import app.services.minio_service as minio_mod
+
+    fuuid = uuid_pkg.uuid4()
+    key = f"tests/issue695/{fuuid}/orig.bin"
+    _make_media_file(db_session, int(normal_user.id), uuid=fuuid, storage_path=key)
+
+    order: list[str] = []
+    real_commit = db_session.commit
+
+    def _commit_spy():
+        order.append("commit")
+        return real_commit()
+
+    def _delete_spy(path):
+        order.append(f"delete:{path}")
+
+    monkeypatch.setattr(db_session, "commit", _commit_spy)
+    monkeypatch.setattr(minio_mod, "delete_file", _delete_spy)
+
+    response = client.delete(f"/api/admin/users/{normal_user.uuid}", headers=admin_token_headers)
+    assert response.status_code == status.HTTP_200_OK, response.text
+
+    assert "commit" in order
+    assert f"delete:{key}" in order
+    assert order.index("commit") < order.index(f"delete:{key}"), (
+        f"a storage delete happened before any commit: {order}"
+    )
+
+
+def test_the_media_file_delete_is_still_one_statement(
+    client, admin_token_headers, normal_user, db_session
+):
+    """Pins decision 1: collect-plans-then-bulk-delete, never a purge_media_file loop.
+
+    ``purge_media_file`` commits twice per file, which would release
+    ``delete_admin_user``'s savepoint on the FIRST file if it were called in a loop —
+    so the bulk ``query(MediaFile).delete()`` must survive as exactly one DELETE
+    statement against ``media_file``, seeded with several rows so a per-row loop
+    would be caught.
+    """
+    from sqlalchemy import event
+
+    for _ in range(3):
+        _make_media_file(db_session, int(normal_user.id))
+
+    statements: list[str] = []
+
+    def _before_cursor_execute(conn, cursor, statement, parameters, context, executemany):
+        if "DELETE FROM media_file" in statement:
+            statements.append(statement)
+
+    engine = db_session.get_bind()
+    event.listen(engine, "before_cursor_execute", _before_cursor_execute)
+    try:
+        response = client.delete(
+            f"/api/admin/users/{normal_user.uuid}", headers=admin_token_headers
+        )
+        assert response.status_code == status.HTTP_200_OK, response.text
+    finally:
+        event.remove(engine, "before_cursor_execute", _before_cursor_execute)
+
+    assert len(statements) == 1, f"expected exactly one bulk DELETE, got {statements}"
+
+
+def test_every_caller_of_the_user_cascade_also_purges_storage():
+    """Structural backstop: any caller of ``_delete_user_media_files`` must also purge storage.
+
+    AST over ``backend/app`` — includes a must-fire fixture (a synthetic function
+    calling the cascade helper alone) so this cannot be a detector that matches
+    nothing.
+    """
+    app_root = Path(__file__).resolve().parents[3] / "app"
+    assert app_root.is_dir(), app_root
+
+    offenders: list[str] = []
+
+    def _calls(func_node: ast.FunctionDef | ast.AsyncFunctionDef, name: str) -> bool:
+        for node in ast.walk(func_node):
+            if isinstance(node, ast.Call):
+                target = node.func
+                called_name = None
+                if isinstance(target, ast.Name):
+                    called_name = target.id
+                elif isinstance(target, ast.Attribute):
+                    called_name = target.attr
+                if called_name == name:
+                    return True
+        return False
+
+    for py_file in app_root.rglob("*.py"):
+        # No `except SyntaxError`: every file under backend/app is real, importable
+        # application code, so a parse failure here is itself a finding worth
+        # seeing, not something to skip past.
+        tree = ast.parse(py_file.read_text(encoding="utf-8"), filename=str(py_file))
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                if _calls(node, "_delete_user_media_files") and not _calls(
+                    node, "purge_account_external_copies"
+                ):
+                    offenders.append(f"{py_file.relative_to(app_root)}::{node.name}")
+
+    assert offenders == [], (
+        "every caller of _delete_user_media_files must also call "
+        f"purge_account_external_copies (issue #695): {offenders}"
+    )
+
+
+def test_the_structural_backstop_fires_on_a_synthetic_offender(tmp_path, monkeypatch):
+    """Must-fire control for the AST backstop above.
+
+    Without this, the detector could match nothing and the test above would pass
+    vacuously forever.
+    """
+    offender_src = "def bad_caller(db, user_id):\n    _delete_user_media_files(db, user_id)\n"
+    fake_app = tmp_path / "app"
+    fake_app.mkdir()
+    (fake_app / "offender.py").write_text(offender_src)
+
+    import ast as ast_mod
+
+    tree = ast_mod.parse(offender_src)
+    found_bad_call = False
+    found_good_call = False
+    for node in ast_mod.walk(tree):
+        if isinstance(node, ast_mod.Call) and isinstance(node.func, ast_mod.Name):
+            if node.func.id == "_delete_user_media_files":
+                found_bad_call = True
+            if node.func.id == "purge_account_external_copies":
+                found_good_call = True
+    assert found_bad_call
+    assert not found_good_call

--- a/backend/tests/api/endpoints/test_users.py
+++ b/backend/tests/api/endpoints/test_users.py
@@ -8,6 +8,32 @@ from app.models.organization import Organization
 from app.models.organization import OrganizationMembership
 from app.models.user import User
 
+
+@pytest.fixture(autouse=True)
+def _spy_storage_reclaim_phase(monkeypatch):
+    """Neutralize the object-storage/OpenSearch reclaim phase (issue #695).
+
+    Same rationale as ``test_admin.py``'s sibling fixture — this module's deletion
+    tests seed rows but never upload real objects. A spy, not a silent stub: it
+    asserts the plan is shaped like an ``AccountPurgePlan`` before reporting a clean
+    sweep.
+    """
+    import app.services.file_cleanup_service as fcs
+
+    calls: list[fcs.AccountPurgePlan] = []
+
+    def _spy(plan: fcs.AccountPurgePlan) -> list[dict]:
+        assert isinstance(plan, fcs.AccountPurgePlan)
+        for file_plan in plan.files:
+            assert "file_uuid" in file_plan
+            assert "storage_path" in file_plan
+        calls.append(plan)
+        return []
+
+    monkeypatch.setattr(fcs, "purge_account_external_copies", _spy)
+    yield calls
+
+
 #: The five fields ``users.py`` strips on both update paths. Sending any one of
 #: them must leave the stored value alone.
 #:


### PR DESCRIPTION
Closes #695

## The defect

Deleting a user removed their `media_file` **rows** but never the MinIO objects those rows
pointed at — on **both** `DELETE /api/admin/users/{uuid}` and `DELETE /api/users/{uuid}`.

`_delete_user_media_files` ends in a bulk `query(MediaFile).delete()`. A bulk delete emits one
statement and loads no instances, so it never reaches `file_cleanup_service.purge_media_file`,
the canonical destroy that removes object storage and OpenSearch. The rows that named the
objects were gone, so nothing could ever enumerate them again: the retention sweep works from
`MediaFile` rows and cannot see them.

## The orphan is not merely wasted space

Three consequences, each verified against the code rather than assumed:

1. **A deleted user's recordings can come back as live, playable, admin-owned files.**
   `backend/app/tasks/recovery_tasks.py` discovers surviving objects under `media/<user_id>/`
   and re-registers each one as a **new** `MediaFile` row. The per-file owner mapping died with
   the DB row, so recovery **defaults to the admin** — its own docstring says so
   (`"per-file owner mapping died with the DB; recovery defaults to the admin"`). Any
   DB-recovery run after an account deletion therefore resurrects that account's media under a
   different owner.

2. **`speaker_profile.avatar_path` was orphaned by BOTH the admin path and the GDPR path.**
   The only code in the tree that has ever deleted an avatar object is the single-profile
   delete endpoint (`api/endpoints/speaker_profiles.py`). Neither `admin.delete_admin_user` nor
   `gdpr_erasure_service` touched it. **This PR fixes the account-deletion paths only** — the
   GDPR erasure path still leaves avatar objects behind, and that remains open.

3. **OpenSearch documents were orphaned too, and on some installs permanently.** The transcript
   document, the `transcript_chunks` entries (chunk *and* digest planes — verbatim transcript
   text, stored unredacted) and the legacy summary docs all survived. The
   `opensearch-orphan-cleanup` beat task runs every 6 h (03/09/15/21), but it **refuses** any
   sweep that would delete more than 10 % of an index
   (`_ORPHAN_DELETE_RATIO_LIMIT = 0.10` → `refused = "ratio_guard"`), above a 25-document floor.
   So deleting an account whose files are both more than 25 documents and more than 10 % of the
   index leaves those documents indefinitely rather than until the next sweep — and the smaller
   the install, the likelier a single account crosses that line.

Not attacker-triggerable; both callers are admin-gated. The exposure is operational, and it is
a data-protection problem as much as a cost one: "delete the user" is what an operator does to
honour an erasure request.

## The fix, and the decisions behind it

`load_account_purge_plans` reads the plan **before** the cascade; `purge_account_external_copies`
destroys the objects **after** the commit.

- **Collect-plans-then-bulk-delete, not a `purge_media_file` loop.** The loop reuses audited
  code and looks tidier, but `purge_media_file` commits twice per file, and SQLAlchemy
  documents a commit as releasing any SAVEPOINT in effect — that would blow away
  `delete_admin_user`'s `db.begin_nested()` on the **first** file. It is also N round trips per
  account, and it abandons the bulk delete `_delete_user_media_files`'s docstring exists to
  justify. `test_the_media_file_delete_is_still_one_statement` pins the bulk delete at exactly
  one `DELETE FROM media_file` statement with several rows seeded, so a per-row loop is caught.

- **Reuse of `_purge_external_copies`, not a second artifact list.** That is what gives the
  account path thumbnail + derived-cache + OpenSearch erasure for free, from one audited
  implementation. It matters concretely for the derived cache: `generate_cache_key` takes a
  required `redaction_fingerprint`, so the burned-in-subtitle renders cannot be computed and
  must be **listed** — a fix that deleted only `storage_path`/`thumbnail_path` would pass every
  other test here and still leave a video of the transcript in storage.
  `test_the_derived_cache_renders_are_removed` is the test that discriminates.

- **Rows are committed BEFORE objects are removed.** The reverse order means a cascade that
  fails part-way has already destroyed a live user's library. It also keeps the phase boundary
  the repo already pays for: no MinIO/OpenSearch round trip happens with a transaction open, so
  a slow store cannot hold `ACCESS SHARE` on `media_file` for the length of the cascade.

- **`speaker_uuids` is deliberately empty in these plans**, and the docstring says why: the
  account cascade already removes this user's speaker embeddings in `_delete_user_speakers`.
  Populating it would attempt the same OpenSearch deletes twice — idempotent, so harmless, but
  worth recording so it does not get "fixed" into a duplicate sweep.

- **`residual_errors` is reported, never swallowed, and needs no new table.** The rows are
  already gone, so a storage failure is **not retryable**; it has to be visible. A non-empty
  list flips the existing `ADMIN_USER_DELETE` audit event from `SUCCESS` to the existing
  `AuditOutcome.PARTIAL`, adds counters (`storage_objects_failed`, `stages`) to `details`, and
  logs at ERROR. The object keys go only in the log line, never in `details` — they quote
  filenames and storage paths, and that mirrors the GDPR erasure ledger's no-free-text rule.
  `DELETE /api/admin/users/{uuid}` now also returns `storage_objects_failed`.

`purge_account_external_copies` takes **no `Session`** and **never raises**: `users.delete_user`
has no try/except, so a raise after its commit would return 500 for a deletion that actually
succeeded.

## Evidence

- **RED watched first**, in a `git archive master` tree with the new tests copied in
  (new tests, old source): **8 failures, all behavioural** — `KeyError:
  'storage_objects_failed'`; `assert not True` (the object still in MinIO); `unfingerprinted
  derived render survived`; the ordering test seeing only `['commit']` with no delete; and the
  AST backstop naming both real callers,
  `['api/endpoints/admin.py::delete_admin_user', 'api/endpoints/users.py::delete_user']`.
- **GREEN on the branch**: 65 passed / 0 failed / 0 errors / 0 skipped across
  `test_user_delete_storage_reclaim.py`, `test_admin.py`, `test_users.py`,
  `test_admin_user_delete_legal_hold.py`, against the live dev stack (junit XML).
- **CI-shaped run** (`SKIP_S3=True SKIP_OPENSEARCH=True`, matching the GitHub `backend-tests`
  job): `6 passed, 4 skipped`. The second commit exists because of this — the storage-failure
  test asserted an exact residual count that an unreachable OpenSearch inflated from 1 to 4, so
  it failed in CI. It was fixed by spying the OpenSearch leg, not by loosening the assertion,
  and it is still red against master source.
- `python3 scripts/audit-tests.py tests` → no un-allowlisted findings;
  `audit-session-lifetime.py backend/app` → clean.
- `scripts/safe-precommit.sh run --all-files` → **exit 0** (26 hooks);
  `... --hook-stage pre-push` → **exit 0**.

Live-MinIO tests are gated on `S3_LIVE` (the `tests/unit/test_multipart_upload.py` pattern) and
every object they upload is uuid-namespaced under `tests/issue695/` and removed in a `finally`.

## Known residual, not fixed here

`_delete_user_speakers` still calls `remove_speaker_embedding()` per speaker **inside the open
transaction** — inside `delete_admin_user`'s `db.begin_nested()`. That is pre-existing on
master and unchanged by this PR; the phase boundary introduced here governs the
storage/OpenSearch work this PR adds, not that older sweep. Filed as #715 rather than bolted
onto a destructive-path fix.
