### PR TITLE
chore(speakers): delete dead SimilarityService.batch_cosine_similarity

### DIFF
--- a/backend/app/services/similarity_service.py
+++ b/backend/app/services/similarity_service.py
@@ -70,57 +70,6 @@ class SimilarityService:
         return float(max(-1.0, min(1.0, similarity)))
 
     @staticmethod
-    def batch_cosine_similarity(
-        query_embedding: np.ndarray | torch.Tensor,
-        target_embeddings: list[np.ndarray | torch.Tensor],
-    ) -> list[float]:
-        """
-        GPU-accelerated batch cosine similarity using PyTorch.
-
-        Processes all comparisons in parallel using vectorized tensor operations.
-
-        Args:
-            query_embedding: Single query embedding
-            target_embeddings: List of target embeddings to compare against
-
-        Returns:
-            List of cosine similarities in ``[-1, 1]``, in the same order as
-            ``target_embeddings``. Same space as :meth:`cosine_similarity`.
-        """
-        if not target_embeddings:
-            return []
-
-        # Convert all inputs to torch tensors
-        if isinstance(query_embedding, np.ndarray):
-            query_tensor = torch.from_numpy(query_embedding).float()
-        else:
-            query_tensor = query_embedding.float()
-
-        target_tensors = []
-        for target in target_embeddings:
-            if isinstance(target, np.ndarray):
-                target_tensors.append(torch.from_numpy(target).float())
-            else:
-                target_tensors.append(target.float())
-
-        # Stack targets into a single tensor and move to device
-        targets_matrix = torch.stack(target_tensors).to(SimilarityService.device)
-        query_tensor = query_tensor.to(SimilarityService.device)
-
-        # Compute all similarities at once using PyTorch's vectorized operations
-        similarities = nn_functional.cosine_similarity(
-            query_tensor.unsqueeze(0).expand(targets_matrix.size(0), -1), targets_matrix, dim=1
-        )
-
-        # Convert to Python floats, bounded to cosine's real domain (issue #690).
-        result = []
-        for sim in similarities:
-            score = float(sim.item())
-            result.append(max(-1.0, min(1.0, score)))
-
-        return result
-
-    @staticmethod
     def opensearch_similarity_search(
         embedding: list[float] | np.ndarray | torch.Tensor,
         user_id: int,

--- a/backend/tests/unit/test_similarity_service_cosine_range.py
+++ b/backend/tests/unit/test_similarity_service_cosine_range.py
@@ -1,6 +1,6 @@
 """``SimilarityService`` must report one cosine space from every method (issue #690).
 
-Cosine lives in ``[-1, 1]``. ``cosine_similarity`` and ``batch_cosine_similarity``
+Cosine lives in ``[-1, 1]``. ``cosine_similarity``
 used to clamp to ``[0, 1]`` while ``opensearch_similarity_search`` — a method on the
 *same class* — returned the unclamped ``(2 * score) - 1`` conversion. Two callers of
 one class therefore got different ranges for the same quantity, and every negative
@@ -97,29 +97,6 @@ def test_cosine_similarity_preserves_a_negative_cosine(label, other, expected):
 
     assert result == pytest.approx(expected, abs=1e-6), label
     assert result < 0.0, f"{label}: the negative half of the cosine domain was clamped away"
-
-
-def test_batch_cosine_similarity_preserves_negative_cosines():
-    """The batch path clamped identically and must move with its sibling."""
-    targets = [np.array(other, dtype=np.float64) for _, other, _ in COSINE_PAIRS]
-
-    results = SimilarityService.batch_cosine_similarity(UNIT_X, targets)
-
-    assert len(results) == len(COSINE_PAIRS)
-    assert results == [pytest.approx(expected, abs=1e-6) for _, _, expected in COSINE_PAIRS]
-    assert results[0] < 0.0, "cosine -1.0 came back non-negative"
-    assert results[1] < 0.0, "cosine -0.6 came back non-negative"
-
-
-def test_the_two_in_process_methods_report_the_same_value():
-    """One class, one space: the scalar and batch paths must not diverge."""
-    targets = [np.array(other, dtype=np.float64) for _, other, _ in COSINE_PAIRS]
-
-    batched = SimilarityService.batch_cosine_similarity(UNIT_X, targets)
-    scalar = [SimilarityService.cosine_similarity(UNIT_X, target) for target in targets]
-
-    assert len(scalar) == len(COSINE_PAIRS)
-    assert batched == [pytest.approx(value, abs=1e-6) for value in scalar]
 
 
 def test_the_clamp_still_bounds_float_rounding_to_the_cosine_domain():


### PR DESCRIPTION
Deletes `SimilarityService.batch_cosine_similarity`, which has no production caller.

## The premise was verified before deleting anything

This repo has a history of issues whose stated premises were wrong, so "no production caller" was proven rather than assumed — across all the routes a plain grep misses:

- Direct references: only the definition (`similarity_service.py:73`) and its own tests.
- **String dispatch**: no `getattr(obj, "batch_cosine_similarity")` or registry/dict lookup anywhere.
- **`__all__` / re-exports**: absent from both `similarity_service.py` and `app/services/__init__.py`.
- **Caller survey**: every real consumer of `SimilarityService` (`speaker_matching_service.py`, `speaker_update.py`, and tests) calls only `opensearch_similarity_search` or `cosine_similarity`.
- `backend/tests/audit-allowlist.txt` holds no entry keyed to the deleted tests — a stale entry would have failed the audit gate.

## What was removed

- The `batch_cosine_similarity` static method. No helpers were orphaned by it — it used only shared class state and imports still in use.
- Its two batch-only tests, plus the docstring reference.

**Coverage is not lost.** `test_the_torch_path_and_the_opensearch_path_agree_on_one_vector_pair` is kept: it independently asserts the torch-vs-OpenSearch cosine agreement invariant through `cosine_similarity`, which is the property that actually matters given this repo's `cosinesimil` conversion trap.

## Gates

- `audit-tests.py tests` → 0 open findings
- `audit-route-coverage.py` → no regression
- `pytest tests/ -k "similarity or speaker"` → **1127 passed**, 9 skipped, 15 xfailed, 0 failed
- Pre-commit (ruff, mypy, bandit, import-linter, audit-tests, session-lifetime audit, conventional-commit) all passed

Closes #702