### PR TITLE
fix(search): label semantic_confidence only on the path its threshold was tuned for

### DIFF
--- a/backend/app/services/search/hybrid_search_service.py
+++ b/backend/app/services/search/hybrid_search_service.py
@@ -2383,7 +2383,7 @@ class HybridSearchService:
             logger.warning(f"BM25 group backfill failed for query='{query}': {e}")
             return grouped
 
-        bm25_grouped, _ = self._process_collapsed_results(bm25_response, query)
+        bm25_grouped, _ = self._process_collapsed_results(bm25_response, query, is_fused_rrf=False)
         seen = {hit.file_uuid for hit in grouped}
         new_hits = [hit for hit in bm25_grouped if hit.file_uuid not in seen]
         if not new_hits:
@@ -2404,6 +2404,7 @@ class HybridSearchService:
         self,
         response: dict[str, Any],
         query: str,
+        is_fused_rrf: bool = False,
     ) -> tuple[list[SearchHit], int]:
         """Process collapsed OpenSearch response into SearchHit objects.
 
@@ -2413,6 +2414,14 @@ class HybridSearchService:
         Args:
             response: OpenSearch response with collapse + inner_hits.
             query: Original search query for highlight classification.
+            is_fused_rrf: Whether `response` came from the fused hybrid RRF
+                query (`_build_collapsed_search_body`'s `hybrid` body, with a
+                search pipeline attached). `SEARCH_SEMANTIC_HIGH_CONFIDENCE`
+                was tuned against RRF scores (~0.016 at rank 1); on any other
+                path (plain BM25, or the `_bm25_leg_is_starved` raw-cosinesimil
+                arm) that same threshold reads "high" for nearly every result
+                (issue #698). Confidence is only labelled when this is True —
+                everywhere else `semantic_confidence` stays "".
 
         Returns:
             Tuple of (list of SearchHit, estimated total_files).
@@ -2475,8 +2484,9 @@ class HybridSearchService:
             if is_semantic_only:
                 if "semantic" not in match_sources:
                     match_sources.append("semantic")
-                threshold = settings.SEARCH_SEMANTIC_HIGH_CONFIDENCE
-                semantic_confidence = "high" if best_score >= threshold else "low"
+                if is_fused_rrf:
+                    threshold = settings.SEARCH_SEMANTIC_HIGH_CONFIDENCE
+                    semantic_confidence = "high" if best_score >= threshold else "low"
 
             # Detect metadata speaker match
             if query_lower:
@@ -2636,23 +2646,15 @@ class HybridSearchService:
         file_uuid = bucket["key"]
         title = meta["title"]
 
-        if p2 and p2["occurrences"]:
-            occurrences = p2["occurrences"]
-            title_highlighted = p2["title_highlighted"] or title
-            match_sources: list[str] = list(p2["match_sources"])
-            keyword_count: int = p2["keyword_count"]
-            semantic_count: int = p2["semantic_count"]
-            best_score: float = p2["best_score"]
-        else:
-            occurrences = []
-            title_highlighted = title
-            match_sources = ["semantic"]
-            keyword_count = 0
-            semantic_count = 1
-            best_score = 0.5
-
-        if not occurrences:
+        if not p2 or not p2["occurrences"]:
             return None
+
+        occurrences = p2["occurrences"]
+        title_highlighted = p2["title_highlighted"] or title
+        match_sources: list[str] = list(p2["match_sources"])
+        keyword_count: int = p2["keyword_count"]
+        semantic_count: int = p2["semantic_count"]
+        best_score: float = p2["best_score"]
 
         speakers: list[str] = meta["speakers"]
         if query_lower:
@@ -2664,12 +2666,13 @@ class HybridSearchService:
                     break
 
         is_semantic_only = keyword_count == 0
+        # No confidence badge on this path: Phase 2 scores are raw BM25
+        # (unbounded, ~1-30), not the RRF score `SEARCH_SEMANTIC_HIGH_CONFIDENCE`
+        # was tuned against. Labelling here would read "high" for nearly every
+        # result — see issue #698. An absent badge beats a meaningless one.
         semantic_confidence = ""
-        if is_semantic_only:
-            if "semantic" not in match_sources:
-                match_sources.append("semantic")
-            threshold = settings.SEARCH_SEMANTIC_HIGH_CONFIDENCE
-            semantic_confidence = "high" if best_score >= threshold else "low"
+        if is_semantic_only and "semantic" not in match_sources:
+            match_sources.append("semantic")
 
         has_both = keyword_count > 0 and semantic_count > 0
         total_occurrences = max(len(occurrences), keyword_count + semantic_count)
@@ -3159,9 +3162,17 @@ class HybridSearchService:
         if response is None:
             return self._empty_response(query, page, page_size)
 
-        # Process collapsed results
+        # Process collapsed results. `needs_search_pipeline` is True only for
+        # the fused `hybrid` body (an RRF search pipeline was attached); the
+        # `_bm25_leg_is_starved` arm returns a neural-only body with no
+        # pipeline (raw cosinesimil scores), and a retry fallback to BM25
+        # after a hybrid failure produces plain BM25 scores despite
+        # `needs_search_pipeline` having been True for the original attempt.
         t_process = time.time()
-        grouped, total_files_est = self._process_collapsed_results(response, query)
+        is_fused_rrf = needs_search_pipeline and not fell_back_to_bm25
+        grouped, total_files_est = self._process_collapsed_results(
+            response, query, is_fused_rrf=is_fused_rrf
+        )
         process_ms = round((time.time() - t_process) * 1000)
 
         # Group-starvation backfill: with hybrid+RRF, collapse can only return

--- a/backend/tests/unit/test_semantic_confidence_score_spaces_698.py
+++ b/backend/tests/unit/test_semantic_confidence_score_spaces_698.py
@@ -1,0 +1,285 @@
+"""Issue #698: ``semantic_confidence`` must not compare three score spaces to one threshold.
+
+``SEARCH_SEMANTIC_HIGH_CONFIDENCE`` (0.010) was compared against ``best_score`` on THREE paths
+that put wildly different numbers in that field:
+
+| path | score space | typical magnitude |
+|---|---|---|
+| fused hybrid (RRF) | rank-fusion score | ~0.016 at rank 1 — what the threshold was tuned for |
+| ``_bm25_leg_is_starved`` arm | raw ``cosinesimil`` | [0, 1], 0.5 = orthogonal |
+| Phase 2 (``_build_search_hit_from_bucket``) | raw BM25 | ~1-30 |
+
+**Chosen fix: option 2** — label confidence only on the fused RRF path (the one the threshold
+was tuned for); omit the badge everywhere else. An absent badge beats a meaningless "high" one.
+
+Each test below pins one path in isolation, per the issue's acceptance criteria: a single test
+proves nothing, because the old shape passed trivially on two of three paths.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import app.services.search.hybrid_search_service as hss
+from app.core.config import settings
+from app.services.search.hybrid_search_service import HybridSearchService
+
+SETTING_NAME = "SEARCH_SEMANTIC_HIGH_CONFIDENCE"
+
+
+def _collapsed_response(score: float) -> dict:
+    """A one-file collapsed response whose single inner hit is semantic-only.
+
+    No ``highlight`` on the inner hit and an empty query mean ``_process_inner_hits`` records
+    ``keyword_count == 0`` — the ``is_semantic_only`` branch under test — regardless of which
+    OpenSearch body actually produced the score.
+    """
+    return {
+        "hits": {
+            "hits": [
+                {
+                    "_score": score,
+                    "_source": {
+                        "file_uuid": "file-under-test",
+                        "file_id": 1,
+                        "title": "Quarterly planning",
+                        "speakers": [],
+                        "tags": [],
+                        "language": "en",
+                        "content_type": "audio/wav",
+                    },
+                    "inner_hits": {
+                        "segments": {
+                            "hits": {
+                                "total": {"value": 1},
+                                "hits": [
+                                    {
+                                        "_score": score,
+                                        "_source": {
+                                            "content": "we should revisit the roadmap",
+                                            "speaker": "SPEAKER_00",
+                                            "start_time": 0.0,
+                                            "end_time": 3.0,
+                                            "chunk_index": 0,
+                                        },
+                                    }
+                                ],
+                            }
+                        }
+                    },
+                }
+            ]
+        }
+    }
+
+
+class _CountingClient:
+    """Fake OpenSearch client whose `.count()` answer drives `_bm25_leg_is_starved`."""
+
+    def __init__(self, count: int) -> None:
+        self._count = count
+        self.count_calls: list[dict] = []
+
+    def count(self, index: str, body: dict) -> dict:
+        self.count_calls.append({"index": index, "body": body})
+        return {"count": self._count}
+
+
+@pytest.fixture(autouse=True)
+def _fixed_threshold(monkeypatch):
+    """Pin the setting so these tests don't depend on the coded default."""
+    monkeypatch.setattr(settings, SETTING_NAME, 0.010)
+
+
+def test_fused_rrf_path_labels_confidence_and_a_genuinely_high_score_reads_high():
+    """CONTROL: the path the threshold was tuned for still works.
+
+    A fused hybrid RRF hit with a score above threshold must still report "high" — the fix must
+    not be indistinguishable from "always low".
+    """
+    hits, _ = HybridSearchService()._process_collapsed_results(
+        _collapsed_response(0.02), "", is_fused_rrf=True
+    )
+    assert len(hits) == 1
+    assert hits[0].semantic_confidence == "high"
+
+
+def test_fused_rrf_path_reports_low_below_threshold():
+    hits, _ = HybridSearchService()._process_collapsed_results(
+        _collapsed_response(0.005), "", is_fused_rrf=True
+    )
+    assert len(hits) == 1
+    assert hits[0].semantic_confidence == "low"
+
+
+def test_starved_bm25_arm_is_reachable_and_never_labels_confidence(monkeypatch):
+    """The `_bm25_leg_is_starved` arm is genuinely reached, not simulated.
+
+    Drives `_build_collapsed_search_body` with a real (faked) OpenSearch client whose `.count()`
+    reports zero keyword matches — the exact condition `_bm25_leg_is_starved` checks — and
+    confirms the body it returns carries no fusion pipeline (`needs_pipeline is False`), which is
+    the production signal `_search_with_collapse` uses to compute `is_fused_rrf`. A raw
+    `cosinesimil` score of 0.5 (orthogonal — the worst possible match) is then fed through
+    `_process_collapsed_results` with that same signal, and must NOT read "high": before the
+    fix, 0.5 >= 0.010 always did.
+    """
+    svc = HybridSearchService()
+    starved_client = _CountingClient(count=0)
+    monkeypatch.setattr(hss, "get_opensearch_client", lambda: starved_client)
+    monkeypatch.setattr(svc, "_get_neural_model_id", lambda: "fake-model-id")
+
+    body, needs_pipeline = svc._build_collapsed_search_body(
+        "space exploration",
+        filters=[],
+        page=1,
+        page_size=20,
+        has_speaker_filter=False,
+        use_neural=True,
+        sort_by="relevance",
+        sort_order="desc",
+    )
+
+    # The starvation check really ran, and really found zero keyword matches.
+    assert starved_client.count_calls, "the starvation pre-check (`.count()`) was never called"
+    assert needs_pipeline is False, (
+        "a starved keyword leg must route to the neural-only body with no fusion pipeline"
+    )
+    assert "hybrid" not in body["query"], "starved body must not be a fused hybrid query"
+
+    # Orthogonal cosinesimil score: the worst possible match, and >= the 0.010 threshold, which
+    # is exactly the shape that used to read "high" for essentially every unfused semantic hit.
+    hits, _ = svc._process_collapsed_results(
+        _collapsed_response(0.5), "space exploration", is_fused_rrf=needs_pipeline
+    )
+    assert len(hits) == 1
+    assert hits[0].semantic_confidence == "", (
+        "the raw-cosinesimil starved arm must never label confidence — score space is not RRF"
+    )
+
+
+def test_starved_bm25_arm_high_raw_cosine_still_unlabeled(monkeypatch):
+    """Even a strong raw-cosine match (0.9, i.e. a real cosine of 0.8) gets no badge here.
+
+    A cosinesimil score of 0.9 is a genuinely good semantic match, but it lives in [0, 1] space,
+    not RRF space, so labelling it against the RRF-tuned threshold is still meaningless — the
+    fix withholds the badge on this path unconditionally, not merely at the orthogonal boundary.
+    """
+    svc = HybridSearchService()
+    starved_client = _CountingClient(count=0)
+    monkeypatch.setattr(hss, "get_opensearch_client", lambda: starved_client)
+    monkeypatch.setattr(svc, "_get_neural_model_id", lambda: "fake-model-id")
+
+    _, needs_pipeline = svc._build_collapsed_search_body(
+        "artificial intelligence",
+        filters=[],
+        page=1,
+        page_size=20,
+        has_speaker_filter=False,
+        use_neural=True,
+        sort_by="relevance",
+        sort_order="desc",
+    )
+    assert needs_pipeline is False
+
+    hits, _ = svc._process_collapsed_results(
+        _collapsed_response(0.9), "artificial intelligence", is_fused_rrf=needs_pipeline
+    )
+    assert hits[0].semantic_confidence == ""
+
+
+def test_phase2_bm25_path_never_labels_confidence_even_at_a_typical_bm25_score():
+    """Phase 2 (`_build_search_hit_from_bucket`) is pure BM25 — scores ~1-30, not RRF's ~0-0.065.
+
+    A typical BM25 score of 12.0 would have read "high" against the old 0.010 threshold on
+    almost every semantic-only Phase-2 result. The fix is that this path never reads the
+    threshold at all.
+    """
+    bucket = {
+        "key": "file-under-test",
+        "title_kw": {"buckets": [{"key": "Quarterly planning"}]},
+        "language_kw": {"buckets": [{"key": "en"}]},
+        "content_type_kw": {"buckets": [{"key": "audio/wav"}]},
+        "speakers_kw": {"buckets": []},
+        "tags_kw": {"buckets": []},
+        "max_duration": {"value": 60.0},
+        "max_file_size": {"value": 1024},
+        "max_upload_time": {"value_as_string": "2026-01-01T00:00:00Z"},
+        "min_file_id": {"value": 1},
+    }
+    phase2 = {
+        "occurrences": [object()],
+        "title_highlighted": "",
+        "match_sources": [],
+        "keyword_count": 0,
+        "semantic_count": 1,
+        "best_score": 12.0,
+    }
+    hit = HybridSearchService()._build_search_hit_from_bucket(bucket, phase2, "")
+    assert hit is not None
+    assert hit.semantic_confidence == ""
+
+
+def test_phase2_no_p2_lookup_entry_returns_none_not_a_fabricated_hit():
+    """Dead-code removal (#698): the old `best_score = 0.5` branch is gone.
+
+    With no Phase 2 lookup entry for the file, the function must return None rather than
+    constructing a `SearchHit` from fabricated defaults (`occurrences=[]`, `best_score=0.5`) that
+    the very next line then always discarded (`if not occurrences: return None`) — proving the
+    assignment was unreachable.
+    """
+    bucket = {
+        "key": "file-under-test",
+        "title_kw": {"buckets": [{"key": "Quarterly planning"}]},
+        "language_kw": {"buckets": []},
+        "content_type_kw": {"buckets": []},
+        "speakers_kw": {"buckets": []},
+        "tags_kw": {"buckets": []},
+        "max_duration": {"value": 0.0},
+        "max_file_size": {"value": 0},
+        "max_upload_time": {"value_as_string": ""},
+        "min_file_id": {"value": 1},
+    }
+    assert HybridSearchService()._build_search_hit_from_bucket(bucket, None, "") is None
+
+
+def test_dead_best_score_literal_is_gone_from_source():
+    """Source-level guard: `best_score = 0.5` must not reappear in the bucket builder.
+
+    A behavioural test alone cannot see a dead default reintroduced under a reachable-looking
+    guard; this pins the exact literal the issue names as dead code.
+    """
+    import inspect
+
+    src = inspect.getsource(HybridSearchService._build_search_hit_from_bucket)
+    assert "0.5" not in src, (
+        "the dead `best_score = 0.5` fallback (issue #698) must not be reintroduced"
+    )
+
+
+def test_backfill_starved_groups_never_labels_confidence(monkeypatch):
+    """`_backfill_starved_groups` always queries plain BM25 — must pass `is_fused_rrf=False`.
+
+    Regression guard for the second `_process_collapsed_results` call site: a future edit that
+    drops the explicit `is_fused_rrf=False` would silently default to `True` if the parameter's
+    default ever changed, mislabeling backfilled BM25 hits.
+    """
+    svc = HybridSearchService()
+
+    class _FakeClient:
+        def search(self, index: str, body: dict) -> dict:
+            return _collapsed_response(15.0)
+
+    grouped = svc._backfill_starved_groups(
+        client=_FakeClient(),
+        grouped=[],
+        search_query="widgets",
+        filters=[],
+        page=1,
+        page_size=20,
+        has_speaker_filter=False,
+        sort_by="relevance",
+        sort_order="desc",
+        query="widgets",
+    )
+    assert len(grouped) == 1
+    assert grouped[0].semantic_confidence == ""

--- a/backend/tests/unit/test_semantic_confidence_threshold.py
+++ b/backend/tests/unit/test_semantic_confidence_threshold.py
@@ -1,22 +1,21 @@
 """``SEARCH_SEMANTIC_HIGH_CONFIDENCE`` has exactly one value, read from ``settings``.
 
-Two call sites in ``hybrid_search_service`` decide ``SearchHit.semantic_confidence``
-(``"high"`` / ``"low"``) for a semantic-only file:
+As of issue #698, only ONE call site in ``hybrid_search_service`` may decide
+``SearchHit.semantic_confidence`` from this threshold: ``_process_collapsed_results``, and only
+on the fused hybrid-RRF path (``is_fused_rrf=True``). ``SEARCH_SEMANTIC_HIGH_CONFIDENCE`` was
+tuned against RRF scores (~0.016 at rank 1); comparing it against a raw ``cosinesimil`` score
+(``_bm25_leg_is_starved`` arm, [0, 1], 0.5 = orthogonal) or a raw BM25 score
+(``_build_search_hit_from_bucket``, Phase 2, ~1-30) reads "high" for nearly every result — see
+issue #698. ``_build_search_hit_from_bucket`` therefore no longer reads the setting at all; it
+never labels confidence (``semantic_confidence`` stays ``""``), which is honest for a BM25-space
+score.
 
-* ``_process_collapsed_results``   — the single-phase collapse path
-* ``_build_search_hit_from_bucket`` — the two-phase (non-relevance sort) path
-
-Both read the setting, and both used to read it through ``getattr(settings, ...)`` with a
-**divergent** inline fallback: ``0.015`` at the first site, ``0.010`` at the second. Because
-``SEARCH_SEMANTIC_HIGH_CONFIDENCE`` is a declared field on the ``BaseSettings`` subclass it can
-never be absent, so *both* fallbacks were unreachable and the effective threshold was ``0.010``
-at both sites. The code nonetheless read as if two different thresholds were in play, and the
-next reader to "honour" the 0.015 would have changed live ranking behaviour by accident.
-
-The guard below is source-level on purpose: a behavioural test cannot see a dead default, so
-it cannot fail when one is reintroduced. ``test_no_call_site_supplies_an_inline_default`` is the
-red-before/green-after assertion; the behavioural pair beside it pins that both sites actually
-track ``settings`` rather than a literal of their own.
+This file previously pinned the earlier, source-level "the setting has one dead-code-free value,
+read identically at both sites" invariant from PR #697/#698's prerequisite. That invariant is
+superseded: there is now deliberately only one reader, and the two paths deliberately no longer
+agree (one labels, one never does). ``test_no_call_site_supplies_an_inline_default`` remains —
+still true, still worth guarding — and per-score-space behaviour is covered in
+``test_semantic_confidence_score_spaces_698.py``.
 
 Pattern follows ``tests/api/test_file_mutation_permissions.py``'s ``MUTATING_ENDPOINTS``
 anti-drift guard — AST, not grep, so a mention in a docstring or comment cannot satisfy it.
@@ -38,11 +37,10 @@ SETTING_NAME = "SEARCH_SEMANTIC_HIGH_CONFIDENCE"
 APP_DIR = pathlib.Path(__file__).resolve().parents[2] / "app"
 SERVICE_PATH = APP_DIR / "services" / "search" / "hybrid_search_service.py"
 
-# The two functions that classify a semantic-only hit's confidence. Both must read the
-# setting, and neither may carry a default of its own.
+# The one function permitted to read the setting (#698: `_build_search_hit_from_bucket`'s
+# Phase 2 scores are raw BM25, not RRF, so it must never read this threshold at all).
 EXPECTED_READER_FUNCTIONS = {
     "_process_collapsed_results",
-    "_build_search_hit_from_bucket",
 }
 
 
@@ -216,8 +214,10 @@ def _bucket_and_phase2(score: float) -> tuple[dict, dict]:
     return bucket, phase2
 
 
-def _confidence_from_collapsed_path(score: float) -> str:
-    hits, _ = HybridSearchService()._process_collapsed_results(_collapsed_response(score), "")
+def _confidence_from_collapsed_path(score: float, *, is_fused_rrf: bool = True) -> str:
+    hits, _ = HybridSearchService()._process_collapsed_results(
+        _collapsed_response(score), "", is_fused_rrf=is_fused_rrf
+    )
     assert len(hits) == 1, "fixture should yield exactly one collapsed file group"
     return hits[0].semantic_confidence
 
@@ -230,28 +230,26 @@ def _confidence_from_two_phase_path(score: float) -> str:
 
 
 @pytest.mark.parametrize("threshold", [0.010, 0.25])
-def test_both_paths_switch_at_the_same_configured_threshold(monkeypatch, threshold):
-    """Both classification paths must move together when the single setting moves.
+def test_the_fused_path_switches_at_the_configured_threshold(monkeypatch, threshold):
+    """The one remaining classifier moves when the single setting moves.
 
-    Probed just below, exactly at, and just above the configured value. A site carrying its own
-    literal instead of the setting disagrees with the other at the ``0.25`` parametrization.
+    Probed just below, exactly at, and just above the configured value, on the fused-RRF path
+    only (`is_fused_rrf=True`) — the only case this threshold is ever compared against.
     """
     monkeypatch.setattr(settings, SETTING_NAME, threshold)
     below, at, above = threshold - 0.001, threshold, threshold + 0.001
 
     assert _confidence_from_collapsed_path(below) == "low"
-    assert _confidence_from_two_phase_path(below) == "low"
     assert _confidence_from_collapsed_path(at) == "high"
-    assert _confidence_from_two_phase_path(at) == "high"
     assert _confidence_from_collapsed_path(above) == "high"
-    assert _confidence_from_two_phase_path(above) == "high"
 
 
-@pytest.mark.parametrize("score", [0.005, 0.0125, 0.02])
-def test_the_two_paths_agree_on_every_probe_score(score):
-    """The two sites classify identically at the deployed threshold.
+@pytest.mark.parametrize("score", [0.005, 0.0125, 0.02, 999.0])
+def test_the_two_phase_path_never_labels_confidence(score):
+    """`_build_search_hit_from_bucket` (Phase 2, raw BM25 scores) never reads the threshold.
 
-    ``0.0125`` sits between the two former inline defaults (0.010 and 0.015), so this probe is
-    the one that would disagree if a site ever honoured a 0.015 of its own.
+    Any score — including one far outside RRF's ~0-0.065 range — must produce no badge rather
+    than a meaningless "high". This is the issue #698 regression: before the fix this path read
+    "high" for nearly every semantic-only Phase-2 result.
     """
-    assert _confidence_from_collapsed_path(score) == _confidence_from_two_phase_path(score)
+    assert _confidence_from_two_phase_path(score) == ""


### PR DESCRIPTION
## The defect

`SEARCH_SEMANTIC_HIGH_CONFIDENCE` (0.010) was compared against `best_score` at two call sites, but `best_score` arrives from **three different score spaces**:

| path | `_score` is | magnitude | vs 0.010 |
|---|---|---|---|
| hybrid with fusion pipeline | RRF | ~0.016 at rank 1 | plausible — what it was tuned for |
| `_bm25_leg_is_starved` arm | raw `cosinesimil` | `[0,1]`, **0.5 = orthogonal** | everything reads "high" |
| Phase 2 bucket path | BM25 | ~1–30 | everything reads "high" |

Display-only — nothing is mis-ranked — but a badge that always reads "high" carries no information, and users learn to trust it. Reachability is ordinary, not exotic: `search_mode="semantic"` does not exist (400s), so the starved arm fires during **normal hybrid search** whenever the keyword leg matches zero chunk documents.

## Approach: option 2 of the three the issue proposed

Label confidence **only** on the fused RRF path; omit the badge (`""`) elsewhere. An absent badge beats a meaningless one.

Rejected: option 1 (normalise all three spaces) — a bigger, riskier diff for a display-only label, and it would have needed `cosine_space` conversions plus a second tuned BM25 threshold. Option 3 (rank/margin-based confidence) — that is a new metric, not a fix to this one.

- `_process_collapsed_results` gained `is_fused_rrf`; `_search_with_collapse` passes `needs_search_pipeline and not fell_back_to_bm25`, `_backfill_starved_groups` passes `False`.
- `_build_search_hit_from_bucket` no longer reads the threshold at all.
- Removed a genuinely dead `best_score = 0.5` else-branch — `occurrences` was always `[]` there, so an earlier `if not occurrences: return None` made it unreachable.

## Evidence

RED against a `git archive HEAD` tree: **7 of 8 new tests failed** (`assert 'high' == ''` and siblings). The 8th tests unrelated pre-existing behaviour and correctly passed — noted rather than counted as evidence.

GREEN: 17 passed (8 new + 9 in the updated threshold-guard file).
Gates: `audit-tests.py` → 0 findings; `pytest -k "search or confidence"` → 548 passed, 39 skipped, 4 xfailed.

There is one test per score space, so the shape the issue called out — "the current shape passes trivially on two of three" — can no longer recur silently.

Closes #698