### PR TITLE
fix(docker): tag published images by capability, not just architecture

### DIFF
--- a/.claude/skills/docker-build-push/SKILL.md
+++ b/.claude/skills/docker-build-push/SKILL.md
@@ -1,18 +1,80 @@
 ---
 name: docker-build-push
-description: Build and push OpenTranscribe production images (backend/frontend) to Docker Hub, multi-arch via the remote builder. Use when the user says "build the production images", "push to Docker Hub", "publish images", "multi-arch build", or is cutting a release that ships new container images.
+description: Build and push OpenTranscribe production images (backend, lite backend, frontend, docs) to Docker Hub, multi-arch via the remote builder. Use when the user says "build the production images", "push to Docker Hub", "publish images", "multi-arch build", or is cutting a release that ships new container images.
 ---
 
 # Docker build & push (production images)
 
-**Always** use `USE_REMOTE_BUILDER=true` for multi-arch — without it ARM64 falls back to QEMU (2–3 hours vs 15–30 min via the Mac Studio builder).
+**Ask the script what it builds — never assume, and never copy the table into another file:**
 
 ```bash
-USE_REMOTE_BUILDER=true ./scripts/docker-build-push.sh                    # both services
-USE_REMOTE_BUILDER=true ./scripts/docker-build-push.sh backend|frontend   # one service
-USE_REMOTE_BUILDER=true SKIP_SECURITY_SCAN=true ./scripts/docker-build-push.sh backend  # quick iteration
-USE_REMOTE_BUILDER=true ./scripts/docker-build-push.sh auto               # auto-detect changed
-PLATFORMS=linux/amd64 ./scripts/docker-build-push.sh backend              # single-arch (no remote needed)
+./scripts/docker-build-push.sh list-platforms   # component<TAB>capability<TAB>platforms
+./scripts/security-scan.sh list-components      # must be the SAME key set (asserted at runtime)
 ```
 
-Full docs: `scripts/README.md`.
+Current output (re-derive it, do not trust this paste):
+
+```
+backend     cuda        linux/amd64
+blackwell   blackwell   linux/arm64
+docs        multiarch   linux/amd64,linux/arm64
+frontend    multiarch   linux/amd64,linux/arm64
+lite        cpu         linux/amd64,linux/arm64
+```
+
+## Tag grammar (issue #680)
+
+Capability lives in the **repository** — a manifest index cannot span repos — and is **restated
+in the tag**:
+
+- `davidamacey/opentranscribe-backend` (CUDA): leg `vX.Y.Z-cuda-amd64` → index `vX.Y.Z` →
+  `:latest` as a digest-copy of the index. `vX.Y.Z-cuda-arm64` is **reserved and not built**
+  (no aarch64 CUDA torch wheel at the pinned version; `onnxruntime-gpu` has zero aarch64 wheels;
+  diar-native ships no CUDA arm64 sidecar).
+- `davidamacey/opentranscribe-backend-lite` (CPU): legs `vX.Y.Z-cpu-amd64` + `vX.Y.Z-cpu-arm64`
+  → index `vX.Y.Z` → `:latest` digest-copy. **This is the arm64 image** — `opentranscribe.sh`
+  defaults an arm64 host to it.
+- `frontend` / `docs`: no capability legs, one multi-platform build under `vX.Y.Z`.
+- `blackwell`: `vX.Y.Z-blackwell-arm64` + `:blackwell`. Built **only on request**, never by
+  `all`/`auto`, and not published by the release pipeline.
+
+Legs are pushed individually and the index is assembled with `buildx imagetools create`, so the
+index provably contains exactly those legs — that is what `scripts/release/80-publish.sh` then
+verifies (leg has exactly one platform; index platform set matches exactly, missing **and** extra
+both fail; same-capability legs are equivalent within a size-ratio bound).
+
+## Usage
+
+**`USE_REMOTE_BUILDER=true` for anything including `linux/arm64`** (today: `lite`) — without it
+arm64 runs under QEMU, 2–3 h instead of 15–30 min.
+
+```bash
+USE_REMOTE_BUILDER=true ./scripts/docker-build-push.sh              # all: backend, lite, frontend, docs
+USE_REMOTE_BUILDER=true ./scripts/docker-build-push.sh backend      # full/CUDA backend only
+USE_REMOTE_BUILDER=true ./scripts/docker-build-push.sh lite         # CPU backend only (amd64 + arm64)
+./scripts/docker-build-push.sh frontend|docs                        # one service
+./scripts/docker-build-push.sh auto                                 # only git-changed components
+./scripts/docker-build-push.sh blackwell                            # on request only, never in `all`
+SKIP_SECURITY_SCAN=true ./scripts/docker-build-push.sh backend      # quick iteration
+BUILD_MODE=local ./scripts/docker-build-push.sh all                 # build + --load, push NOTHING
+```
+
+⚠️ **`PLATFORMS` is an explicit OVERRIDE, not a default.** Leave it unset and each component
+builds only its own declared platforms. It used to default to `linux/amd64,linux/arm64` for
+*every* component — the mechanism by which a CPU-only arm64 backend was published under the CUDA
+image's tag (issue #680). Set it only to force a one-off:
+
+```bash
+PLATFORMS=linux/amd64 ./scripts/docker-build-push.sh lite   # skip the arm64 leg this once
+```
+
+Other knobs: `PUSH_LATEST=false` (the release flow's default — `:latest` moves later by digest in
+`scripts/release/90-promote.sh`), `DRY_RUN=true`, `NO_CACHE=true`, `FAIL_ON_SECURITY_ISSUES=true`.
+
+## Don't publish by hand for a release
+
+`./scripts/release.sh run <version>` owns build → scan → rehearse → publish → smoke → promote.
+`.github/workflows/docker-publish.yml` is **retired** (it published under the old `latest-amd64`
+grammar and would overwrite the promoted `:latest` index).
+
+Full docs: `scripts/README.md`, `scripts/CLAUDE.md`.

--- a/.env.example
+++ b/.env.example
@@ -247,6 +247,14 @@ MAX_SPEAKERS=20
 NUM_SPEAKERS=
 ENABLE_VRAM_PROFILING=false
 DEPLOYMENT_MODE=full
+# Full/CUDA image override, symmetric to BACKEND_LITE_IMAGE below (issue #680).
+# ⚠️ Not yet wired into docker-compose.prod.yml the way BACKEND_LITE_IMAGE is
+# wired into docker-compose.lite.yml — prod.yml's 13 backend service definitions
+# still hardcode `davidamacey/opentranscribe-backend:${OT_IMAGE_TAG:-latest}`,
+# so only the TAG is overridable there today (OT_IMAGE_TAG), not the full image
+# reference. Documented here so the asymmetry is visible; wiring it through
+# prod.yml is follow-up work, not done in this change.
+BACKEND_IMAGE=davidamacey/opentranscribe-backend:latest
 BACKEND_LITE_IMAGE=davidamacey/opentranscribe-backend-lite:latest
 # faster_whisper | whisperx | cloud
 ENGINE_TRANSCRIBER_BACKEND=faster_whisper

--- a/.env.example
+++ b/.env.example
@@ -248,13 +248,20 @@ NUM_SPEAKERS=
 ENABLE_VRAM_PROFILING=false
 DEPLOYMENT_MODE=full
 # Full/CUDA image override, symmetric to BACKEND_LITE_IMAGE below (issue #680).
-# ⚠️ Not yet wired into docker-compose.prod.yml the way BACKEND_LITE_IMAGE is
-# wired into docker-compose.lite.yml — prod.yml's 13 backend service definitions
-# still hardcode `davidamacey/opentranscribe-backend:${OT_IMAGE_TAG:-latest}`,
-# so only the TAG is overridable there today (OT_IMAGE_TAG), not the full image
-# reference. Documented here so the asymmetry is visible; wiring it through
-# prod.yml is follow-up work, not done in this change.
-BACKEND_IMAGE=davidamacey/opentranscribe-backend:latest
+# Wired into all 13 backend service definitions in docker-compose.prod.yml as
+# `${BACKEND_IMAGE:-davidamacey/opentranscribe-backend:${OT_IMAGE_TAG:-latest}}`,
+# so leaving it UNSET keeps the historical behaviour exactly (OT_IMAGE_TAG still
+# selects the tag); setting it replaces the whole image REFERENCE — which is what
+# you need to pin a capability LEG rather than the index, e.g.
+#   BACKEND_IMAGE=davidamacey/opentranscribe-backend:v0.5.0-cuda-amd64
+#
+# ⚠️ SHIPPED COMMENTED OUT ON PURPOSE, exactly like OT_IMAGE_TAG above. Setting it
+# here would mean every install that copies this file has a FULL image reference
+# pinned in .env, which beats OT_IMAGE_TAG — silently defeating release pinning for
+# everyone (`update` would pin the tag and the deployment would keep running
+# whatever this line said). Same trap this file already documents for
+# BACKUP_HOST_PATH and MEDIA_NAS_PATH: a value shipped SET is a default nobody chose.
+#BACKEND_IMAGE=davidamacey/opentranscribe-backend:latest
 BACKEND_LITE_IMAGE=davidamacey/opentranscribe-backend-lite:latest
 # faster_whisper | whisperx | cloud
 ENGINE_TRANSCRIBER_BACKEND=faster_whisper

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,175 +1,81 @@
-name: Build and Publish Docker Images
+name: Build and Publish Docker Images (RETIRED — see scripts/release.sh)
+
+# ⚠️ RETIRED, DELIBERATELY, by issue #680. Do not re-enable the jobs below without
+# reading this whole comment.
+#
+# This workflow was a SECOND publisher, parallel to and unaware of the release
+# pipeline (`scripts/release.sh` → `scripts/release/80-publish.sh`), and it published
+# under the OLD tag grammar: `:latest-amd64` / `:latest-arm64` legs assembled into
+# `:latest` by `docker buildx imagetools create`.
+#
+# Two independent reasons that is now actively unsafe:
+#
+#  1. IT WOULD OVERWRITE THE PUBLISHED INDEX. Its final step did
+#         imagetools create -t davidamacey/opentranscribe-backend:latest \
+#             davidamacey/opentranscribe-backend:latest-amd64
+#     i.e. it REPLACES `:latest` with a manifest assembled from a tag this workflow
+#     built moments earlier — silently discarding whatever the release pipeline
+#     promoted there by digest (`scripts/release/90-promote.sh`, whose entire point
+#     is that `:latest` and `:vX.Y.Z` provably resolve to the SAME digest). One
+#     manual dispatch of this workflow after a release would break that guarantee
+#     with no error anywhere.
+#
+#  2. WRONG GRAMMAR, AND A SECOND HOME FOR IT. Capability now lives in the
+#     repository and is restated in the tag: `vX.Y.Z-<cap>-<arch>` legs
+#     (`-cuda-amd64`, `-cpu-amd64`, `-cpu-arm64`) assembled into a `vX.Y.Z` index,
+#     with `:latest` a digest-copy of that index. `latest-amd64` is not part of that
+#     scheme. The scheme has exactly ONE home — the COMPONENT_PLATFORMS /
+#     COMPONENT_CAPABILITY table in `scripts/docker-build-push.sh`, printed by
+#     `./scripts/docker-build-push.sh list-platforms` — precisely so a second copy
+#     cannot drift out of sync with it. Re-implementing it here would recreate the
+#     drift issue #680 is about.
+#
+# The `build_backend_arm64` job below was ALREADY `if: false` for an unrelated reason
+# (13.8 GB image exhausting the GitHub runner), which is how the backend manifest step
+# came to assemble an amd64-only index by hand while the local pipeline believed it was
+# publishing both arches. That mismatch is the shape of the #680 bug.
+#
+# To publish images, use the release pipeline, which builds, SCANS, rehearses,
+# publishes and only then promotes:
+#
+#     ./scripts/release.sh run <version>          # full sequence
+#     ./scripts/release.sh publish <version> --yes
+#
+# If CI-side image builds are ever wanted again, they must call
+# `scripts/docker-build-push.sh` (so they inherit the platform/capability table and
+# the leg/index assembly) rather than open-coding `docker/build-push-action` tags —
+# and the manifest-structure gate in `scripts/release/80-publish.sh` must run against
+# whatever they publish.
 
 on:
-  workflow_dispatch:  # Manual triggering ONLY - automatic builds disabled
-  # Automatic builds disabled - run manually via GitHub Actions UI
-  # push:
-  #   branches:
-  #     - master
-  #   paths-ignore:
-  #     - '**.md'
-  #     - '.github/**'
-  #     - '!.github/workflows/docker-publish.yml'
+  workflow_dispatch:
+    inputs:
+      i_understand_this_is_retired:
+        description: >-
+          This workflow is retired (issue #680) and will fail on purpose.
+          Use ./scripts/release.sh instead. Type RETIRED to acknowledge.
+        required: true
+        default: ''
 
 jobs:
-  build_backend_amd64:
+  refuse:
+    name: This workflow is retired — use scripts/release.sh
     runs-on: ubuntu-latest
     steps:
-      - name: Maximize build disk space
-        uses: easimon/maximize-build-space@fc881a613ad2a34aca9c9624518214ebc21dfc0c # v10
-        with:
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
-          remove-docker-images: 'true'
-
-      - name: Checkout code
-        uses: actions/checkout@v7
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build and push backend AMD64
-        uses: docker/build-push-action@v7
-        with:
-          context: ./backend
-          file: ./backend/Dockerfile.prod
-          platforms: linux/amd64
-          push: true
-          tags: davidamacey/opentranscribe-backend:latest-amd64
-          cache-from: type=registry,ref=davidamacey/opentranscribe-backend:buildcache-amd64
-          cache-to: type=registry,ref=davidamacey/opentranscribe-backend:buildcache-amd64,mode=max
-
-  build_backend_arm64:
-    runs-on: ubuntu-latest
-    if: false  # Disabled - build locally due to size (13.8GB) causing GitHub runner failures
-    steps:
-      - name: Maximize build disk space
-        uses: easimon/maximize-build-space@fc881a613ad2a34aca9c9624518214ebc21dfc0c # v10
-        with:
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
-          remove-docker-images: 'true'
-
-      - name: Checkout code
-        uses: actions/checkout@v7
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build and push backend ARM64
-        uses: docker/build-push-action@v7
-        with:
-          context: ./backend
-          file: ./backend/Dockerfile.prod
-          platforms: linux/arm64
-          push: true
-          tags: davidamacey/opentranscribe-backend:latest-arm64
-          cache-from: type=registry,ref=davidamacey/opentranscribe-backend:buildcache-arm64
-          cache-to: type=registry,ref=davidamacey/opentranscribe-backend:buildcache-arm64,mode=max
-
-  build_frontend_amd64:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Maximize build disk space
-        uses: easimon/maximize-build-space@fc881a613ad2a34aca9c9624518214ebc21dfc0c # v10
-        with:
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
-          remove-docker-images: 'true'
-
-      - name: Checkout code
-        uses: actions/checkout@v7
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build and push frontend AMD64
-        uses: docker/build-push-action@v7
-        with:
-          context: ./frontend
-          file: ./frontend/Dockerfile.prod
-          platforms: linux/amd64
-          push: true
-          tags: davidamacey/opentranscribe-frontend:latest-amd64
-          cache-from: type=registry,ref=davidamacey/opentranscribe-frontend:buildcache-amd64
-          cache-to: type=registry,ref=davidamacey/opentranscribe-frontend:buildcache-amd64,mode=max
-
-  build_frontend_arm64:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Maximize build disk space
-        uses: easimon/maximize-build-space@fc881a613ad2a34aca9c9624518214ebc21dfc0c # v10
-        with:
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
-          remove-docker-images: 'true'
-
-      - name: Checkout code
-        uses: actions/checkout@v7
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build and push frontend ARM64
-        uses: docker/build-push-action@v7
-        with:
-          context: ./frontend
-          file: ./frontend/Dockerfile.prod
-          platforms: linux/arm64
-          push: true
-          tags: davidamacey/opentranscribe-frontend:latest-arm64
-          cache-from: type=registry,ref=davidamacey/opentranscribe-frontend:buildcache-arm64
-          cache-to: type=registry,ref=davidamacey/opentranscribe-frontend:buildcache-arm64,mode=max
-
-  create_manifests:
-    needs: [build_backend_amd64, build_frontend_amd64, build_frontend_arm64]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Login to DockerHub
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Create and push backend manifest (AMD64 only for now)
+      - name: Explain and fail
         run: |
-          docker buildx imagetools create -t davidamacey/opentranscribe-backend:latest \
-            davidamacey/opentranscribe-backend:latest-amd64
-
-      - name: Create and push frontend manifest
-        run: |
-          docker buildx imagetools create -t davidamacey/opentranscribe-frontend:latest \
-            davidamacey/opentranscribe-frontend:latest-amd64 \
-            davidamacey/opentranscribe-frontend:latest-arm64
+          echo "::error title=Retired workflow::docker-publish.yml was retired by issue #680."
+          echo ""
+          echo "It published under the OLD tag grammar (:latest-amd64 / :latest-arm64 -> :latest)"
+          echo "and its final step would OVERWRITE the :latest index that scripts/release/90-promote.sh"
+          echo "promotes by digest, silently breaking the ':latest and :vX.Y.Z are the same bytes'"
+          echo "guarantee. Its backend arm64 job was also already disabled, so it assembled an"
+          echo "amd64-only index by hand -- the exact shape of the #680 bug."
+          echo ""
+          echo "Publish with the release pipeline instead:"
+          echo "  ./scripts/release.sh run <version>"
+          echo "  ./scripts/release.sh publish <version> --yes"
+          echo ""
+          echo "Current tag grammar (single source of truth):"
+          echo "  ./scripts/docker-build-push.sh list-platforms"
+          exit 1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -324,7 +324,7 @@ repos:
         entry: scripts/tests/test-publish-platforms.sh
         language: system
         pass_filenames: false
-        files: ^(backend/Dockerfile\.(prod|lite)|scripts/(docker-build-push\.sh|security-scan\.sh|lib/manifest_platform_check\.py|release/80-publish\.sh|tests/(test-publish-platforms\.sh|fixtures/manifest-fixtures\.py)))$
+        files: ^(backend/Dockerfile\.(prod|lite)|scripts/(docker-build-push\.sh|security-scan\.sh|lib/manifest_platform_check\.py|release/(80-publish|85-smoke)\.sh|tests/(test-publish-platforms\.sh|fixtures/manifest-fixtures\.py)))$
 
   # Commit message linting (optional)
   - repo: https://github.com/compilerla/conventional-pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -319,6 +319,13 @@ repos:
         pass_filenames: false
         files: ^scripts/(docker-build-push\.sh|security-scan\.sh|tests/test-scan-not-a-pass\.sh)$
 
+      - id: publish-platforms-not-a-pass
+        name: a published multi-arch tag cannot report equivalence it does not have (#680)
+        entry: scripts/tests/test-publish-platforms.sh
+        language: system
+        pass_filenames: false
+        files: ^(backend/Dockerfile\.(prod|lite)|scripts/(docker-build-push\.sh|security-scan\.sh|lib/manifest_platform_check\.py|release/80-publish\.sh|tests/(test-publish-platforms\.sh|fixtures/manifest-fixtures\.py)))$
+
   # Commit message linting (optional)
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v3.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,17 @@ Run with `./opentr.sh start dev --gpu-scale` — **the flag is what enables scal
 
 ### Docker build & push (production images)
 
-Skill: `.claude/skills/docker-build-push/SKILL.md` (multi-arch requires `USE_REMOTE_BUILDER=true`).
+Skill: `.claude/skills/docker-build-push/SKILL.md` (any build including `linux/arm64` requires
+`USE_REMOTE_BUILDER=true`, or it runs under QEMU).
+
+**Capability lives in the REPOSITORY and is restated in the TAG** (issue #680):
+`opentranscribe-backend` is CUDA, `opentranscribe-backend-lite` is CPU, and each publishes
+`vX.Y.Z-<cap>-<arch>` legs assembled into a `vX.Y.Z` index whose digest `:latest` is then copied
+from. **`PLATFORMS` is an explicit override, not a default** — the old both-arch default is how a
+CPU-only arm64 backend got published under the CUDA image's tag. Never transcribe the platform
+set into a doc or a script: ask `./scripts/docker-build-push.sh list-platforms`
+(`component<TAB>capability<TAB>platforms`), which is the single home for it. Full table and the
+reason `cuda-arm64` is reserved-but-unbuilt: `scripts/CLAUDE.md`.
 
 ### Cutting a release — `./scripts/release.sh`, never by hand
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ OpenTranscribe is a powerful, containerized web application for transcribing and
 
 ### ⚡ **Performance & Scaling**
 - **Multi-GPU Worker Scaling**: Optional parallel processing on dedicated GPUs for high-throughput systems, including an optional ASR/diarization **GPU split** (`--with-gpu-split`) that runs transcription and diarization on separate GPUs
-- **Hybrid Mode**: Automatic CPU transcription + GPU/MPS diarization for small-VRAM GPUs and Apple Silicon
+- **Hybrid Mode**: Automatic CPU transcription + GPU diarization for small-VRAM GPUs (Linux/WSL2 with an NVIDIA GPU only — a containerized deployment on Apple Silicon has no Docker Metal passthrough and runs CPU-only via the `--lite` image, not MPS)
 - **Combined Transcription Engine**: Unified, backend-pluggable engine with admin-tunable runtime settings and per-worker metrics
 - **Fast Uploads**: Optional presigned direct-to-MinIO uploads with content-hash (imohash) deduplication and a shared-memory WAV handoff that removes redundant downloads from the processing pipeline
 - **Pipeline Timing Instrumentation**: Opt-in end-to-end wall-clock timing (`ENABLE_BENCHMARK_TIMING`) with admin timing endpoints
@@ -1218,16 +1218,16 @@ docker stats
 - Fast NVMe storage
 - Load balancer for multiple instances
 
-#### **Low-VRAM / macOS Deployments — Hybrid Mode**
+#### **Low-VRAM Deployments — Hybrid Mode**
 
-For systems where the GPU cannot fit the full transcription model, OpenTranscribe automatically activates **hybrid mode**: transcription runs on CPU while diarization stays on GPU/MPS. This requires only ~1.3 GB VRAM for PyAnnote and delivers speaker-diarized transcripts without a dedicated GPU.
+For systems where the GPU cannot fit the full transcription model, OpenTranscribe automatically activates **hybrid mode**: transcription runs on CPU while diarization stays on GPU. This requires only ~1.3 GB VRAM for PyAnnote and delivers speaker-diarized transcripts without a dedicated GPU. This is a Linux/WSL2-with-NVIDIA-GPU feature — there is no GPU/MPS path available on macOS (Docker Desktop has no Metal passthrough), so macOS deployments use the `--lite` (CPU-only) image instead and run both stages on CPU.
 
 | Scenario | Transcription | Diarization | Trigger |
 |---|---|---|---|
 | GPU ≥ 8 GB + large-v3-turbo | GPU | GPU | Normal mode |
 | GPU 4–6 GB + large-v3-turbo | CPU (small model) | GPU | Auto hybrid |
-| macOS Apple Silicon (any) | CPU (small model) | MPS (PyAnnote fork) | Always hybrid |
-| `WHISPER_HYBRID_MODE=true` | CPU (small model) | GPU/MPS | Manual override |
+| macOS (any Apple Silicon) | CPU (small model) | CPU (`--lite` image) | Always CPU-only — no MPS in Docker |
+| `WHISPER_HYBRID_MODE=true` | CPU (small model) | GPU | Manual override (Linux/WSL2 + NVIDIA GPU only) |
 
 The CPU model defaults to `small` (int8, ~15–30× real-time on modern hardware). Override with `WHISPER_HYBRID_CPU_MODEL=medium` for better accuracy at the cost of speed.
 

--- a/backend/Dockerfile.lite
+++ b/backend/Dockerfile.lite
@@ -28,15 +28,25 @@
 # 2026-09-04: 2.70 GB. Not a budget, not a target.)
 # =============================================================================
 
-# diar-native (T1 diarization sidecar) binary + ONNX Runtime CPU-provider libs, pinned
-# by DIGEST — SAME pin as Dockerfile.prod:21, so the binary running here is byte-for-byte
-# the one the full image ships, never a separately-tracked version (#660). Unlike
-# Dockerfile.prod, this stage's COPY below deliberately excludes
-# libonnxruntime_providers_cuda.so: lite is CPU-only by definition (no CUDA runtime, no
-# nvidia driver expected on the host), and diar-server's CPU execution provider needs no
-# separate provider .so to dlopen — only the CUDA path does. DIAR_MODE must be `cpu` (or
-# unset, since diar-server's own default is cpu) for any container built from this image.
-FROM davidamacey/diar-native@sha256:83a709be94d0ca06441fa10aea0680f53b03cc10eb3ce11c4eeb84478400567d AS diar-native-bin
+# diar-native (T1 diarization sidecar) binary + ONNX Runtime CPU-provider libs.
+# ⚠️ Pre-#680 bug: this stage pinned the SAME digest as Dockerfile.prod:21 — the CUDA
+# standalone image (tag 0.3.1) — despite the comment above (now corrected) claiming
+# CPU-provider libs. That happened to still "work" on amd64 only because the COPY below
+# cherry-picks specific files out of a CUDA-capable image, and there was no arm64 leg at
+# all: BuildKit does not error on a --platform linux/arm64 build against a single-arch
+# amd64 base (issue #680) — COPY --from succeeds and only running the copied ELF fails,
+# with "exec format error" at container start. Fixed by selecting the real per-arch
+# diar-native CPU tag via TARGETARCH, still pinned by digest so the binary is
+# reproducible — just the correct (CPU) image, and now built for both architectures.
+ARG TARGETARCH
+FROM davidamacey/diar-native@sha256:b00b4bb5999d0b5cc353dae27c07b17fe61b232517f250aaf3ef03536c610879 AS diar-native-bin-amd64
+FROM davidamacey/diar-native@sha256:63e7a7275aada3da8c4840cbc5e2b4e498605a6658086355c62b84af75232d64 AS diar-native-bin-arm64
+# This FROM selects one of the two DIGEST-PINNED stages immediately above by ARG
+# TARGETARCH; hadolint cannot trace that indirection and flags it as an untagged
+# external image, but it resolves to one of the two pinned FROMs on this same
+# page, never a floating tag.
+# hadolint ignore=DL3006
+FROM diar-native-bin-${TARGETARCH} AS diar-native-bin
 
 # -----------------------------------------------------------------------------
 # Stage 1: Build Stage - Install Python dependencies with compilation

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -18,7 +18,25 @@ FROM denoland/deno:bin AS deno-bin
 # ambiguous). Only ~419 MB of the standalone 3.46 GB image is actually needed: the
 # binary, three ORT libs (see the exclusion note below), and libopenblas0. The standalone image
 # is 2.9 GB as of diar-native 0.3.1.
-FROM davidamacey/diar-native@sha256:83a709be94d0ca06441fa10aea0680f53b03cc10eb3ce11c4eeb84478400567d AS diar-native-bin
+#
+# ⚠️ #680/#667: this is a SINGLE-ARCH (linux/amd64) image — diar-native publishes no CUDA
+# arm64 build (only *-cpu-arm64 / *-provision-arm64, see Dockerfile.lite). A
+# `--platform linux/arm64` build of this Dockerfile does NOT fail here — BuildKit only warns
+# (InvalidBaseImagePlatform) and COPY --from still succeeds, shipping an amd64 ELF that
+# fails at container start with "exec format error". This full/CUDA image is therefore
+# amd64-ONLY for v0.5.0 (a `vX.Y.Z-cuda-arm64` tag leg is reserved in the grammar but not
+# built). The arm64 stage below intentionally references a tag that does not exist so that
+# declaring `--platform linux/arm64` for this Dockerfile fails LOUDLY at the pull step
+# instead of silently shipping a broken binary — remove this stage and replace it with a
+# real digest only once diar-native publishes a CUDA arm64 artifact.
+ARG TARGETARCH
+FROM davidamacey/diar-native@sha256:83a709be94d0ca06441fa10aea0680f53b03cc10eb3ce11c4eeb84478400567d AS diar-native-bin-amd64
+FROM davidamacey/diar-native:UNAVAILABLE-NO-CUDA-ARM64-BUILD-SEE-ISSUE-680 AS diar-native-bin-arm64
+# This FROM selects one of the two stages immediately above (amd64 is digest-
+# pinned; arm64 is a deliberately nonexistent tag, see the comment above) by ARG
+# TARGETARCH; hadolint cannot trace that indirection.
+# hadolint ignore=DL3006
+FROM diar-native-bin-${TARGETARCH} AS diar-native-bin
 
 # -----------------------------------------------------------------------------
 # Stage 1: Build Stage - Install Python dependencies with compilation

--- a/backend/tests/unit/test_compose_file_selection.py
+++ b/backend/tests/unit/test_compose_file_selection.py
@@ -523,13 +523,22 @@ def _rehearsal_source(name: str) -> str:
 # same stale-exemption discipline as backend/tests/audit-allowlist.txt.
 _HAND_BUILT_BRINGUP_EXEMPTIONS = {
     "test-lite-mode.sh": (
-        "docker-compose.lite.yml is NOT in release-manifest.txt and get_compose_files() "
-        "has no lite branch, so no shipped command can select it — see "
-        "test_lite_mode_is_not_reachable_by_a_shipped_deployment below. The moment that "
-        "changes, that test fails and this exemption must be removed. Since issue #660 "
-        "the hand-built chain also adds docker-compose.diar-native.yml (the CPU-EP "
-        "speaker-embedding sidecar); that addition is reachable only from this script "
-        "and from opentr.sh (dev-only), and does not make lite shippable."
+        "ISSUE #680 INVALIDATED THIS ENTRY'S ORIGINAL REASON and it is deliberately "
+        "rewritten rather than deleted. It used to read 'no shipped command can build "
+        "this chain' — true until #680 added docker-compose.lite.yml to "
+        "release-manifest.txt, gave get_compose_files() a lite branch, and made "
+        "`docker-build-push.sh all` publish opentranscribe-backend-lite. "
+        "test_lite_mode_is_reachable_by_a_shipped_deployment below now asserts all "
+        "three, so the old justification is gone. What keeps the exemption is a "
+        "different fact: this scenario must pin ONE fixed chain regardless of what the "
+        "host has (a GPU here would make the shipped selector add the GPU overlay, and "
+        "the whole point is the no-GPU shape), and it is also the live positive case "
+        "for test_the_hand_built_bringup_detector_actually_fires — a detector with no "
+        "positive case silently stops detecting. Driving it through "
+        "`DEPLOYMENT_MODE=lite ./opentranscribe.sh start` with FORCE_CPU_MODE is now "
+        "POSSIBLE and is the right follow-up; it needs its own change, not a drive-by. "
+        "Since issue #660 the chain also adds docker-compose.diar-native.yml (the "
+        "CPU-EP speaker-embedding sidecar)."
     ),
 }
 
@@ -589,18 +598,24 @@ def test_the_hand_built_bringup_detector_actually_fires():
     )
 
 
-def test_lite_mode_is_not_reachable_by_a_shipped_deployment():
-    """Finding E: `--lite` is a repo/dev-only shape today, and must be labelled as one.
+def test_lite_mode_is_reachable_by_a_shipped_deployment():
+    """Issue #680 turned finding E's tripwire around: lite is now genuinely shippable.
 
-    README.md advertises "API-Lite Deployment", but `docker-compose.lite.yml` is absent
-    from release-manifest.txt (so a curl install never downloads it) and
-    get_compose_files() has no lite branch (so nothing could select it if it did). The
-    lite image is not published by `scripts/docker-build-push.sh all` either.
+    This test used to assert the OPPOSITE — that `--lite` was a repo/dev-only shape —
+    and it existed to fail the moment anyone made it real, so the three facts it named
+    could not silently go stale. All three changed in one place, so it is now the
+    positive invariant on the same three facts:
 
-    This test is the tripwire on that relabel. If someone makes lite genuinely
-    shippable, this fails — and `test-lite-mode.sh`'s "dev-only" header, its exemption
-    above, and the docs all have to be revisited in the same change rather than left
-    stale.
+      1. `docker-compose.lite.yml` is in release-manifest.txt, so a curl install
+         downloads it;
+      2. `opentranscribe.sh:get_compose_files()` has a branch that can select it;
+      3. `scripts/docker-build-push.sh all` builds the lite image, so a release
+         publishes `opentranscribe-backend-lite`.
+
+    All three are load-bearing for arm64, where the full/CUDA image publishes no
+    manifest at all: `arm64_deployment_preflight()` defaults an arm64 host to
+    DEPLOYMENT_MODE=lite, which is a no-op unless every one of them holds. Losing any
+    one turns that default into a deployment that resolves nothing.
     """
     manifest = MANIFEST.read_text(encoding="utf-8")
     listed = [
@@ -613,14 +628,84 @@ def test_lite_mode_is_not_reachable_by_a_shipped_deployment():
         for line in MANAGER.read_text(encoding="utf-8").splitlines()
         if not line.lstrip().startswith("#")
     )
+    builder_code = "\n".join(
+        line
+        for line in (REPO_ROOT / "scripts" / "docker-build-push.sh")
+        .read_text(encoding="utf-8")
+        .splitlines()
+        if not line.lstrip().startswith("#")
+    )
 
     in_manifest = "docker-compose.lite.yml" in listed
     in_selector = "docker-compose.lite.yml" in manager_code
-    assert not in_manifest and not in_selector, (
-        "docker-compose.lite.yml is now reachable by a shipped deployment "
-        f"(manifest={in_manifest}, selector={in_selector}). test-lite-mode.sh and "
-        "scripts/release-tests/README.md still describe it as repo/dev-only, and the "
-        "release pipeline still does not publish opentranscribe-backend-lite — update "
-        "all three in this change, and drop the exemption in "
-        "_HAND_BUILT_BRINGUP_EXEMPTIONS."
+    # `all)` must build lite, not merely know the word — build_backend_lite is the
+    # function that produces the image, so its presence in the all/auto dispatch is
+    # the fact, and a bare `lite` string anywhere in the file is not.
+    builds_lite = "build_backend_lite" in builder_code
+
+    assert in_manifest and in_selector and builds_lite, (
+        "lite is no longer reachable by a shipped deployment "
+        f"(manifest={in_manifest}, selector={in_selector}, built={builds_lite}). "
+        "arm64 hosts default to DEPLOYMENT_MODE=lite because the full/CUDA image "
+        "publishes no arm64 manifest — with any of these three missing, that default "
+        "points at nothing. See scripts/release-tests/test-lite-mode.sh's scope note."
+    )
+
+
+def test_the_lite_overlay_covers_every_service_that_would_pull_the_full_image():
+    """A lite deployment must not pull the full/CUDA image for ANY service it starts.
+
+    `flower` was the one that slipped: it has no `profiles:` and no `scale: 0`, so it
+    starts on every deployment, and `docker-compose.lite.yml` did not override its
+    image. On amd64 that quietly drags the ~4.4 GB CUDA image into a deployment whose
+    premise is ~2 GB. On arm64 — where `arm64_deployment_preflight()` now DEFAULTS to
+    lite precisely because the full image publishes no arm64 manifest — `docker compose
+    up` fails outright with "no matching manifest for linux/arm64", so the branch's
+    headline behaviour would not work at all.
+
+    Enumerated from the compose files rather than listed here, so a service added to
+    prod.yml later cannot be forgotten. A service is covered if lite.yml overrides its
+    `image`, scales it to 0, or the base file puts it behind a `profiles:` gate.
+    """
+    yaml = pytest.importorskip("yaml")
+
+    base = yaml.safe_load((REPO_ROOT / "docker-compose.yml").read_text(encoding="utf-8"))
+    prod = yaml.safe_load((REPO_ROOT / "docker-compose.prod.yml").read_text(encoding="utf-8"))
+    lite = yaml.safe_load((REPO_ROOT / "docker-compose.lite.yml").read_text(encoding="utf-8"))
+
+    base_services = base.get("services", {})
+    lite_services = lite.get("services", {})
+
+    def _replicas(svc: dict) -> int | None:
+        deploy = svc.get("deploy") or {}
+        return deploy.get("replicas")
+
+    full_image_services = {
+        name
+        for name, svc in (prod.get("services") or {}).items()
+        if "opentranscribe-backend:" in str((svc or {}).get("image", ""))
+    }
+    # Must-fire control: if the scan finds nothing, every assertion below is vacuous.
+    assert full_image_services, (
+        "no service in docker-compose.prod.yml references the full backend image — the "
+        "detector matched nothing and this test proves nothing. Did the image reference "
+        "change shape (e.g. a new variable) without this scan being updated?"
+    )
+
+    uncovered = []
+    for name in sorted(full_image_services):
+        if (base_services.get(name) or {}).get("profiles"):
+            continue  # gpu-scale / gpu-split: not started by a lite deployment
+        override = lite_services.get(name) or {}
+        if override.get("image") or _replicas(override) == 0:
+            continue
+        if _replicas(base_services.get(name) or {}) == 0:
+            continue
+        uncovered.append(name)
+
+    assert not uncovered, (
+        f"docker-compose.lite.yml does not cover {uncovered}: these services start on a "
+        "lite deployment and would pull davidamacey/opentranscribe-backend (the full "
+        "CUDA image). On arm64 that image has no manifest at all, so `up` fails. Give "
+        "each one a ${BACKEND_LITE_IMAGE:-...} image override, or scale it to 0."
     )

--- a/docker-compose.lite.yml
+++ b/docker-compose.lite.yml
@@ -63,3 +63,16 @@ services:
     image: ${BACKEND_LITE_IMAGE:-davidamacey/opentranscribe-backend-lite:latest}
     environment:
       - DEPLOYMENT_MODE=lite
+
+  # ⚠️ flower was the ONE default-profile service this overlay missed (issue #680).
+  # It has no `profiles:` and no `scale: 0` in docker-compose.yml, so it starts on every
+  # lite deployment — and without this block it starts from the FULL/CUDA image. On
+  # amd64 that silently pulls ~4.4 GB into a deployment whose whole premise is ~2 GB; on
+  # arm64, where opentranscribe.sh now defaults to lite because the full image publishes
+  # no arm64 manifest at all, `docker compose up` fails outright with "no matching
+  # manifest for linux/arm64". Every other backend-image service here is either
+  # overridden above, scaled to 0, or behind the gpu-scale/gpu-split profiles.
+  flower:
+    image: ${BACKEND_LITE_IMAGE:-davidamacey/opentranscribe-backend-lite:latest}
+    environment:
+      - DEPLOYMENT_MODE=lite

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -8,7 +8,7 @@
 
 services:
   backend:
-    image: davidamacey/opentranscribe-backend:${OT_IMAGE_TAG:-latest}
+    image: ${BACKEND_IMAGE:-davidamacey/opentranscribe-backend:${OT_IMAGE_TAG:-latest}}
     build:
       context: ./backend
       dockerfile: Dockerfile.prod  # Production build
@@ -34,7 +34,7 @@ services:
       RATE_LIMIT_TRUSTED_PROXIES: ${RATE_LIMIT_TRUSTED_PROXIES:-127.0.0.1/32,172.16.0.0/12}
 
   celery-worker:
-    image: davidamacey/opentranscribe-backend:${OT_IMAGE_TAG:-latest}
+    image: ${BACKEND_IMAGE:-davidamacey/opentranscribe-backend:${OT_IMAGE_TAG:-latest}}
     build:
       context: ./backend
       dockerfile: Dockerfile.prod  # Production build
@@ -48,7 +48,7 @@ services:
       # No temp volume needed - temp files live in container only
 
   celery-download-worker:
-    image: davidamacey/opentranscribe-backend:${OT_IMAGE_TAG:-latest}
+    image: ${BACKEND_IMAGE:-davidamacey/opentranscribe-backend:${OT_IMAGE_TAG:-latest}}
     build:
       context: ./backend
       dockerfile: Dockerfile.prod  # Production build
@@ -59,7 +59,7 @@ services:
       - ${MODEL_CACHE_DIR:-./models}/torch:/home/appuser/.cache/torch
 
   celery-cpu-worker:
-    image: davidamacey/opentranscribe-backend:${OT_IMAGE_TAG:-latest}
+    image: ${BACKEND_IMAGE:-davidamacey/opentranscribe-backend:${OT_IMAGE_TAG:-latest}}
     build:
       context: ./backend
       dockerfile: Dockerfile.prod  # Production build
@@ -72,7 +72,7 @@ services:
     # merely wrong rather than harmful.
 
   celery-redaction:
-    image: davidamacey/opentranscribe-backend:${OT_IMAGE_TAG:-latest}
+    image: ${BACKEND_IMAGE:-davidamacey/opentranscribe-backend:${OT_IMAGE_TAG:-latest}}
     build:
       context: ./backend
       dockerfile: Dockerfile.prod  # Production build
@@ -83,7 +83,7 @@ services:
       - ${MODEL_CACHE_DIR:-./models}/torch:/home/appuser/.cache/torch
 
   celery-cloud-asr-worker:
-    image: davidamacey/opentranscribe-backend:${OT_IMAGE_TAG:-latest}
+    image: ${BACKEND_IMAGE:-davidamacey/opentranscribe-backend:${OT_IMAGE_TAG:-latest}}
     build:
       context: ./backend
       dockerfile: Dockerfile.prod  # Production build
@@ -91,7 +91,7 @@ services:
     # No volumes needed - cloud-ASR worker is network-bound only
 
   celery-nlp-worker:
-    image: davidamacey/opentranscribe-backend:${OT_IMAGE_TAG:-latest}
+    image: ${BACKEND_IMAGE:-davidamacey/opentranscribe-backend:${OT_IMAGE_TAG:-latest}}
     build:
       context: ./backend
       dockerfile: Dockerfile.prod  # Production build
@@ -99,7 +99,7 @@ services:
     # No volumes needed - NLP worker doesn't need model cache
 
   celery-embedding-worker:
-    image: davidamacey/opentranscribe-backend:${OT_IMAGE_TAG:-latest}
+    image: ${BACKEND_IMAGE:-davidamacey/opentranscribe-backend:${OT_IMAGE_TAG:-latest}}
     build:
       context: ./backend
       dockerfile: Dockerfile.prod  # Production build
@@ -111,7 +111,7 @@ services:
       - ${MODEL_CACHE_DIR:-./models}/huggingface:/home/appuser/.cache/huggingface
 
   celery-beat:
-    image: davidamacey/opentranscribe-backend:${OT_IMAGE_TAG:-latest}
+    image: ${BACKEND_IMAGE:-davidamacey/opentranscribe-backend:${OT_IMAGE_TAG:-latest}}
     build:
       context: ./backend
       dockerfile: Dockerfile.prod  # Production build
@@ -136,7 +136,7 @@ services:
       start_period: 30s
 
   flower:
-    image: davidamacey/opentranscribe-backend:${OT_IMAGE_TAG:-latest}
+    image: ${BACKEND_IMAGE:-davidamacey/opentranscribe-backend:${OT_IMAGE_TAG:-latest}}
     build:
       context: ./backend
       dockerfile: Dockerfile.prod  # Production build
@@ -178,7 +178,7 @@ services:
   # NOTE: No 'scale' parameter here - base has scale: 0, gpu-scale.yml sets scale: 1
   # This overlay only provides production-specific settings (image, build, pull_policy)
   celery-worker-gpu-scaled:
-    image: davidamacey/opentranscribe-backend:${OT_IMAGE_TAG:-latest}
+    image: ${BACKEND_IMAGE:-davidamacey/opentranscribe-backend:${OT_IMAGE_TAG:-latest}}
     build:
       context: ./backend
       dockerfile: Dockerfile.prod  # Production build
@@ -195,7 +195,7 @@ services:
   # Base provides command/env/healthcheck via the gpu-split profile; these blocks
   # only supply the image/build/pull_policy/volumes (mirrors celery-worker-gpu-scaled).
   celery-worker-gpu-transcribe:
-    image: davidamacey/opentranscribe-backend:${OT_IMAGE_TAG:-latest}
+    image: ${BACKEND_IMAGE:-davidamacey/opentranscribe-backend:${OT_IMAGE_TAG:-latest}}
     build:
       context: ./backend
       dockerfile: Dockerfile.prod  # Production build
@@ -209,7 +209,7 @@ services:
       - pipeline_scratch:/scratch/opentranscribe
 
   celery-worker-gpu-diarize:
-    image: davidamacey/opentranscribe-backend:${OT_IMAGE_TAG:-latest}
+    image: ${BACKEND_IMAGE:-davidamacey/opentranscribe-backend:${OT_IMAGE_TAG:-latest}}
     build:
       context: ./backend
       dockerfile: Dockerfile.prod  # Production build

--- a/docs-site/docs/developer-guide/releasing.md
+++ b/docs-site/docs/developer-guide/releasing.md
@@ -286,11 +286,45 @@ Release — publishing it in CI would point new users at a version whose images 
 not exist yet. `finish` owns that, and refuses until this workflow is green.
 
 :::note[Why publishing is local]
-The backend production image is ~13.8 GB. GitHub's free runners cannot build it —
-that is why `docker-publish.yml`'s backend ARM64 job is disabled. ARM64 builds use
-a remote builder over SSH (`scripts/setup-remote-builder.sh`), which turns a 2-3
-hour QEMU emulation into roughly 20 minutes of native build.
+The backend production image is ~13.8 GB. GitHub's free runners cannot build it.
+`.github/workflows/docker-publish.yml` is now **retired** entirely (issue #680): it
+was a second publisher using the old `:latest-amd64` / `:latest-arm64` grammar, and
+its final step assembled `:latest` by hand — which would overwrite the index
+`promote` had copied by digest, silently breaking the ":latest and :vX.Y.Z are the
+same bytes" guarantee. Publishing happens only through `./scripts/release.sh`.
+ARM64 legs use a remote builder over SSH (`scripts/setup-remote-builder.sh`), which
+turns 2-3 hours of QEMU emulation into roughly 20 minutes of native build.
 :::
+
+### What gets published, and under what tags
+
+Capability lives in the **repository** and is restated in the **tag**. Do not copy this
+table into another file — `./scripts/docker-build-push.sh list-platforms` prints it, and
+`80-publish.sh` derives its checks from that command rather than from any hardcoded
+architecture list:
+
+| Repository | Capability | Legs published | Index | `:latest` |
+|---|---|---|---|---|
+| `opentranscribe-backend` | `cuda` | `vX.Y.Z-cuda-amd64` | `vX.Y.Z` | digest-copy of index |
+| `opentranscribe-backend-lite` | `cpu` | `vX.Y.Z-cpu-amd64`, `vX.Y.Z-cpu-arm64` | `vX.Y.Z` | digest-copy |
+| `opentranscribe-frontend` | — | (no capability legs) | `vX.Y.Z` | digest-copy |
+| `opentranscribe-docs` | — | (no capability legs) | `vX.Y.Z` | digest-copy |
+
+`vX.Y.Z-cuda-arm64` is **reserved in the grammar but not built**: there is no aarch64 CUDA
+torch wheel at the pinned version, `onnxruntime-gpu` publishes no aarch64 wheels at all, and
+diar-native ships no CUDA arm64 build of its sidecar. So the full image is **amd64-only**, and
+`opentranscribe.sh` defaults an arm64 host to the lite image with an explanation.
+
+`publish` verifies structure, not just existence — the pre-#680 check only grepped the
+manifest for an architecture string, which a *degraded but present* arm64 leg passes:
+
+1. each `-<cap>-<arch>` leg tag declares **exactly one** platform, the declared one;
+2. each `vX.Y.Z` index declares **exactly** the declared platform set — a missing platform
+   fails **and so does an extra one**;
+3. legs of the **same** capability are equivalent: identical layer count, size ratio within
+   1.25 (lite/frontend/docs) or 2.00 (full). Never compared across capabilities — the whole
+   point is that a CUDA image and a CPU image have no reason to be the same size, which is
+   why "arm64 is 8.4× smaller" went unnoticed for as long as it did.
 
 ## Before you start
 

--- a/docs-site/docs/faq.md
+++ b/docs-site/docs/faq.md
@@ -57,8 +57,12 @@ No, but **highly recommended** for practical use. CPU-only processing is very sl
 
 ### Can I use Apple Silicon (M1/M2/M3)?
 
-Yes! OpenTranscribe supports Apple Silicon Macs with MPS (Metal Performance Shaders) acceleration. Performance is between CPU and NVIDIA GPU:
-- **M2 Max**: 1-hour video → ~15-20 minutes
+Yes, with the `--lite` (CPU-only) image — but **not** with MPS acceleration. Docker
+Desktop on macOS has no Metal/GPU passthrough into the Linux VM the container runs
+in, so every container on Apple Silicon is CPU-only regardless of the host chip's
+MPS capability. Expect CPU-class timings, not GPU-class ones — see the CPU figures
+above. (An MPS code path exists in the diarization engine, but it is unreachable in
+every containerized deployment; see `backend/app/transcription/CLAUDE.md`.)
 
 ### What GPUs are supported?
 

--- a/docs-site/docs/features/transcription.md
+++ b/docs-site/docs/features/transcription.md
@@ -170,8 +170,10 @@ Model Selection (Advanced) or `WHISPER_MODEL=nyrahealth/faster_CrisperWhisper`.
 
 **Alternative**: Use `large-v3` if you need translation to English or maximum accuracy
 
-:::info[Hybrid Mode (Low-VRAM GPU / macOS)]
-When the GPU cannot fit the transcription model (or on macOS), OpenTranscribe automatically switches to **hybrid mode**: the `small` model runs on CPU (int8) while PyAnnote diarization stays on GPU/MPS. You still get speaker-separated transcripts — just at CPU transcription speeds (~15–30× real-time).
+:::info[Hybrid Mode (Low-VRAM NVIDIA GPU)]
+When the GPU cannot fit the transcription model, OpenTranscribe automatically switches to **hybrid mode**: the `small` model runs on CPU (int8) while PyAnnote diarization stays on the GPU. You still get speaker-separated transcripts — just at CPU transcription speeds (~15–30× real-time).
+
+This is a Linux/WSL2-with-NVIDIA-GPU feature. **macOS is not a hybrid-mode platform**: Docker Desktop has no Metal/GPU passthrough, so a container on Apple Silicon has no MPS device to put diarization on and runs both stages on CPU via the `--lite` image.
 
 Override with `WHISPER_HYBRID_MODE=true/false/auto` and `WHISPER_HYBRID_CPU_MODEL=small|medium|base`.
 :::

--- a/docs-site/docs/getting-started/quick-start.md
+++ b/docs-site/docs/getting-started/quick-start.md
@@ -53,7 +53,7 @@ The installer will ask for:
 2. **Whisper Model Size** (default: `large-v3-turbo` — auto-detected based on hardware)
    - `large-v3-turbo` - 6x faster, excellent accuracy (default, NVIDIA GPU recommended)
    - `large-v3` - Best accuracy, required for translation to English
-   - `medium` - Good balance (8GB+ GPU or Apple Silicon)
+   - `medium` - Good balance (8GB+ NVIDIA GPU)
    - `base` - Fast (CPU-only systems)
 
 ### Step 3: Start OpenTranscribe

--- a/docs-site/docs/installation/hardware-requirements.md
+++ b/docs-site/docs/installation/hardware-requirements.md
@@ -62,7 +62,10 @@ For regular use and production deployments:
 :::info[Hybrid Mode for Low-VRAM GPUs and macOS]
 If your GPU has less than ~5 GB of usable VRAM, OpenTranscribe automatically activates **hybrid mode**: transcription runs on CPU (small model, int8) while speaker diarization stays on GPU. This requires only ~1.3 GB VRAM for PyAnnote and still produces fully diarized transcripts.
 
-On **macOS (Apple Silicon)**, hybrid mode is always active — PyAnnote runs on MPS while faster-whisper runs on CPU (MPS transcription support is unreliable).
+On **macOS (Apple Silicon)**, use the `--lite` (CPU-only) image — Docker Desktop
+on macOS has no Metal/GPU passthrough, so every container is CPU-only there
+regardless of host chip. There is no MPS acceleration path available inside a
+container on this platform; expect CPU-class timings.
 
 See [Performance Tuning → Hybrid Mode](../operations/performance-tuning.md#hybrid-mode) for configuration details.
 :::
@@ -196,7 +199,7 @@ The following ports must be available:
 | Platform | NVIDIA GPU | Notes |
 |----------|------------|-------|
 | Linux | ✅ Full support | Best performance |
-| macOS | N/A — Apple Silicon | Hybrid mode auto-enabled: PyAnnote on MPS, transcription on CPU |
+| macOS | N/A — no Docker Metal passthrough | CPU-only via the `--lite` image — no MPS acceleration in a container |
 | Windows | ✅ via WSL2 | CUDA in WSL2 required |
 
 ## Verification Commands

--- a/docs-site/docs/installation/hardware-requirements.md
+++ b/docs-site/docs/installation/hardware-requirements.md
@@ -56,10 +56,10 @@ For regular use and production deployments:
 - **Transcription only**: 4-6GB VRAM
 - **Transcription + Diarization**: 6-8GB VRAM
 - **Multiple concurrent jobs**: 10-12GB+ VRAM
-- **Hybrid mode (low-VRAM / macOS)**: ~1.3GB VRAM for diarization only — transcription runs on CPU
+- **Hybrid mode (low-VRAM NVIDIA GPUs)**: ~1.3GB VRAM for diarization only — transcription runs on CPU
 :::
 
-:::info[Hybrid Mode for Low-VRAM GPUs and macOS]
+:::info[Hybrid Mode for Low-VRAM GPUs — and why macOS is not one]
 If your GPU has less than ~5 GB of usable VRAM, OpenTranscribe automatically activates **hybrid mode**: transcription runs on CPU (small model, int8) while speaker diarization stays on GPU. This requires only ~1.3 GB VRAM for PyAnnote and still produces fully diarized transcripts.
 
 On **macOS (Apple Silicon)**, use the `--lite` (CPU-only) image — Docker Desktop

--- a/docs-site/docs/operations/performance-tuning.md
+++ b/docs-site/docs/operations/performance-tuning.md
@@ -85,7 +85,7 @@ WHISPER_MODEL=large-v3-turbo
 
 ### Hybrid Mode {/* #hybrid-mode */}
 
-For systems where the GPU cannot fit the full transcription model, OpenTranscribe auto-activates **hybrid mode**: transcription runs on CPU while diarization stays on GPU/MPS. This requires only ~1.3 GB VRAM.
+For systems where the GPU cannot fit the full transcription model, OpenTranscribe auto-activates **hybrid mode**: transcription runs on CPU while diarization stays on the NVIDIA GPU. This requires only ~1.3 GB VRAM.
 
 **Auto-activation thresholds** (minimum batch=2 VRAM peak vs. 80% of GPU VRAM):
 
@@ -95,7 +95,12 @@ For systems where the GPU cannot fit the full transcription model, OpenTranscrib
 | medium | 3,829 MB | ~4.8 GB |
 | small | 2,933 MB | ~3.7 GB |
 
-macOS (Apple Silicon) always uses hybrid mode — PyAnnote runs on MPS, transcription runs on CPU.
+macOS (Apple Silicon) is **not** a hybrid-mode platform: Docker Desktop has no Metal/GPU
+passthrough into the Linux VM, so a container there has no MPS device to place diarization on.
+Use the `--lite` (CPU-only) image; both stages run on CPU. The MPS branch in
+`HardwareConfig._detect_optimal_device` gates on `platform.system() == "darwin"`, which is never
+true inside the Linux container every install path runs — see
+`backend/app/transcription/CLAUDE.md`.
 
 ```bash
 # Hybrid mode environment variables
@@ -164,7 +169,8 @@ See the [Multi-GPU Scaling](../configuration/multi-gpu-scaling) documentation fo
 
 The `HardwareConfig` class in `backend/app/utils/hardware_detection.py` handles all auto-detection:
 
-1. **Device detection**: CUDA > MPS (Apple Silicon) > CPU
+1. **Device detection**: CUDA > MPS > CPU — but the MPS arm is unreachable in a container
+   (it requires `platform.system() == "darwin"`), so on macOS this resolves to CPU
 2. **Compute type**: Based on GPU compute capability (see table above)
 3. **Batch size**: Based on total VRAM (see table above)
 4. **Environment overrides**: `TORCH_DEVICE`, `COMPUTE_TYPE`, `BATCH_SIZE` override auto-detection

--- a/opentranscribe.sh
+++ b/opentranscribe.sh
@@ -375,6 +375,105 @@ is_blackwell_gpu() {
     [[ "$compute_cap" == 12.* ]]
 }
 
+# Host CPU architecture, normalized to the names Docker/OCI manifests use
+# (amd64 / arm64), so a caller never has to know that `uname -m` says x86_64 on
+# one and aarch64 on the other. Anything else is echoed through unchanged.
+host_architecture() {
+    local machine
+    machine=$(uname -m 2>/dev/null || echo unknown)
+    case "$machine" in
+        x86_64|amd64)   echo "amd64" ;;
+        aarch64|arm64)  echo "arm64" ;;
+        *)              echo "$machine" ;;
+    esac
+}
+
+# The deployment mode this run will actually use, env var beating .env.
+# read_env_value only ever reads .env, so a preflight that exports
+# DEPLOYMENT_MODE (see arm64_deployment_preflight below) would otherwise be
+# invisible to every consumer that asks .env directly.
+effective_deployment_mode() {
+    local mode="${DEPLOYMENT_MODE:-}"
+    if [ -z "$mode" ]; then
+        mode=$(read_env_value DEPLOYMENT_MODE)
+    fi
+    echo "$mode" | tr '[:upper:]' '[:lower:]'
+}
+
+# arm64 hosts: the FULL (CUDA) image has no arm64 leg, so default to lite (#680).
+#
+# This is not a preference, it is what is publishable. Three independent reasons,
+# each one sufficient on its own:
+#
+#   1. No CUDA/torch parity. The cu128 index has no aarch64 torch wheel for the
+#      pinned version, and the 14 nvidia-*-cu12 dependencies are gated
+#      `platform_machine == "x86_64"` — an arm64 "full" build silently resolves
+#      to a CPU-only dependency set. That is exactly the artifact issue #680
+#      found published under the GPU image's tag.
+#   2. onnxruntime-gpu has ZERO aarch64 wheels at the pinned version, so the
+#      GPU execution provider cannot be installed on arm64 at all.
+#   3. diar-native publishes no CUDA arm64 build (only *-cpu-arm64 and
+#      *-provision-arm64), so the sidecar binary the full image COPYs in does
+#      not exist for this architecture.
+#
+# Consequently `davidamacey/opentranscribe-backend:<version>` publishes an
+# amd64-only manifest index. Pulling it on arm64 fails with "no matching
+# manifest for linux/arm64" — which is the CORRECT, loud outcome, and much
+# better than the pre-#680 state where a degraded arm64 image was published
+# under that same tag and started successfully before failing at model-load
+# time inside a worker.
+#
+# So on arm64 this switches the run to DEPLOYMENT_MODE=lite (the CPU-only image,
+# which DOES publish an arm64 leg) and says why. Override with
+# OPENTRANSCRIBE_FORCE_FULL_ON_ARM64=true if you have built a full arm64 image
+# yourself — nothing here can produce one for you.
+#
+# MUST be called as a plain statement, never through `$(...)` — same subshell
+# hazard documented on pin_diar_native_image_for_blackwell: the `export` below
+# has to survive into the later `compose_files=$(get_compose_files)` call.
+arm64_deployment_preflight() {
+    [ "$(host_architecture)" = "arm64" ] || return 0
+
+    local mode
+    mode=$(effective_deployment_mode)
+    if [ "$mode" = "lite" ]; then
+        echo -e "${BLUE}🖥️  arm64 host, DEPLOYMENT_MODE=lite — using the CPU-only image (the only one published for arm64)${NC}" >&2
+        return 0
+    fi
+
+    if [ "${OPENTRANSCRIBE_FORCE_FULL_ON_ARM64:-}" = "true" ]; then
+        echo -e "${YELLOW}⚠️  arm64 host with OPENTRANSCRIBE_FORCE_FULL_ON_ARM64=true — NOT switching to lite${NC}" >&2
+        echo -e "${YELLOW}   The published full/CUDA image has no arm64 manifest. Unless you built one${NC}" >&2
+        echo -e "${YELLOW}   yourself, the pull will fail with 'no matching manifest for linux/arm64'.${NC}" >&2
+        return 0
+    fi
+
+    echo -e "${YELLOW}🖥️  arm64 host detected — defaulting to the lite (CPU-only) image${NC}" >&2
+    echo -e "${YELLOW}   The full/CUDA image is published for linux/amd64 ONLY. On arm64:${NC}" >&2
+    echo -e "${YELLOW}     • no aarch64 CUDA torch wheel exists at the pinned version, and the${NC}" >&2
+    echo -e "${YELLOW}       nvidia-*-cu12 dependencies are gated platform_machine == \"x86_64\"${NC}" >&2
+    echo -e "${YELLOW}     • onnxruntime-gpu publishes no aarch64 wheels at all${NC}" >&2
+    echo -e "${YELLOW}     • diar-native publishes no CUDA arm64 build of its sidecar binary${NC}" >&2
+    echo -e "${YELLOW}   Cloud ASR providers still work; local GPU transcription does not.${NC}" >&2
+    echo -e "${YELLOW}   To override (only useful if you built a full arm64 image yourself):${NC}" >&2
+    echo -e "${YELLOW}     OPENTRANSCRIBE_FORCE_FULL_ON_ARM64=true ./opentranscribe.sh start${NC}" >&2
+    export DEPLOYMENT_MODE=lite
+}
+
+# Is a working NVIDIA GPU path actually on offer for this host? Architecture is
+# part of the answer, not just the presence of a runtime: an arm64 host can
+# advertise the nvidia runtime (Jetson, GB10) and still have no full/CUDA image
+# to run, per arm64_deployment_preflight above. Used to decide whether to even
+# mention the GPU path to an operator.
+nvidia_gpu_offer_available() {
+    [ "$(detect_nvidia_runtime)" = "nvidia" ] || return 1
+    force_cpu_mode_requested && return 1
+    if [ "$(host_architecture)" = "arm64" ] && [ "${OPENTRANSCRIBE_FORCE_FULL_ON_ARM64:-}" != "true" ]; then
+        return 1
+    fi
+    return 0
+}
+
 # force_cpu_mode_requested: returns success (0) when the user opted out of
 # GPU acceleration at install time (setup-opentranscribe.sh --cpu, or the
 # OPENTRANSCRIBE_FORCE_CPU env var), which persisted FORCE_CPU_MODE=true to
@@ -540,25 +639,69 @@ diar_native_marker_present() {
 get_compose_files() {
     local compose_files="-f docker-compose.yml"
 
+    # Architecture preflight FIRST, because it can change DEPLOYMENT_MODE and every
+    # decision below reads it. Called here rather than only at the `start` case arm
+    # so that stop/restart/status/compose-files resolve the SAME chain start did —
+    # a teardown that resolves a different overlay set than the bring-up addresses
+    # a different set of services. Its banners go to stderr like every other banner
+    # in this function, so `compose-files` still prints only the chain on stdout.
+    arm64_deployment_preflight
+
     # Production deployment always uses prod overrides
     if [ -f docker-compose.prod.yml ]; then
         compose_files="$compose_files -f docker-compose.prod.yml"
     fi
 
+    # Lite (CPU-only) overlay. Before issue #680 this branch did not exist at all:
+    # DEPLOYMENT_MODE=lite was read by four other places in this script but could
+    # never actually select docker-compose.lite.yml, so a production install had no
+    # shipped way to run the lite images — scripts/release-tests/test-lite-mode.sh
+    # says so in its own header and hand-assembles the chain instead. That gap is
+    # what made "default arm64 to lite" impossible to honour, since there was
+    # nowhere for the default to point.
+    local deployment_mode
+    deployment_mode=$(effective_deployment_mode)
+    if [ "$deployment_mode" = "lite" ]; then
+        if [ -f docker-compose.lite.yml ]; then
+            compose_files="$compose_files -f docker-compose.lite.yml"
+            echo -e "${BLUE}☁️  Lite overlay enabled (DEPLOYMENT_MODE=lite) — CPU-only image, cloud ASR${NC}" >&2
+        else
+            echo -e "${YELLOW}⚠️  DEPLOYMENT_MODE=lite but docker-compose.lite.yml is missing${NC}" >&2
+            echo -e "${YELLOW}   This install predates the lite overlay being shipped (release-manifest.txt).${NC}" >&2
+            echo -e "${YELLOW}   Run './opentranscribe.sh update-full' to fetch it, or the full image will be used.${NC}" >&2
+        fi
+    fi
+
     # Add GPU overlay if NVIDIA runtime is available and overlay exists,
-    # unless the user explicitly chose CPU-only mode at install time.
-    local docker_runtime
+    # unless the user explicitly chose CPU-only mode at install time, or this is
+    # a lite deployment (the lite image carries no CUDA runtime at all, so a GPU
+    # reservation on it reserves a device nothing in the container can use).
+    #
+    # `gpu_overlay_selected` records the ANSWER, not the inputs. The diar-native-gpu
+    # gate further down used to recompute it from `$docker_runtime` +
+    # force_cpu_mode_requested, which silently stopped tracking this block the moment a
+    # third reason to skip the GPU (lite) was added — the sidecar would have reserved a
+    # CUDA device, and flipped DIAR_MODE to `cuda`, inside a CPU-only image. That is
+    # exactly the invariant #660 states: the sidecar can never claim a device the rest
+    # of the stack decided not to use.
+    local docker_runtime gpu_overlay_selected=false
     docker_runtime=$(detect_nvidia_runtime)
-    if force_cpu_mode_requested; then
+    if [ "$deployment_mode" = "lite" ]; then
+        if [ "$docker_runtime" = "nvidia" ]; then
+            echo -e "${BLUE}🧮 Lite deployment — skipping GPU overlay despite nvidia runtime being available${NC}" >&2
+        fi
+    elif force_cpu_mode_requested; then
         if [ "$docker_runtime" = "nvidia" ]; then
             echo -e "${BLUE}🧮 CPU-only mode (FORCE_CPU_MODE=true in .env) — skipping GPU overlay despite nvidia runtime being available${NC}" >&2
         fi
     elif [ "$docker_runtime" = "nvidia" ]; then
         if is_blackwell_gpu && [ -f docker-compose.blackwell.yml ]; then
             compose_files="$compose_files -f docker-compose.blackwell.yml"
+            gpu_overlay_selected=true
             echo -e "${BLUE}Blackwell GPU overlay enabled (SM_12x detected)${NC}" >&2
         elif [ -f docker-compose.gpu.yml ]; then
             compose_files="$compose_files -f docker-compose.gpu.yml"
+            gpu_overlay_selected=true
             echo -e "${BLUE}GPU acceleration enabled (NVIDIA Container Toolkit detected)${NC}" >&2
         fi
     fi
@@ -678,10 +821,13 @@ get_compose_files() {
             # The overlay above is CPU-safe by construction (no device reservation,
             # DIAR_MODE defaults to cpu) so it can load on a GPU-less or FORCE_CPU_MODE
             # host. The reservation and the `cuda` override are in a second file, added
-            # only when a GPU overlay was actually selected above — keyed off the same
-            # $docker_runtime probe, so the sidecar can never claim a device the rest of
-            # the stack decided not to use (#660).
-            if [ "$docker_runtime" = "nvidia" ] && ! force_cpu_mode_requested \
+            # only when a GPU overlay was ACTUALLY selected above — gated on that block's
+            # recorded answer ($gpu_overlay_selected), not on re-deriving it from
+            # $docker_runtime, so the sidecar can never claim a device the rest of the
+            # stack decided not to use (#660). Re-deriving is how this drifted: it
+            # reproduced two of the three skip conditions and missed lite (#680), which
+            # would have put a CUDA reservation and DIAR_MODE=cuda on the CPU-only image.
+            if [ "$gpu_overlay_selected" = true ] \
                && [ -f docker-compose.diar-native-gpu.yml ]; then
                 compose_files="$compose_files -f docker-compose.diar-native-gpu.yml"
                 echo -e "${BLUE}   Holds ~2.2 GB of GPU memory on device ${DIAR_NATIVE_GPU:-${GPU_DEVICE_ID:-0}} while up.${NC}" >&2
@@ -1321,6 +1467,11 @@ case "${1:-help}" in
             ensure_minio_kms_secret ".env"
         fi
         echo -e "${YELLOW}🚀 Starting OpenTranscribe...${NC}"
+        # Plain statement, not `$(...)`: get_compose_files() calls this too, but from
+        # inside a command substitution, where the DEPLOYMENT_MODE export dies with the
+        # subshell. `docker compose up` below interpolates ${BACKEND_LITE_IMAGE}/
+        # ${DEPLOYMENT_MODE} itself, so the export has to exist in THIS shell as well.
+        arm64_deployment_preflight
         pin_diar_native_image_for_blackwell
         pin_gpu_split_profile
         compose_files=$(get_compose_files)

--- a/opentranscribe.sh
+++ b/opentranscribe.sh
@@ -460,14 +460,23 @@ arm64_deployment_preflight() {
     export DEPLOYMENT_MODE=lite
 }
 
-# Is a working NVIDIA GPU path actually on offer for this host? Architecture is
-# part of the answer, not just the presence of a runtime: an arm64 host can
-# advertise the nvidia runtime (Jetson, GB10) and still have no full/CUDA image
-# to run, per arm64_deployment_preflight above. Used to decide whether to even
-# mention the GPU path to an operator.
+# Is a working NVIDIA GPU path actually on offer for this deployment? The runtime
+# being present is only one of FOUR reasons the answer can be no, and every caller
+# that re-derives a subset of them drifts the moment a fifth is added — which is
+# exactly how the diar-native-gpu gate came to reproduce two of three conditions
+# and miss lite (#680). One function, one answer:
+#
+#   1. no nvidia container runtime at all;
+#   2. the operator opted out at install time (FORCE_CPU_MODE);
+#   3. DEPLOYMENT_MODE=lite — the lite image carries no CUDA runtime, so any GPU
+#      reservation made for it reserves a device nothing in the container can use;
+#   4. an arm64 host, where the full/CUDA image publishes no manifest at all (see
+#      arm64_deployment_preflight) — a Jetson/GB10 can advertise the nvidia runtime
+#      and still have nothing CUDA-capable to run.
 nvidia_gpu_offer_available() {
     [ "$(detect_nvidia_runtime)" = "nvidia" ] || return 1
     force_cpu_mode_requested && return 1
+    [ "$(effective_deployment_mode)" != "lite" ] || return 1
     if [ "$(host_architecture)" = "arm64" ] && [ "${OPENTRANSCRIBE_FORCE_FULL_ON_ARM64:-}" != "true" ]; then
         return 1
     fi
@@ -524,8 +533,12 @@ force_cpu_mode_requested() {
 # every OTHER call site here, which builds `$compose_files` and runs `docker compose` in
 # the SAME process.
 pin_diar_native_image_for_blackwell() {
-    force_cpu_mode_requested && return 0
-    [ "$(detect_nvidia_runtime)" = "nvidia" ] || return 0
+    # nvidia_gpu_offer_available(), not a re-derived runtime+FORCE_CPU pair: this
+    # function WRITES a pin into .env, so getting it wrong is sticky. On a lite
+    # deployment (including every arm64 host, which now defaults to lite) it would
+    # otherwise persist DIAR_NATIVE_IMAGE=<blackwell CUDA image> for a stack whose
+    # GPU overlay was never loaded.
+    nvidia_gpu_offer_available || return 0
     is_blackwell_gpu || return 0
     [ -f docker-compose.blackwell.yml ] || return 0
 
@@ -570,16 +583,17 @@ pin_diar_native_image_for_blackwell() {
 # exact silent-misconfiguration issue #703's live-consumer check now falls back safely
 # from, but the fallback is "process on the shared gpu queue", not "actually split").
 #
-# Also requires an nvidia runtime and no FORCE_CPU_MODE opt-out — same probe
-# get_compose_files() uses for the plain GPU overlay — since a GPU-reservation overlay
-# cannot load on a host that decided not to use its GPU at all.
+# Also requires nvidia_gpu_offer_available() — the single home for "is a GPU path
+# actually on offer here", covering the nvidia runtime, FORCE_CPU_MODE, lite mode and
+# arm64 — since a GPU-reservation overlay cannot load on a deployment that decided not
+# to use its GPU at all, and enumerating a subset of those reasons here is how the
+# diar-native-gpu gate drifted (#680).
 gpu_split_active() {
     [ -f docker-compose.gpu-split.yml ] || return 1
     local split_enabled
     split_enabled=$(read_env_value ENGINE_GPU_SPLIT | tr '[:upper:]' '[:lower:]')
     [ "$split_enabled" = "true" ] || return 1
-    force_cpu_mode_requested && return 1
-    [ "$(detect_nvidia_runtime)" = "nvidia" ] || return 1
+    nvidia_gpu_offer_available || return 1
     return 0
 }
 

--- a/release-manifest.txt
+++ b/release-manifest.txt
@@ -84,6 +84,16 @@ docker-compose.diar-native-gpu.yml
 # references it by name so a fresh install that skips it just keeps the disk-backed
 # default. Load with `./opentr.sh start dev --with-scratch-tmpfs`.
 docker-compose.scratch-tmpfs.yml	optional
+# The lite (CPU-only, cloud-ASR) overlay. `optional` because most installs are full
+# deployments and an older release genuinely does not carry this file — but it is NOT
+# cosmetic: before issue #680 this file was in no manifest at all AND had no branch in
+# get_compose_files(), so `DEPLOYMENT_MODE=lite` was read in four places and could never
+# actually select anything. scripts/release-tests/test-lite-mode.sh documents that gap in
+# its own header and hand-assembles the chain because no shipped command could produce it.
+# It is also what makes the arm64 default reachable: the full/CUDA image publishes no
+# arm64 manifest (see arm64_deployment_preflight in opentranscribe.sh), so on arm64 this
+# overlay is the only thing there is to run.
+docker-compose.lite.yml	optional
 
 # --- Reverse proxy -------------------------------------------------------------
 nginx/site.conf.template

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -598,7 +598,8 @@ aux-file record.
   that list** — `assert_platform_table_matches_scan_components` checks it on every run, because
   a component in one table and not the other is either unscanned or built with an empty platform
   list. Guarded by `scripts/tests/test-scan-not-a-pass.sh` (19 cases) and
-  `scripts/tests/test-publish-platforms.sh` (11 assertions, each with an observed red state),
+  `scripts/tests/test-publish-platforms.sh` (19 sections, each with an observed red state —
+  it prints its own assertion count, don't transcribe one here),
   both offline, both wired as pre-commit hooks.
   ⚠️ `test-scan-not-a-pass.sh` uses **`bogus`** as its "unknown component" placeholder. It used
   to use `lite` — which stopped being unknown the moment #680 made it real, at which point those
@@ -612,6 +613,36 @@ aux-file record.
   `scripts/release/40-build.sh`'s baked-version check runs against. It also runs
   `push-security-reports.sh` when `PUSH_SECURITY_REPORTS=true`, which **git-commits and pushes**
   `security-reports/` to whatever branch is checked out.
+
+### `80-publish.sh`'s manifest gate: two document shapes, three exit codes
+
+⚠️ **`imagetools inspect --raw` returns two different documents and they carry different
+facts.** Measured against the published `opentranscribe-backend:v0.4.1`:
+
+| ref | shape | declares platforms? | has layers? |
+|---|---|---|---|
+| `repo:tag` (published tag) | INDEX — `manifests[]` | ✅ (plus `unknown/unknown` attestations) | ❌ — per-entry `size` is the **~2.4 KB manifest blob** |
+| `repo@<digest>` | MANIFEST — `config`+`layers` | ❌ (architecture lives in the config blob) | ✅ |
+
+So the platform-set checks read the **index** and the size/layer comparison must read the
+**per-platform manifest** — `resolve-digest` pulls the digest out of the index and the stage
+re-inspects `repo@<digest>`. Feeding the index straight to `check-ratio` reports
+`sizes a=0 b=0 ratio=inf` and fails **every time, even comparing an index against itself**;
+that is how the gate shipped for its first revision, so it would have blocked the very
+release it exists to protect. The equivalence check is keyed on **how many platforms the
+index declares**, never on how many capability leg tags exist — gating on legs silently
+exempted `frontend`/`docs`, whose 1.25 bound `releasing.md` documents.
+
+**`scripts/lib/manifest_platform_check.py` exits 0 / 1 / 3**, and the split is the same rule
+as `security-scan.sh`'s 1-vs-2 (#681): `1` = checked and WRONG, `3` = **could not check**
+(malformed/empty/absent JSON, or a correct document of the wrong shape). Both fail the
+stage; only `1` is a claim about the artifact. An uncaught `JSONDecodeError` would have
+exited 1 and read, in the log, exactly like a real platform mismatch.
+
+`85-smoke.sh` asserts CAPABILITY (`torch.version.cuda` empty for lite, non-empty for full),
+and **must capture the `docker run` exit status**: an image that cannot execute at all prints
+an empty string too, so discarding rc turns "could not check" into "CPU-only confirmed" — the
+#680 failure mode with a green tick, in the stage whose job is to catch it.
 
 ## DESTRUCTIVE — never run casually
 

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -550,11 +550,35 @@ aux-file record.
 
 ## docker-build-push.sh
 
-- **ALWAYS `USE_REMOTE_BUILDER=true`.** It defaults to `false` and `PLATFORMS` defaults to
-  `linux/amd64,linux/arm64`, so without it ARM64 builds under QEMU — 2–3 h instead of 15–30 min.
+- **The tag grammar, and its ONE home** (issue #680). Capability lives in the **repository** — a
+  manifest index cannot span repos — and is **restated in the tag**:
+
+  | repo | capability | legs built | index | `:latest` |
+  |---|---|---|---|---|
+  | `opentranscribe-backend` | `cuda` | `vX.Y.Z-cuda-amd64` | `vX.Y.Z` | digest-copy of the index |
+  | `opentranscribe-backend-lite` | `cpu` | `vX.Y.Z-cpu-amd64`, `vX.Y.Z-cpu-arm64` | `vX.Y.Z` | digest-copy |
+  | `opentranscribe-frontend` / `-docs` | `multiarch` | (no cap legs) | `vX.Y.Z` | digest-copy |
+  | `opentranscribe-backend` (`:blackwell`) | `blackwell` | `vX.Y.Z-blackwell-arm64` | — | `:blackwell` |
+
+  `vX.Y.Z-cuda-arm64` is **reserved and not built**: no aarch64 CUDA torch wheel at the pinned
+  version, `onnxruntime-gpu` has zero aarch64 wheels, and diar-native publishes no CUDA arm64
+  sidecar. Do not transcribe this table anywhere else — ask the script:
+  **`./scripts/docker-build-push.sh list-platforms`** prints `component<TAB>capability<TAB>platforms`
+  and is the single source of truth (`COMPONENT_PLATFORMS` / `COMPONENT_CAPABILITY`).
+  `scripts/release/80-publish.sh` and `40-build.sh` derive from it rather than hardcoding arches.
+- **`PLATFORMS` is now an explicit OVERRIDE, not a default.** It used to default to
+  `linux/amd64,linux/arm64` for **every** component, which is the mechanism issue #680 names for
+  how a degraded arm64 backend got published beside a good amd64 one under one tag with nothing
+  to notice. Unset, each component builds only its own declared platforms; set, it forces every
+  component being built onto that list (`PLATFORMS=linux/amd64 $0 backend` for a quick
+  single-arch build).
+- **ALWAYS `USE_REMOTE_BUILDER=true`** when a build includes `linux/arm64` (today: `lite`).
+  It defaults to `false`, and without it arm64 builds under QEMU — 2–3 h instead of 15–30 min.
   It hard-exits if the `opentranscribe-multiarch` builder is missing (`setup-remote-builder.sh setup`).
-- `SKIP_SECURITY_SCAN=true` for quick iteration; `PLATFORMS=linux/amd64` for single-arch (no remote
-  builder needed); `$0 auto` builds only git-changed components.
+- `SKIP_SECURITY_SCAN=true` for quick iteration; `$0 lite` / `$0 backend` for one component;
+  `$0 auto` builds only git-changed components (`backend` changes build **both** backend and lite,
+  since both come from `backend/`). `blackwell` is built **only on request** — never by
+  `all`/`auto`, and never published.
 - ⚠️ **"Scanned, findings tolerable" and "never scanned" are DIFFERENT outcomes and must stay
   that way** (issue #681). `security-scan.sh` exits **1** for findings and **2** for could-not-scan
   (unknown component, image unobtainable, a sub-scan that died without recording a verdict);
@@ -565,15 +589,29 @@ aux-file record.
   state, since it was in `BUILT_COMPONENTS` with a `security-scan.sh` arm but no registry-pull
   branch, so the default path "scanned" an image it never fetched.
 - **The scannable component list has exactly one home**: the `SCAN_COMPONENT_*` tables in
-  `security-scan.sh`, exposed as `./scripts/security-scan.sh list-components`.
-  `docker-build-push.sh` validates `BUILT_COMPONENTS` against that before pulling anything, and
-  both its pull dispatches now have a failing `*)`. Adding a component (e.g. `lite`, issue #667)
-  means adding it there; forgetting is now loud instead of a green run over an unscanned
-  published image. Guarded by `scripts/tests/test-scan-not-a-pass.sh` (19 cases, 0.4 s, no
-  Docker/network), wired as the `scan-not-a-pass` pre-commit hook.
-- **Every path ends in `buildx --push` — there is no local-only mode.** `:latest` and `:vX.Y.Z` hit
-  Docker Hub the instant the build finishes, and it then runs `push-security-reports.sh`, which
-  **git-commits and pushes** `security-reports/` to whatever branch is checked out.
+  `security-scan.sh`, exposed as `./scripts/security-scan.sh list-components` (and
+  `list-repos`, `component<TAB>repo`, which `scripts/release/50-scan.sh` derives its
+  component→repo map from). `docker-build-push.sh` validates `BUILT_COMPONENTS` against that
+  before pulling anything, and both its pull dispatches have a failing `*)`. Adding a component
+  means adding it there; forgetting is loud instead of a green run over an unscanned published
+  image. `lite` and `blackwell` are in it as of #680. **The platform table's key set must EQUAL
+  that list** — `assert_platform_table_matches_scan_components` checks it on every run, because
+  a component in one table and not the other is either unscanned or built with an empty platform
+  list. Guarded by `scripts/tests/test-scan-not-a-pass.sh` (19 cases) and
+  `scripts/tests/test-publish-platforms.sh` (11 assertions, each with an observed red state),
+  both offline, both wired as pre-commit hooks.
+  ⚠️ `test-scan-not-a-pass.sh` uses **`bogus`** as its "unknown component" placeholder. It used
+  to use `lite` — which stopped being unknown the moment #680 made it real, at which point those
+  cases started a REAL Trivy scan and hung. If you ever make `bogus` a component, rename it there.
+- **`BUILD_MODE=local` is the only path that does not push.** Every other path ends in
+  `buildx --push`: `:vX.Y.Z` (and `:latest`, unless `PUSH_LATEST=false`) hit Docker Hub the
+  instant the build finishes. Capability-bearing components push one **leg** per architecture and
+  then assemble the index with `buildx imagetools create`, so the index provably contains exactly
+  those legs. In `local` mode there is nothing in a registry to assemble from, so index assembly
+  is skipped and the single host-arch build is additionally tagged `repo:vX.Y.Z` — which is what
+  `scripts/release/40-build.sh`'s baked-version check runs against. It also runs
+  `push-security-reports.sh` when `PUSH_SECURITY_REPORTS=true`, which **git-commits and pushes**
+  `security-reports/` to whatever branch is checked out.
 
 ## DESTRUCTIVE — never run casually
 

--- a/scripts/docker-build-push.sh
+++ b/scripts/docker-build-push.sh
@@ -14,6 +14,7 @@ NC='\033[0m' # No Color
 # Configuration
 DOCKERHUB_USERNAME="${DOCKERHUB_USERNAME:-davidamacey}"
 REPO_BACKEND="${DOCKERHUB_USERNAME}/opentranscribe-backend"
+REPO_BACKEND_LITE="${DOCKERHUB_USERNAME}/opentranscribe-backend-lite"
 REPO_FRONTEND="${DOCKERHUB_USERNAME}/opentranscribe-frontend"
 REPO_DOCS="${DOCKERHUB_USERNAME}/opentranscribe-docs"
 
@@ -21,8 +22,47 @@ REPO_DOCS="${DOCKERHUB_USERNAME}/opentranscribe-docs"
 COMMIT_SHA=$(git rev-parse --short HEAD)
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
-# Default to building both platforms
-PLATFORMS="linux/amd64,linux/arm64"
+# --- Per-component platform + capability table (issue #680) -----------------
+#
+# Capability lives in the REPOSITORY (opentranscribe-backend is CUDA,
+# opentranscribe-backend-lite is CPU), and is RESTATED in the tag as the
+# `-<cap>-<arch>` leg (e.g. v0.5.0-cuda-amd64, v0.5.0-cpu-arm64). The vX.Y.Z tag
+# on each repo is a multi-arch INDEX assembled from that repo's own legs only —
+# never mixed across repos/capabilities.
+#
+# v0.5.0 ships exactly THREE artifacts: backend cuda-amd64, lite cpu-amd64,
+# lite cpu-arm64. A `cuda-arm64` backend leg is RESERVED in this table (empty
+# platform list) but not built — diar-native publishes no CUDA arm64 artifact
+# (see backend/Dockerfile.prod's diar-native-bin-arm64 stage). blackwell is
+# arm64-only, GPU-generation-gated (SM_121+, not host-arch-gated — see
+# build_backend_blackwell), and is never built by `all`/`auto`.
+#
+# `frontend` and `docs` carry no GPU/CPU capability distinction, so their
+# "capability" is the literal string `multiarch` and they get no `-<cap>-<arch>`
+# leg tags — they keep the historical single multi-platform `buildx build --push`
+# under one tag, exactly as before this table existed.
+declare -A COMPONENT_CAPABILITY=(
+    [backend]="cuda"
+    [lite]="cpu"
+    [frontend]="multiarch"
+    [docs]="multiarch"
+    [blackwell]="blackwell"
+)
+declare -A COMPONENT_PLATFORMS=(
+    [backend]="linux/amd64"
+    [lite]="linux/amd64,linux/arm64"
+    [frontend]="linux/amd64,linux/arm64"
+    [docs]="linux/amd64,linux/arm64"
+    [blackwell]="linux/arm64"
+)
+
+# PLATFORMS is an explicit OVERRIDE, not the default any more (issue #680 —
+# the old unconditional "linux/amd64,linux/arm64" default is exactly what let a
+# broken/degraded arm64 backend leg publish under the same tag as a good amd64
+# one with nothing to notice). Leave unset to use COMPONENT_PLATFORMS above;
+# set it to force every component being built onto the same platform list
+# (e.g. `PLATFORMS=linux/amd64 $0 backend` for a quick single-arch build).
+PLATFORMS="${PLATFORMS:-}"
 BUILD_TARGET="${1:-all}"
 
 # Remote builder configuration
@@ -200,6 +240,63 @@ assert_components_scannable() {
     return "${rc}"
 }
 
+# The COMPONENT_PLATFORMS/COMPONENT_CAPABILITY table's key set must exactly
+# equal security-scan.sh's scannable-component list — the same drift #681
+# guarded against (a component nobody scans) has a mirror-image failure here
+# (a component nobody knows the platforms for). Checked eagerly, once, so a
+# component added to one table and forgotten in the other is a loud failure
+# rather than a component silently built with an empty platform list.
+assert_platform_table_matches_scan_components() {
+    if [ ! -f "./scripts/security-scan.sh" ]; then
+        print_error "scripts/security-scan.sh is missing — cannot verify the platform table"
+        return 1
+    fi
+
+    local scan_known=()
+    mapfile -t scan_known < <(./scripts/security-scan.sh list-components 2>/dev/null | sort)
+    local table_known=()
+    mapfile -t table_known < <(printf '%s\n' "${!COMPONENT_PLATFORMS[@]}" | sort)
+
+    if [ "${scan_known[*]}" != "${table_known[*]}" ]; then
+        print_error "COMPONENT_PLATFORMS key set != security-scan.sh list-components"
+        print_error "  security-scan.sh: ${scan_known[*]}"
+        print_error "  docker-build-push.sh table: ${table_known[*]}"
+        return 1
+    fi
+    return 0
+}
+
+# component<TAB>capability<TAB>platforms, one per line, sorted by component.
+# The single home for "what does this script build, in what capability, for
+# which architectures" — mirrors `list-components` in security-scan.sh.
+list_platforms() {
+    local component
+    for component in $(printf '%s\n' "${!COMPONENT_PLATFORMS[@]}" | sort); do
+        printf '%s\t%s\t%s\n' \
+            "${component}" \
+            "${COMPONENT_CAPABILITY[${component}]}" \
+            "${COMPONENT_PLATFORMS[${component}]}"
+    done
+}
+
+# The union of platforms that will actually be touched by a given BUILD_TARGET,
+# used ONLY for the QEMU-emulation advisory messages (never for build dispatch
+# itself — each build_* function asks build_platforms() for its OWN component).
+effective_platforms_for_target() {
+    local target="$1"
+    local components=()
+    case "${target}" in
+        backend|lite|frontend|docs|blackwell) components=("${target}") ;;
+        all|auto) components=(backend lite frontend docs) ;;
+        *) return 0 ;;
+    esac
+    local component seen=""
+    for component in "${components[@]}"; do
+        seen="${seen},$(build_platforms "${component}")"
+    done
+    echo "${seen}"
+}
+
 # Function to run security scan if enabled.
 #
 # Returns 0 (proceed), 1 (findings the caller's policy refuses to tolerate), or
@@ -257,14 +354,25 @@ run_security_scan() {
 # build functions cannot drift apart on it.
 # ---------------------------------------------------------------------------
 
-# Platforms for this run. Local mode is host-arch only: `--load` cannot export a
-# multi-arch manifest into the local image store.
+# Platforms for this run, keyed by component. Local mode is host-arch only:
+# `--load` cannot export a multi-arch manifest into the local image store.
+# PLATFORMS (if the caller set it) is an explicit override applied to every
+# component; otherwise each component's own COMPONENT_PLATFORMS entry is used.
 build_platforms() {
+    local component="$1"
     if [ "${BUILD_MODE}" = "local" ]; then
         docker version --format '{{.Server.Os}}/{{.Server.Arch}}' 2>/dev/null || echo "linux/amd64"
-    else
+    elif [ -n "${PLATFORMS}" ]; then
         echo "${PLATFORMS}"
+    else
+        echo "${COMPONENT_PLATFORMS[${component}]:-}"
     fi
+}
+
+# One platform per element, for components that build a leg per architecture.
+build_platform_list() {
+    local component="$1"
+    build_platforms "${component}" | tr ',' '\n'
 }
 
 # --load (keep it here) vs --push (send it to Docker Hub).
@@ -276,8 +384,10 @@ build_output_flag() {
     fi
 }
 
-# Tag arguments for a repo: always :vX.Y.Z, plus :latest unless the caller is
-# going to move :latest by digest afterwards.
+# Tag arguments for a repo with NO per-arch capability legs (frontend, docs):
+# always :vX.Y.Z, plus :latest unless the caller is going to move :latest by
+# digest afterwards. This is the historical single multi-platform-build/single-tag
+# shape, unchanged by the #680 capability-tag grammar.
 build_tag_args() {
     local repo="$1"
     local args=("--tag" "${repo}:${VERSION_FULL}")
@@ -285,6 +395,45 @@ build_tag_args() {
         args+=("--tag" "${repo}:latest")
     fi
     printf '%s\n' "${args[@]}"
+}
+
+# The single-arch LEG tag for a capability-bearing component (backend, lite,
+# blackwell): repo:vX.Y.Z-<cap>-<arch>. Never carries :latest — :latest only
+# ever moves on the ASSEMBLED INDEX (assemble_capability_index below), so it is
+# always a multi-platform manifest, never accidentally a single-arch one.
+build_leg_tag() {
+    local repo="$1" cap="$2" arch="$3"
+    echo "${repo}:${VERSION_FULL}-${cap}-${arch}"
+}
+
+# Assemble the vX.Y.Z (and, unless PUSH_LATEST=false, :latest) index for a
+# capability-bearing repo from the leg tags that were just pushed, using
+# `buildx imagetools create` — a manifest-list copy by digest, so the index
+# provably contains exactly those legs and nothing rebuilt or re-pushed.
+# Never call this with legs from more than one repo/capability: mixing a CUDA
+# backend leg into the lite index (or vice versa) is exactly the class of bug
+# issue #680 exists to prevent.
+assemble_capability_index() {
+    local repo="$1"
+    shift
+    local legs=("$@")
+
+    if [ "${BUILD_MODE}" = "local" ]; then
+        print_info "local mode — skipping index assembly for ${repo} (nothing was pushed to assemble from)"
+        return 0
+    fi
+    if [ ${#legs[@]} -eq 0 ]; then
+        print_error "assemble_capability_index: no legs given for ${repo}"
+        return 1
+    fi
+
+    print_info "Assembling ${repo}:${VERSION_FULL} from: ${legs[*]}"
+    docker buildx imagetools create --tag "${repo}:${VERSION_FULL}" "${legs[@]}"
+
+    if [ "${PUSH_LATEST}" = "true" ]; then
+        print_info "Assembling ${repo}:latest from: ${legs[*]}"
+        docker buildx imagetools create --tag "${repo}:latest" "${legs[@]}"
+    fi
 }
 
 # OCI provenance labels. Safe on every image — labels need no ARG declaration,
@@ -317,8 +466,8 @@ build_backend_identity_args() {
 # Announce what a build is about to do, and short-circuit under DRY_RUN.
 # Returns 1 when the caller should skip the actual build.
 build_announce() {
-    local what="$1"
-    print_info "${what}: mode=${BUILD_MODE} platforms=$(build_platforms) version=${VERSION_FULL}"
+    local what="$1" component="$2"
+    print_info "${what}: mode=${BUILD_MODE} platforms=$(build_platforms "${component}") version=${VERSION_FULL}"
     if [ "${BUILD_MODE}" = "local" ]; then
         print_info "  local mode — loading into the local daemon, pushing NOTHING"
     fi
@@ -329,62 +478,138 @@ build_announce() {
     return 0
 }
 
-# Function to build and push Blackwell backend image (ARM64 only)
-# Uses Dockerfile.blackwell with SM_121 compatibility patches for DGX Spark / GB10
-build_backend_blackwell() {
-    print_info "Building Blackwell backend image..."
-    print_info "Platform: linux/arm64 (DGX Spark / Blackwell is ARM64-only)"
-    print_info "Version: ${VERSION_FULL}"
-    print_info "Tags: blackwell, blackwell-${VERSION_FULL}"
+# Build one architecture LEG of a capability-bearing component (backend, lite,
+# blackwell) and tag it repo:vX.Y.Z-<cap>-<arch>. Returns the leg tag on stdout
+# so callers can collect legs for assemble_capability_index. `local` mode
+# --loads instead of --pushes, so imagetools (which reads from the registry)
+# has nothing to assemble from — callers must skip assembly in that mode,
+# which assemble_capability_index already does. Because that leaves NO
+# repo:vX.Y.Z tag in the local daemon, local mode ALSO tags the single build
+# repo:vX.Y.Z directly — this is what the release flow's 40-build.sh baked-
+# version check (`docker run repo:VERSION`) depends on; local mode is single-
+# platform by construction (build_platforms() collapses to the host arch), so
+# there is exactly one leg and tagging it twice is unambiguous.
+build_one_leg() {
+    local component="$1" repo="$2" dockerfile_dir="$3" dockerfile="$4" arch="$5"
+    shift 5
+    local extra_build_args=("$@")
 
-    cd backend
+    local cap="${COMPONENT_CAPABILITY[${component}]}"
+    local leg_tag
+    leg_tag="$(build_leg_tag "${repo}" "${cap}" "${arch#linux/}")"
 
-    docker buildx build \
-        --platform "linux/arm64" \
-        --file Dockerfile.blackwell \
-        --build-arg APP_VERSION="${VERSION_FULL}" \
-        --tag "${REPO_BACKEND}:blackwell" \
-        --tag "${REPO_BACKEND}:blackwell-${VERSION_FULL}" \
-        ${CACHE_FLAG} \
-        --push \
-        .
+    local extra_tags=()
+    if [ "${BUILD_MODE}" = "local" ]; then
+        extra_tags=("--tag" "${repo}:${VERSION_FULL}")
+    fi
 
-    cd ..
+    local identity_args
+    mapfile -t identity_args < <(build_identity_labels)
 
-    print_success "Blackwell backend image built and pushed successfully"
-    print_info "Tags pushed:"
-    print_info "  - ${REPO_BACKEND}:blackwell"
-    print_info "  - ${REPO_BACKEND}:blackwell-${VERSION_FULL}"
+    (
+        cd "${dockerfile_dir}"
+        docker buildx build \
+            --platform "${arch}" \
+            --file "${dockerfile}" \
+            "${identity_args[@]}" \
+            "${extra_build_args[@]}" \
+            --tag "${leg_tag}" \
+            "${extra_tags[@]}" \
+            ${CACHE_FLAG} \
+            "$(build_output_flag)" \
+            .
+    ) >&2
+
+    echo "${leg_tag}"
 }
 
-# Function to build and push backend (no scan - scan runs separately)
-build_backend() {
-    build_announce "Building backend image" || return 0
+# Function to build and push Blackwell backend image.
+# Uses Dockerfile.blackwell with SM_121+ compatibility patches for DGX Spark / GB10 /
+# RTX 50-series. ⚠️ Blackwell is a GPU GENERATION (compute capability sm_120/sm_121),
+# NOT a host architecture — B200/GB200 are x86_64, GB10/DGX-Spark and RTX 50-series
+# laptops/desktops are the arm64/amd64 split respectively. This repo only ships the
+# arm64 leg (DGX Spark); an amd64 Blackwell leg is out of scope here (see backend/
+# scripts/blackwell_patches.py, which gates on compute capability, never on arch).
+# Built ONLY on request — never by `all`/`auto` — and never scanned by that path either.
+build_backend_blackwell() {
+    local component="blackwell"
+    build_announce "Building Blackwell backend image" "${component}" || return 0
 
-    local tag_args identity_args
-    mapfile -t tag_args < <(build_tag_args "${REPO_BACKEND}")
+    local platform
+    platform="$(build_platforms "${component}")"
+
+    local identity_args
     mapfile -t identity_args < <(build_backend_identity_args; build_identity_labels)
 
     cd backend
 
     docker buildx build \
-        --platform "$(build_platforms)" \
-        --file Dockerfile.prod \
+        --platform "${platform}" \
+        --file Dockerfile.blackwell \
         "${identity_args[@]}" \
-        "${tag_args[@]}" \
+        --tag "${REPO_BACKEND}:blackwell" \
+        --tag "${REPO_BACKEND}:${VERSION_FULL}-blackwell-${platform#linux/}" \
         ${CACHE_FLAG} \
         "$(build_output_flag)" \
         .
 
     cd ..
 
+    BUILT_COMPONENTS+=("${component}")
+    print_success "Blackwell backend image built (${BUILD_MODE} mode)"
+    print_info "Tags:"
+    print_info "  - ${REPO_BACKEND}:blackwell"
+    print_info "  - ${REPO_BACKEND}:${VERSION_FULL}-blackwell-${platform#linux/}"
+}
+
+# Function to build and push the full/CUDA backend (no scan - scan runs separately).
+# v0.5.0 ships this as amd64-only (see backend/Dockerfile.prod); the cuda-arm64 leg
+# is reserved in COMPONENT_PLATFORMS/COMPONENT_CAPABILITY but not built.
+build_backend() {
+    local component="backend"
+    build_announce "Building backend image" "${component}" || return 0
+
+    local identity_build_args
+    mapfile -t identity_build_args < <(build_backend_identity_args)
+
+    local legs=()
+    local arch
+    while IFS= read -r arch; do
+        [ -n "${arch}" ] || continue
+        legs+=("$(build_one_leg "${component}" "${REPO_BACKEND}" "backend" "Dockerfile.prod" "${arch}" "${identity_build_args[@]}")")
+    done < <(build_platform_list "${component}")
+
+    assemble_capability_index "${REPO_BACKEND}" "${legs[@]}"
+
     print_success "Backend image built (${BUILD_MODE} mode)"
-    printf '%s\n' "${tag_args[@]}" | grep -v '^--tag$' | sed 's/^/  - /'
+    printf '%s\n' "${legs[@]}" | sed 's/^/  - /'
+}
+
+# Function to build and push the lite/CPU-only backend (no scan - scan runs separately).
+build_backend_lite() {
+    local component="lite"
+    build_announce "Building lite backend image" "${component}" || return 0
+
+    local identity_build_args
+    mapfile -t identity_build_args < <(build_backend_identity_args)
+
+    local legs=()
+    local arch
+    while IFS= read -r arch; do
+        [ -n "${arch}" ] || continue
+        legs+=("$(build_one_leg "${component}" "${REPO_BACKEND_LITE}" "backend" "Dockerfile.lite" "${arch}" "${identity_build_args[@]}")")
+    done < <(build_platform_list "${component}")
+
+    assemble_capability_index "${REPO_BACKEND_LITE}" "${legs[@]}"
+
+    print_success "Lite backend image built (${BUILD_MODE} mode)"
+    printf '%s\n' "${legs[@]}" | sed 's/^/  - /'
 }
 
 # Function to build and push frontend (no scan - scan runs separately)
 build_frontend() {
-    build_announce "Building frontend image" || return 0
+    local component="frontend"
+    build_announce "Building frontend image" "${component}" || return 0
 
     local tag_args identity_args
     mapfile -t tag_args < <(build_tag_args "${REPO_FRONTEND}")
@@ -393,7 +618,7 @@ build_frontend() {
     cd frontend
 
     docker buildx build \
-        --platform "$(build_platforms)" \
+        --platform "$(build_platforms "${component}")" \
         --file Dockerfile.prod \
         "${identity_args[@]}" \
         "${tag_args[@]}" \
@@ -409,7 +634,8 @@ build_frontend() {
 
 # Function to build and push docs (nginx:alpine + Docusaurus static build)
 build_docs() {
-    build_announce "Building docs image" || return 0
+    local component="docs"
+    build_announce "Building docs image" "${component}" || return 0
 
     local tag_args identity_args
     mapfile -t tag_args < <(build_tag_args "${REPO_DOCS}")
@@ -424,7 +650,7 @@ build_docs() {
     #
     # DOCS_BASE_URL keeps internal links correct when proxied at /docs/.
     docker buildx build \
-        --platform "$(build_platforms)" \
+        --platform "$(build_platforms "${component}")" \
         --file Dockerfile \
         --build-arg DOCS_BASE_URL=/docs/ \
         --build-arg OT_VERSION="${VERSION_FULL}" \
@@ -535,6 +761,7 @@ run_parallel_scans() {
         for component in "${components[@]}"; do
             case "$component" in
                 backend)  return_early_if_missing "${REPO_BACKEND}:${VERSION_FULL}" || return 1 ;;
+                lite)     return_early_if_missing "${REPO_BACKEND_LITE}:${VERSION_FULL}" || return 1 ;;
                 frontend) return_early_if_missing "${REPO_FRONTEND}:${VERSION_FULL}" || return 1 ;;
                 docs)     return_early_if_missing "${REPO_DOCS}:${VERSION_FULL}" || return 1 ;;
                 *)
@@ -556,6 +783,7 @@ run_parallel_scans() {
             local pull_repo
             case "$component" in
                 backend)  pull_repo="${REPO_BACKEND}" ;;
+                lite)     pull_repo="${REPO_BACKEND_LITE}" ;;
                 frontend) pull_repo="${REPO_FRONTEND}" ;;
                 docs)     pull_repo="${REPO_DOCS}" ;;
                 *)
@@ -737,20 +965,30 @@ Usage: $0 [OPTION]
 Build and push Docker images to Docker Hub
 
 Options:
-    backend     Build and push only backend image
-    frontend    Build and push only frontend image
-    docs        Build and push only docs image (nginx:alpine + Docusaurus static)
-    blackwell   Build and push Blackwell backend image (ARM64, :blackwell tag)
-    all         Build and push all three images (default)
-    auto        Auto-detect changes and build only changed components
-    scan        Security scan only (pull latest images, scan, push reports)
-    cleanup     Delete old partial version tags (vX, vX.X) from Docker Hub
-    help        Show this help message
+    backend        Build and push only the full/CUDA backend image (amd64-only for now)
+    lite           Build and push only the lite/CPU backend image (amd64 + arm64)
+    frontend       Build and push only frontend image
+    docs           Build and push only docs image (nginx:alpine + Docusaurus static)
+    blackwell      Build and push Blackwell backend image (arm64, GPU-generation-gated,
+                   never included by all/auto — see build_backend_blackwell)
+    all            Build and push backend, lite, frontend, and docs (default)
+    auto           Auto-detect changes and build only changed components
+    scan           Security scan only (pull latest images, scan, push reports)
+    cleanup        Delete old partial version tags (vX, vX.X) from Docker Hub
+    list-platforms Print component<TAB>capability<TAB>platforms and exit (no Docker needed)
+    help           Show this help message
+
+Tag grammar (issue #680): capability lives in the REPOSITORY (backend=CUDA,
+backend-lite=CPU), restated in the tag as a leg — vX.Y.Z-<cap>-<arch> — with
+vX.Y.Z itself assembled as a multi-arch INDEX from that repo's own legs only.
+:latest is a digest-copy of the index, never an independent build.
 
 Environment Variables:
     VERSION                   Semantic version (e.g., v1.2.3) - overrides VERSION file
     DOCKERHUB_USERNAME        Docker Hub username (default: davidamacey)
-    PLATFORMS                 Target platforms (default: linux/amd64,linux/arm64)
+    PLATFORMS                 Explicit OVERRIDE of the per-component platform table
+                               (see `$0 list-platforms`) — unset by default, so each
+                               component builds only its declared platforms.
     USE_REMOTE_BUILDER        Use remote ARM64 builder for faster builds (default: false)
     REMOTE_BUILDER_NAME       Remote builder name (default: opentranscribe-multiarch)
     NO_CACHE                  Build without cache (default: false)
@@ -817,6 +1055,18 @@ EOF
 
 # Main script
 main() {
+    # list-platforms needs no Docker, no version, and no login — it just prints
+    # the table, mirroring `security-scan.sh list-components`.
+    if [ "${BUILD_TARGET}" = "list-platforms" ]; then
+        list_platforms
+        exit 0
+    fi
+
+    if ! assert_platform_table_matches_scan_components; then
+        print_error "Refusing to continue: the platform table and the scan-component list disagree"
+        exit 1
+    fi
+
     # Version management - read from VERSION file or environment variable
     if [ -n "${VERSION}" ]; then
         # Use VERSION from environment variable
@@ -892,7 +1142,7 @@ main() {
             print_info "Using existing local buildx builder (with QEMU emulation)"
             docker buildx use "${DEFAULT_BUILDER_NAME}"
         fi
-        if [[ "${PLATFORMS}" == *"arm64"* ]]; then
+        if [[ "$(effective_platforms_for_target "${BUILD_TARGET}")" == *"arm64"* ]]; then
             print_warning "Building ARM64 with QEMU emulation (slow)"
             print_info "For faster builds, set up remote builder: ./scripts/setup-remote-builder.sh"
             print_info "Then use: USE_REMOTE_BUILDER=true $0"
@@ -908,6 +1158,11 @@ main() {
             build_backend
             BUILT_COMPONENTS+=("backend")
             ;;
+        lite)
+            print_info "Building lite backend only..."
+            build_backend_lite
+            BUILT_COMPONENTS+=("lite")
+            ;;
         frontend)
             print_info "Building frontend only..."
             build_frontend
@@ -919,22 +1174,26 @@ main() {
             BUILT_COMPONENTS+=("docs")
             ;;
         blackwell)
-            print_info "Building Blackwell backend only (ARM64)..."
+            # build_backend_blackwell appends to BUILT_COMPONENTS itself and is
+            # NEVER reached from all/auto — built and scanned only on request.
+            print_info "Building Blackwell backend only (arm64, GPU-generation-gated)..."
             build_backend_blackwell
             ;;
         all)
-            print_info "Building backend, frontend, and docs..."
+            print_info "Building backend, lite, frontend, and docs..."
             build_backend
+            build_backend_lite
             build_frontend
             build_docs
-            BUILT_COMPONENTS+=("backend" "frontend" "docs")
+            BUILT_COMPONENTS+=("backend" "lite" "frontend" "docs")
             ;;
         auto)
             print_info "Auto-detecting changes..."
 
             if detect_changes "backend"; then
                 build_backend
-                BUILT_COMPONENTS+=("backend")
+                build_backend_lite
+                BUILT_COMPONENTS+=("backend" "lite")
             fi
 
             if detect_changes "frontend"; then
@@ -1019,6 +1278,10 @@ main() {
         print_info "Backend:"
         _tags "${REPO_BACKEND}"
     fi
+    if [ "${BUILD_TARGET}" = "lite" ] || [ "${BUILD_TARGET}" = "all" ] || [ "${BUILD_TARGET}" = "auto" ]; then
+        print_info "Lite backend:"
+        _tags "${REPO_BACKEND_LITE}"
+    fi
     if [ "${BUILD_TARGET}" = "frontend" ] || [ "${BUILD_TARGET}" = "all" ] || [ "${BUILD_TARGET}" = "auto" ]; then
         print_info "Frontend:"
         _tags "${REPO_FRONTEND}"
@@ -1044,8 +1307,8 @@ main() {
     print_success "✅ Default builder restored. Local development builds will work normally."
 
     # Show build performance info if using emulation. Local mode builds host-arch
-    # only, so QEMU is never involved there regardless of what PLATFORMS says.
-    if [ "${BUILD_MODE}" != "local" ] && [ "${USE_REMOTE_BUILDER}" = "false" ] && [[ "${PLATFORMS}" == *"arm64"* ]]; then
+    # only, so QEMU is never involved there regardless of the effective platform set.
+    if [ "${BUILD_MODE}" != "local" ] && [ "${USE_REMOTE_BUILDER}" = "false" ] && [[ "$(effective_platforms_for_target "${BUILD_TARGET}")" == *"arm64"* ]]; then
         print_info ""
         print_info "⚡ Performance Tip:"
         print_info "You used QEMU emulation for ARM64 builds (10-20x slower than native)"

--- a/scripts/lib/manifest_platform_check.py
+++ b/scripts/lib/manifest_platform_check.py
@@ -29,6 +29,27 @@ Three checks, matching issue #680's "suggested fix" #2 and this repo's tag gramm
 (provenance/SBOM), not real image platforms, and must be ignored by every function here
 — counting them as a "platform" would make an index look like it declares more
 architectures than it does.
+
+TWO DOCUMENT SHAPES, AND THEY CARRY DIFFERENT FACTS. `docker buildx imagetools inspect
+--raw` returns either:
+
+  * an INDEX  — `{"manifests": [{"platform": {...}, "digest": ..., "size": ...}, ...]}`.
+    It declares platforms. It carries NO `layers`, and its per-entry `size` is the size
+    of the manifest BLOB (~2 KB), not of the image.
+  * a MANIFEST — `{"config": {...}, "layers": [...]}`. It carries layers and therefore a
+    real image size. It declares NO platform (that lives in the config blob).
+
+So a size/layer comparison MUST be fed the per-platform manifest (resolve its digest out
+of the index with `resolve-digest`, then inspect `repo@<digest>`), never the index. An
+earlier revision fed the index straight into `check-ratio`; measured against the real
+published `opentranscribe-backend:v0.4.1` index that reports `sizes a=0 b=0 ratio=inf`
+and fails EVERY time, even comparing an index against itself.
+
+EXIT CODES ARE THREE-VALUED ON PURPOSE. This repo's standing rule (issue #681) is that
+"checked, result tolerable" and "never checked" must be different outcomes; the same
+applies here. 0 = verified, 1 = verified and WRONG, 3 = could not check (malformed JSON,
+a shape that carries none of the facts asked for). Both 1 and 3 are failures to the
+caller — but only 1 is a statement about the artifact.
 """
 
 from __future__ import annotations
@@ -36,12 +57,47 @@ from __future__ import annotations
 import json
 import sys
 
+EXIT_OK = 0
+EXIT_MISMATCH = 1
+EXIT_MISUSE = 2
+EXIT_CANNOT_CHECK = 3
+
+
+class CannotCheck(Exception):
+    """The document does not carry the fact being asked for.
+
+    Distinct from "the fact is wrong": raised for a malformed/unreadable document, or for
+    a correct document of the wrong SHAPE (an index has no layers; a single manifest has
+    no platform). Never swallowed into a verdict — see the module docstring.
+    """
+
 
 def _manifests(doc: dict) -> list[dict]:
     """Normalize either a manifest-list doc or a single-manifest doc to a list of entries."""
     if 'manifests' in doc:
         return doc['manifests']
     return [doc]
+
+
+def _require_platform_bearing(doc: dict) -> None:
+    """Raise CannotCheck unless `doc` is a shape that DECLARES platforms.
+
+    An index does (`manifests[].platform`). A bare image manifest does not — its
+    architecture lives in the config blob, which `--raw` does not fetch — so reporting
+    "declares 0 platforms" for one would be a verdict drawn from absent data.
+    """
+    if 'manifests' in doc:
+        return
+    if isinstance(doc.get('platform'), dict):
+        return
+    raise CannotCheck(
+        'document declares no platform information: it is a single image manifest '
+        '(keys: '
+        + ', '.join(sorted(doc)[:6])
+        + '), whose architecture lives in the config blob. Re-inspect the tag on a '
+        'builder that pushes provenance (so the tag resolves to an index), or read '
+        "the platform from `imagetools inspect --format '{{json .Image}}'`."
+    )
 
 
 def _is_real_platform(entry: dict) -> bool:
@@ -66,8 +122,64 @@ def platform_set(doc: dict) -> set[str]:
     return out
 
 
+def resolve_digest(doc: dict, platform: str) -> str:
+    """The manifest digest an INDEX lists for `platform` ("linux/amd64").
+
+    This is the step that turns "what the index declares" into "the manifest that
+    actually has layers", so a size/layer comparison is fed the right document. Raises
+    CannotCheck for a non-index doc; returns '' when the index simply has no such
+    platform (a mismatch, which check_index reports properly).
+    """
+    if 'manifests' not in doc:
+        raise CannotCheck(
+            'cannot resolve a per-platform digest: this document is not a manifest '
+            'index (no "manifests" key), so it lists no per-platform manifests'
+        )
+    for entry in doc['manifests']:
+        if not _is_real_platform(entry):
+            continue
+        p = entry.get('platform', {})
+        if f'{p.get("os", "")}/{p.get("architecture", "")}' == platform:
+            digest = entry.get('digest', '')
+            if not digest:
+                raise CannotCheck(f'index entry for {platform} carries no digest')
+            return str(digest)
+    return ''
+
+
+def check_image_config(doc: dict, expect_platform: str) -> tuple[bool, str]:
+    """Verify a leg's platform from its CONFIG BLOB rather than its manifest.
+
+    This is the path for a leg tag that resolves to a bare image manifest instead of an
+    index — which is not hypothetical: MEASURED 2026-09-05 against the real published
+    `davidamacey/diar-native:0.3.1-cpu`, whose `--raw` is
+    `{config, layers, mediaType, schemaVersion}` with no platform anywhere, so
+    `check-leg` on it can only ever answer CANNOT CHECK. Whether a leg lands in that
+    shape depends on whether the push carried provenance attestations, which is a
+    builder setting — so check (a) must not be permanently inconclusive whenever it is
+    off. A check that can never pass is not a gate.
+
+    Input is `docker buildx imagetools inspect <ref> --format '{{json .Image}}'`, i.e.
+    the config blob: `{"os": "linux", "architecture": "amd64", ...}`. imagetools
+    fetches it without pulling the image.
+    """
+    os_ = doc.get('os', '')
+    arch = doc.get('architecture', '')
+    if not os_ or not arch:
+        raise CannotCheck(
+            'image config declares no os/architecture (keys: '
+            + ', '.join(sorted(doc)[:6])
+            + ") — expected the output of `imagetools inspect --format '{{json .Image}}'`"
+        )
+    actual = f'{os_}/{arch}'
+    if actual != expect_platform:
+        return False, f"image config declares platform '{actual}'; expected '{expect_platform}'"
+    return True, f'ok (from image config: {actual})'
+
+
 def check_leg(doc: dict, expect_platform: str) -> tuple[bool, str]:
     """A LEG tag must declare EXACTLY ONE platform, and it must be the declared one."""
+    _require_platform_bearing(doc)
     platforms = platform_set(doc)
     if len(platforms) != 1:
         return (
@@ -84,6 +196,7 @@ def check_index(doc: dict, expect_platforms: set[str]) -> tuple[bool, str]:
     """An INDEX tag must declare EXACTLY the declared platform set — no fewer
     (issue #680's original bug: a degraded/missing arch published anyway) and no
     more (a leg nobody declared)."""
+    _require_platform_bearing(doc)
     actual = platform_set(doc)
     missing = expect_platforms - actual
     extra = actual - expect_platforms
@@ -98,16 +211,25 @@ def check_index(doc: dict, expect_platforms: set[str]) -> tuple[bool, str]:
 
 
 def _entry_size_and_layers(doc: dict) -> tuple[int, int]:
-    """Total size (bytes) and layer count for a SINGLE-PLATFORM manifest doc
-    (i.e. the `docker manifest inspect <repo>:<tag>` of a leg tag, or a manifest
-    entry that has already been resolved to its own layer list)."""
+    """Total size (bytes) and layer count for a SINGLE-PLATFORM image manifest.
+
+    Raises CannotCheck for any other shape. In particular an INDEX has no `layers` at
+    all, so treating a missing key as "0 bytes, 0 layers" would manufacture a verdict —
+    `0 == 0` even makes the layer-count half of the comparison PASS on no data. Resolve
+    the per-platform digest first (`resolve-digest`) and inspect that.
+    """
+    if 'layers' not in doc and 'fsLayers' not in doc:
+        raise CannotCheck(
+            'document carries no layer list, so it has no image size to compare '
+            '(keys: '
+            + ', '.join(sorted(doc)[:6])
+            + '). A manifest INDEX never does — resolve the per-platform digest with '
+            '`resolve-digest` and inspect repo@<digest> instead.'
+        )
     layers = doc.get('layers') or doc.get('fsLayers') or []
-    size = sum(int(entry.get('size', 0)) for entry in layers)
-    if size == 0 and 'config' in doc:
-        # imagetools --raw output nests size at layer level too; fall back to
-        # summing manifest-level `Size` fields if present (docker manifest inspect -v shape).
-        size = int(doc.get('size', 0))
-    return size, len(layers)
+    if not layers:
+        raise CannotCheck('document has an EMPTY layer list — nothing to compare')
+    return sum(int(entry.get('size', 0)) for entry in layers), len(layers)
 
 
 def equivalence_ratio(a: dict, b: dict) -> tuple[bool, float, str]:
@@ -119,14 +241,16 @@ def equivalence_ratio(a: dict, b: dict) -> tuple[bool, float, str]:
     layers_equal = a_layers == b_layers
 
     if a_size == 0 or b_size == 0:
-        return (
-            layers_equal,
-            float('inf'),
-            'one side reports zero total size — cannot compute a ratio',
+        raise CannotCheck(
+            f'a side reports zero total size (a={a_size} b={b_size}) — the manifest '
+            'lists layers but none of them declare a size, so no ratio exists'
         )
 
     ratio = max(a_size, b_size) / min(a_size, b_size)
-    msg = f'layers a={a_layers} b={b_layers} equal={layers_equal}; sizes a={a_size} b={b_size} ratio={ratio:.2f}'
+    msg = (
+        f'layers a={a_layers} b={b_layers} equal={layers_equal}; '
+        f'sizes a={a_size} b={b_size} ratio={ratio:.2f}'
+    )
     return layers_equal, ratio, msg
 
 
@@ -140,47 +264,88 @@ def check_equivalence(a: dict, b: dict, bound: float) -> tuple[bool, str]:
 
 
 def _load(path: str) -> dict:
-    if path == '-':
-        return json.load(sys.stdin)
-    with open(path) as f:
-        return json.load(f)
+    """Read a manifest document, mapping every unreadable/unparseable state to
+    CannotCheck so it exits 3 (could not check) rather than 1 (checked, wrong).
+
+    An uncaught JSONDecodeError would exit 1 and be indistinguishable, in the caller's
+    log, from a genuine platform mismatch.
+    """
+    try:
+        if path in ('-', '/dev/stdin'):
+            raw = sys.stdin.read()
+        else:
+            with open(path) as handle:
+                raw = handle.read()
+    except OSError as exc:
+        raise CannotCheck(f'cannot read {path}: {exc}') from exc
+    if not raw.strip():
+        raise CannotCheck(f'{path} is empty — nothing was inspected')
+    try:
+        doc = json.loads(raw)
+    except ValueError as exc:
+        raise CannotCheck(f'{path} is not valid JSON: {exc}') from exc
+    if not isinstance(doc, dict):
+        raise CannotCheck(f'{path} is not a manifest object (got {type(doc).__name__})')
+    return doc
+
+
+def _dispatch(argv: list[str]) -> int:
+    cmd = argv[1]
+    if cmd == 'check-leg':
+        # check-leg <manifest.json> <expect-platform>
+        ok, msg = check_leg(_load(argv[2]), argv[3])
+        print(msg)
+        return EXIT_OK if ok else EXIT_MISMATCH
+
+    if cmd == 'check-index':
+        # check-index <manifest.json> <comma,separated,platforms>
+        ok, msg = check_index(_load(argv[2]), set(argv[3].split(',')))
+        print(msg)
+        return EXIT_OK if ok else EXIT_MISMATCH
+
+    if cmd == 'check-ratio':
+        # check-ratio <a.json> <b.json> <bound>
+        ok, msg = check_equivalence(_load(argv[2]), _load(argv[3]), float(argv[4]))
+        print(msg)
+        return EXIT_OK if ok else EXIT_MISMATCH
+
+    if cmd == 'check-image-config':
+        # check-image-config <image-config.json> <expect-platform>
+        ok, msg = check_image_config(_load(argv[2]), argv[3])
+        print(msg)
+        return EXIT_OK if ok else EXIT_MISMATCH
+
+    if cmd == 'resolve-digest':
+        # resolve-digest <index.json> <platform>  -> digest on stdout
+        digest = resolve_digest(_load(argv[2]), argv[3])
+        if not digest:
+            print(f'index declares no {argv[3]} manifest')
+            return EXIT_MISMATCH
+        print(digest)
+        return EXIT_OK
+
+    print(f'unknown command: {cmd}', file=sys.stderr)
+    return EXIT_MISUSE
 
 
 def main(argv: list[str]) -> int:
     if len(argv) < 2:
         print(
-            'usage: manifest_platform_check.py <check-leg|check-index|check-ratio> ...',
+            'usage: manifest_platform_check.py <check-leg|check-index|check-ratio'
+            '|check-image-config|resolve-digest> ...',
             file=sys.stderr,
         )
-        return 2
-
-    cmd = argv[1]
-    if cmd == 'check-leg':
-        # check-leg <manifest.json> <expect-platform>
-        doc = _load(argv[2])
-        ok, msg = check_leg(doc, argv[3])
-        print(msg)
-        return 0 if ok else 1
-
-    if cmd == 'check-index':
-        # check-index <manifest.json> <comma,separated,platforms>
-        doc = _load(argv[2])
-        expect = set(argv[3].split(','))
-        ok, msg = check_index(doc, expect)
-        print(msg)
-        return 0 if ok else 1
-
-    if cmd == 'check-ratio':
-        # check-ratio <a.json> <b.json> <bound>
-        a = _load(argv[2])
-        b = _load(argv[3])
-        bound = float(argv[4])
-        ok, msg = check_equivalence(a, b, bound)
-        print(msg)
-        return 0 if ok else 1
-
-    print(f'unknown command: {cmd}', file=sys.stderr)
-    return 2
+        return EXIT_MISUSE
+    try:
+        return _dispatch(argv)
+    except IndexError:
+        print(f'missing argument(s) for {argv[1]}', file=sys.stderr)
+        return EXIT_MISUSE
+    except CannotCheck as exc:
+        # NOT exit 1: the caller must be able to tell "this artifact is wrong" from
+        # "nothing was actually checked". See the module docstring.
+        print(f'CANNOT CHECK: {exc}')
+        return EXIT_CANNOT_CHECK
 
 
 if __name__ == '__main__':

--- a/scripts/lib/manifest_platform_check.py
+++ b/scripts/lib/manifest_platform_check.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Pure functions for verifying published multi-arch manifest structure (issue #680).
+
+No network, no Docker — every function takes a parsed `docker manifest inspect` (or
+`docker buildx imagetools inspect --raw`) JSON document (or a list of them) and returns
+a verdict. The CLI wrapper at the bottom is what 80-publish.sh and
+scripts/tests/test-publish-platforms.sh both call, so the parsing/comparison logic has
+exactly one implementation.
+
+Three checks, matching issue #680's "suggested fix" #2 and this repo's tag grammar:
+
+  leg_platform_set(manifest)      -> the set of "os/arch" platform strings a manifest
+                                      declares. A LEG tag (repo:vX.Y.Z-<cap>-<arch>) must
+                                      have exactly one.
+  index_platform_set(manifest)    -> same, for an INDEX tag (repo:vX.Y.Z) — must equal
+                                      the component's DECLARED platform set exactly:
+                                      missing a platform is #680's original bug, an EXTRA
+                                      platform is just as wrong (a leg published nobody
+                                      asked for), so both directions are checked.
+  equivalence_ratio(a, b)         -> (layer_count_equal, size_ratio) between two
+                                      SINGLE-PLATFORM manifest entries of the SAME
+                                      purpose/capability (e.g. lite-amd64 vs lite-arm64).
+                                      Never call this across purposes (full vs lite,
+                                      backend vs frontend) — there is no reason for their
+                                      sizes to track and #680's whole point is that this
+                                      comparison is only meaningful within one capability.
+
+`architecture: "unknown"` platform entries are BuildKit attestation manifests
+(provenance/SBOM), not real image platforms, and must be ignored by every function here
+— counting them as a "platform" would make an index look like it declares more
+architectures than it does.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+
+def _manifests(doc: dict) -> list[dict]:
+    """Normalize either a manifest-list doc or a single-manifest doc to a list of entries."""
+    if 'manifests' in doc:
+        return doc['manifests']
+    return [doc]
+
+
+def _is_real_platform(entry: dict) -> bool:
+    platform = entry.get('platform', entry)
+    arch = platform.get('architecture', '')
+    # BuildKit attestation manifests declare architecture "unknown" — not a real
+    # platform leg. See module docstring.
+    return bool(arch) and arch != 'unknown'
+
+
+def platform_set(doc: dict) -> set[str]:
+    """The set of "os/arch" strings a manifest (list or single) actually declares,
+    excluding attestation entries."""
+    out = set()
+    for entry in _manifests(doc):
+        platform = entry.get('platform', entry)
+        if not _is_real_platform(entry):
+            continue
+        os_ = platform.get('os', '')
+        arch = platform.get('architecture', '')
+        out.add(f'{os_}/{arch}')
+    return out
+
+
+def check_leg(doc: dict, expect_platform: str) -> tuple[bool, str]:
+    """A LEG tag must declare EXACTLY ONE platform, and it must be the declared one."""
+    platforms = platform_set(doc)
+    if len(platforms) != 1:
+        return (
+            False,
+            f'leg tag declares {len(platforms)} platform(s): {sorted(platforms)}; expected exactly 1',
+        )
+    (only,) = platforms
+    if only != expect_platform:
+        return False, f"leg tag declares platform '{only}'; expected '{expect_platform}'"
+    return True, 'ok'
+
+
+def check_index(doc: dict, expect_platforms: set[str]) -> tuple[bool, str]:
+    """An INDEX tag must declare EXACTLY the declared platform set — no fewer
+    (issue #680's original bug: a degraded/missing arch published anyway) and no
+    more (a leg nobody declared)."""
+    actual = platform_set(doc)
+    missing = expect_platforms - actual
+    extra = actual - expect_platforms
+    if missing or extra:
+        parts = []
+        if missing:
+            parts.append(f'missing: {sorted(missing)}')
+        if extra:
+            parts.append(f'extra: {sorted(extra)}')
+        return False, '; '.join(parts)
+    return True, 'ok'
+
+
+def _entry_size_and_layers(doc: dict) -> tuple[int, int]:
+    """Total size (bytes) and layer count for a SINGLE-PLATFORM manifest doc
+    (i.e. the `docker manifest inspect <repo>:<tag>` of a leg tag, or a manifest
+    entry that has already been resolved to its own layer list)."""
+    layers = doc.get('layers') or doc.get('fsLayers') or []
+    size = sum(int(entry.get('size', 0)) for entry in layers)
+    if size == 0 and 'config' in doc:
+        # imagetools --raw output nests size at layer level too; fall back to
+        # summing manifest-level `Size` fields if present (docker manifest inspect -v shape).
+        size = int(doc.get('size', 0))
+    return size, len(layers)
+
+
+def equivalence_ratio(a: dict, b: dict) -> tuple[bool, float, str]:
+    """(layer_counts_equal, size_ratio >= 1, message) between two single-platform
+    manifests of the SAME capability. size_ratio is always >= 1 (larger/smaller)."""
+    a_size, a_layers = _entry_size_and_layers(a)
+    b_size, b_layers = _entry_size_and_layers(b)
+
+    layers_equal = a_layers == b_layers
+
+    if a_size == 0 or b_size == 0:
+        return (
+            layers_equal,
+            float('inf'),
+            'one side reports zero total size — cannot compute a ratio',
+        )
+
+    ratio = max(a_size, b_size) / min(a_size, b_size)
+    msg = f'layers a={a_layers} b={b_layers} equal={layers_equal}; sizes a={a_size} b={b_size} ratio={ratio:.2f}'
+    return layers_equal, ratio, msg
+
+
+def check_equivalence(a: dict, b: dict, bound: float) -> tuple[bool, str]:
+    layers_equal, ratio, msg = equivalence_ratio(a, b)
+    if not layers_equal:
+        return False, f'layer count mismatch: {msg}'
+    if ratio > bound:
+        return False, f'size ratio {ratio:.2f} exceeds bound {bound}: {msg}'
+    return True, msg
+
+
+def _load(path: str) -> dict:
+    if path == '-':
+        return json.load(sys.stdin)
+    with open(path) as f:
+        return json.load(f)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print(
+            'usage: manifest_platform_check.py <check-leg|check-index|check-ratio> ...',
+            file=sys.stderr,
+        )
+        return 2
+
+    cmd = argv[1]
+    if cmd == 'check-leg':
+        # check-leg <manifest.json> <expect-platform>
+        doc = _load(argv[2])
+        ok, msg = check_leg(doc, argv[3])
+        print(msg)
+        return 0 if ok else 1
+
+    if cmd == 'check-index':
+        # check-index <manifest.json> <comma,separated,platforms>
+        doc = _load(argv[2])
+        expect = set(argv[3].split(','))
+        ok, msg = check_index(doc, expect)
+        print(msg)
+        return 0 if ok else 1
+
+    if cmd == 'check-ratio':
+        # check-ratio <a.json> <b.json> <bound>
+        a = _load(argv[2])
+        b = _load(argv[3])
+        bound = float(argv[4])
+        ok, msg = check_equivalence(a, b, bound)
+        print(msg)
+        return 0 if ok else 1
+
+    print(f'unknown command: {cmd}', file=sys.stderr)
+    return 2
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/scripts/release-tests/README.md
+++ b/scripts/release-tests/README.md
@@ -6,7 +6,7 @@ End-to-end validation for every OpenTranscribe release. Three scenarios:
 |---|---|
 | `test-fresh-install.sh` | A new user runs the documented `setup-opentranscribe.sh` one-liner and ends up with a working stack on the current release |
 | `test-upgrade.sh` | A user with real data on the previous release can run the documented upgrade path and find their data intact, migrations applied, new features available |
-| `test-lite-mode.sh` | The no-GPU lite **topology and pipeline** (`docker-compose.lite.yml`, cloud-only ASR) run the real upload -> ASR -> segments/speakers -> search -> chat flow, against mocked cloud ASR (`scripts/mock-asr-server.py`, a Gladia stand-in) and a mocked LLM (`scripts/mock-llm-server.py`) — no GPU, vendor API key, or network egress required. Complements `scripts/lite-smoke.sh` (Stage 2, Cycle 2D), which only checks lite/cpu-only topology, not the pipeline. **⚠️ It does NOT prove a user can deploy lite mode** — see below. |
+| `test-lite-mode.sh` | The no-GPU lite **topology and pipeline** (`docker-compose.lite.yml`, cloud-only ASR) run the real upload -> ASR -> segments/speakers -> search -> chat flow, against mocked cloud ASR (`scripts/mock-asr-server.py`, a Gladia stand-in) and a mocked LLM (`scripts/mock-llm-server.py`) — no GPU, vendor API key, or network egress required. Complements `scripts/lite-smoke.sh` (Stage 2, Cycle 2D), which only checks lite/cpu-only topology, not the pipeline. Lite became a shipped deployment shape in issue #680 — see below. |
 
 ## Scenarios A and B run the SHIPPED commands
 
@@ -26,19 +26,26 @@ card silently ran the wrong image. Both scenarios now read the resolved chain ba
 manifest promises was actually downloaded. Rationale and the full finding list:
 [`REHEARSAL_ALIGNMENT_PLAN.md`](REHEARSAL_ALIGNMENT_PLAN.md).
 
-### Scenario C (`--lite`) is a repo/dev-only deployment shape
+### Scenario C (`--lite`) is now a SHIPPED deployment shape (changed by issue #680)
 
-`test-lite-mode.sh` is the one scenario that still hand-builds its chain, and that is
-correct rather than an oversight: `docker-compose.lite.yml` is **not** in
-`release-manifest.txt` (a curl install never downloads it), `get_compose_files()` has no
-lite branch (nothing could select it if it did), and `scripts/docker-build-push.sh all`
-does not build the lite image (no release publishes it). The only documented invocation
-is `./opentr.sh start dev --lite` — the *development* script, in a git clone.
+This section previously said the opposite, and the three facts it rested on were all
+changed by #680: `docker-compose.lite.yml` **is** in `release-manifest.txt` (a curl
+install downloads it), `get_compose_files()` **has** a `DEPLOYMENT_MODE=lite` branch, and
+`scripts/docker-build-push.sh all` **does** build and publish
+`opentranscribe-backend-lite`. `test_lite_mode_is_reachable_by_a_shipped_deployment`
+(`backend/tests/unit/test_compose_file_selection.py`) now asserts all three in the
+positive, so this section still cannot go stale unnoticed.
 
-So the scenario's verdict is "lite works", not "a user can deploy lite". Making the
-latter true is a product decision. `test_lite_mode_is_not_reachable_by_a_shipped_deployment`
-(`backend/tests/unit/test_compose_file_selection.py`) fails the moment any of those three
-facts changes, so this section cannot go stale unnoticed.
+It matters most on **arm64**, where the full/CUDA image publishes no manifest at all, so
+`opentranscribe.sh` defaults an arm64 host to lite. Lite is the only published deployment
+for that architecture.
+
+`test-lite-mode.sh` is nevertheless still the one scenario that hand-builds its chain.
+That is now justified differently: it must pin one fixed chain regardless of the host, so
+that a machine with a GPU does not have the shipped selector add the GPU overlay and
+defeat the no-GPU shape it exists to exercise. Driving it through
+`DEPLOYMENT_MODE=lite FORCE_CPU_MODE=true ./opentranscribe.sh start` is now possible and
+is tracked as follow-up in that test module's exemption entry.
 
 ## ⚠️ Precondition: the live stack must be STOPPED
 

--- a/scripts/release-tests/test-lite-mode.sh
+++ b/scripts/release-tests/test-lite-mode.sh
@@ -20,31 +20,33 @@
 # TEST_USE_GPU is hard-coded false: this scenario's entire point is the
 # no-GPU lite deployment shape.
 #
-# ⚠️ SCOPE: `--lite` IS NOT A USER-REACHABLE DEPLOYMENT SHAPE TODAY.
+# ⚠️ SCOPE (REWRITTEN BY ISSUE #680 — the previous version of this block is now FALSE).
 #
-# Unlike Scenarios A and B, this one hand-builds its `docker compose -f ...` chain, and
-# that is currently correct rather than a bug — because there is no shipped command that
-# could build it. Three facts, all verified:
+# This block used to say `--lite` was not a user-reachable deployment shape, resting on
+# three facts. All three were changed by #680, in one place, and are now asserted in the
+# positive by `test_lite_mode_is_reachable_by_a_shipped_deployment`
+# (backend/tests/unit/test_compose_file_selection.py):
 #
-#   * `docker-compose.lite.yml` is NOT in release-manifest.txt, so a real
-#     `curl … setup-opentranscribe.sh | bash` install never downloads it.
-#   * `opentranscribe.sh:get_compose_files()` has no lite branch, so nothing would
-#     select it even if it were on disk.
-#   * `scripts/docker-build-push.sh all` builds backend, frontend and docs — not the
-#     lite image — so no `opentranscribe-backend-lite` is published by a release.
+#   * `docker-compose.lite.yml` IS in release-manifest.txt, so a real
+#     `curl … setup-opentranscribe.sh | bash` install downloads it.
+#   * `opentranscribe.sh:get_compose_files()` HAS a lite branch keyed on
+#     DEPLOYMENT_MODE, so a production install can select it.
+#   * `scripts/docker-build-push.sh all` builds the lite image, so a release publishes
+#     `davidamacey/opentranscribe-backend-lite`.
 #
-# The only documented invocation is `./opentr.sh start dev --lite`
-# (docs-site/docs/operations/deployment-configuration.md), i.e. the DEVELOPMENT script,
-# in a git clone. README.md's "API-Lite Deployment" bullet therefore describes a
-# repo/dev capability, not something a self-hoster can install.
+# That change was not cosmetic: the full/CUDA image publishes an **amd64-only** manifest
+# (no aarch64 CUDA torch wheel, no aarch64 onnxruntime-gpu wheel, no CUDA arm64
+# diar-native sidecar), so `arm64_deployment_preflight()` defaults an arm64 host to
+# DEPLOYMENT_MODE=lite. Lite is the ONLY published deployment for that architecture.
 #
-# So read this scenario's verdict precisely: it proves the lite TOPOLOGY AND PIPELINE
-# work. It does NOT prove a user can deploy them. Making that true is a product decision
-# (manifest entry + a get_compose_files() branch keyed on DEPLOYMENT_MODE + publishing
-# the lite image + installer support) — see scripts/release-tests/REHEARSAL_ALIGNMENT_PLAN.md
-# finding E. `test_lite_mode_is_not_reachable_by_a_shipped_deployment` in
-# backend/tests/unit/test_compose_file_selection.py FAILS the moment any of the three
-# facts above stops holding, so this paragraph cannot quietly go stale.
+# This scenario nonetheless still hand-builds its `docker compose -f ...` chain, which
+# is now justified differently rather than not at all: it must pin ONE fixed chain
+# regardless of the host, and a machine with a GPU would otherwise have the shipped
+# selector add the GPU overlay — defeating the no-GPU shape this scenario exists to
+# exercise. It is also the live positive case for
+# `test_the_hand_built_bringup_detector_actually_fires`. Driving it through
+# `DEPLOYMENT_MODE=lite FORCE_CPU_MODE=true ./opentranscribe.sh start` is now POSSIBLE
+# and is the right follow-up — see the exemption entry in that same test module.
 #
 # Since issue #660, this chain also hand-builds -f docker-compose.diar-native.yml: lite's
 # speaker embeddings come from the diar-native CPU-EP sidecar's /embed_window, not an

--- a/scripts/release/40-build.sh
+++ b/scripts/release/40-build.sh
@@ -32,22 +32,50 @@ fi
 
 # The image must be able to state what it is. This is the check that would have
 # caught the build-arg omission in the documented `docker build` commands.
-baked=$(docker run --rm --entrypoint sh \
-    "${DOCKERHUB_USERNAME:-davidamacey}/opentranscribe-backend:${VERSION}" \
-    -c 'echo "$APP_VERSION"' 2>/dev/null | tr -d '\r')
+#
+# Every backend-derived component from `docker-build-push.sh list-platforms`
+# is checked, not just `backend` (issue #680) — `all` also builds `lite` now,
+# and frontend/docs declare no APP_VERSION build-arg contract at all (frontend
+# takes its version from package.json, docs bakes OT_VERSION separately), so
+# only the two Dockerfile.prod/Dockerfile.lite-based backend images have this
+# baked-version contract to verify.
+DOCKERHUB_USERNAME="${DOCKERHUB_USERNAME:-davidamacey}"
+declare -A REPO_FOR_COMPONENT=(
+    [backend]="${DOCKERHUB_USERNAME}/opentranscribe-backend"
+    [lite]="${DOCKERHUB_USERNAME}/opentranscribe-backend-lite"
+)
 
 status=pass
-if [[ "$baked" != "$VERSION" ]]; then
-    echo -e "${RED}FAIL  backend image reports '${baked:-<empty>}', expected ${VERSION}${NC}" >&2
-    echo "      the --build-arg APP_VERSION contract is broken" >&2
-    status=fail
-else
-    echo -e "${GREEN}PASS  backend image reports ${baked}${NC}" >&2
-fi
+declare -A baked_by_component=()
+while IFS=$'\t' read -r component _capability _platforms; do
+    repo="${REPO_FOR_COMPONENT[${component}]:-}"
+    [ -n "$repo" ] || continue
+
+    baked=$(docker run --rm --entrypoint sh \
+        "${repo}:${VERSION}" \
+        -c 'echo "$APP_VERSION"' 2>/dev/null | tr -d '\r')
+    baked_by_component["$component"]="$baked"
+
+    if [[ "$baked" != "$VERSION" ]]; then
+        echo -e "${RED}FAIL  ${component} image reports '${baked:-<empty>}', expected ${VERSION}${NC}" >&2
+        echo "      the --build-arg APP_VERSION contract is broken for ${component}" >&2
+        status=fail
+    else
+        echo -e "${GREEN}PASS  ${component} image reports ${baked}${NC}" >&2
+    fi
+done < <(./scripts/docker-build-push.sh list-platforms)
 
 if [[ "$JSON_OUT" == "true" ]]; then
-    printf '{"stage":"build","version":"%s","status":"%s","artifacts":{"baked_version":"%s"},"next":%s}\n' \
-        "$VERSION" "$status" "$baked" \
+    artifacts="{"
+    first=true
+    for component in "${!baked_by_component[@]}"; do
+        [[ "$first" == true ]] || artifacts+=","
+        first=false
+        artifacts+="\"${component}_baked_version\":\"${baked_by_component[$component]}\""
+    done
+    artifacts+="}"
+    printf '{"stage":"build","version":"%s","status":"%s","artifacts":%s,"next":%s}\n' \
+        "$VERSION" "$status" "$artifacts" \
         "$([[ "$status" == pass ]] && echo '["scan"]' || echo '["fix the build-arg contract and rebuild"]')"
 fi
 

--- a/scripts/release/50-scan.sh
+++ b/scripts/release/50-scan.sh
@@ -26,7 +26,6 @@ BLUE='\033[0;34m'; NC='\033[0m'
 : "${VERSION:?50-scan.sh needs a version}"
 
 RED='\033[0;31m'; GREEN='\033[0;32m'
-HUB="${DOCKERHUB_USERNAME:-davidamacey}"
 
 # The images must exist locally at THIS tag before we scan.
 #
@@ -38,8 +37,20 @@ HUB="${DOCKERHUB_USERNAME:-davidamacey}"
 #
 # So the tag is asserted rather than assumed: a missing image fails here instead
 # of quietly redirecting the scan to whatever :latest happens to point at.
+#
+# Components/repos are DERIVED from security-scan.sh's own list-repos command
+# (issue #680), not hardcoded — `backend frontend docs` used to be the whole
+# list here, which silently never checked (or scanned) `lite`/`blackwell` once
+# those existed. `blackwell` is deliberately excluded: it is never built by
+# `all`/`auto` and is not part of this stage's local-build precondition.
+declare -A REPO_FOR_COMPONENT=()
+while IFS=$'\t' read -r component repo; do
+    [[ "$component" == "blackwell" ]] && continue
+    REPO_FOR_COMPONENT["$component"]="$repo"
+done < <(./scripts/security-scan.sh list-repos)
+
 missing=()
-for repo in "$HUB/opentranscribe-backend" "$HUB/opentranscribe-frontend" "$HUB/opentranscribe-docs"; do
+for repo in "${REPO_FOR_COMPONENT[@]}"; do
     docker image inspect "${repo}:${VERSION}" >/dev/null 2>&1 || missing+=("${repo}:${VERSION}")
 done
 if (( ${#missing[@]} )); then
@@ -51,12 +62,23 @@ fi
 
 echo -e "${BLUE}Scanning locally built ${VERSION} images${NC}" >&2
 
+# security-scan.sh's own `all` target scans EVERY scannable component,
+# including `blackwell` — which this stage's build precondition above never
+# checks for, because `blackwell` is not part of `docker-build-push.sh all`/
+# `auto` (built and scanned only on request, see docker-build-push.sh's
+# build_backend_blackwell). Scanning explicitly by the components this stage
+# actually has local images for avoids a false "could not scan" on an image
+# nothing here ever built.
 rc=0
-SCAN_SOURCE=local \
-FAIL_ON_CRITICAL="${FAIL_ON_CRITICAL:-true}" \
-OUTPUT_DIR="$OUT_DIR" \
-IMAGE_TAG="$VERSION" \
-    ./scripts/security-scan.sh all || rc=$?
+for component in "${!REPO_FOR_COMPONENT[@]}"; do
+    comp_rc=0
+    SCAN_SOURCE=local \
+    FAIL_ON_CRITICAL="${FAIL_ON_CRITICAL:-true}" \
+    OUTPUT_DIR="$OUT_DIR" \
+    IMAGE_TAG="$VERSION" \
+        ./scripts/security-scan.sh "$component" || comp_rc=$?
+    (( comp_rc > rc )) && rc=$comp_rc
+done
 
 if (( rc >= 2 )); then
     echo -e "${RED}scan could NOT RUN (security-scan.sh exit ${rc}) — this is not 'no findings'${NC}" >&2
@@ -66,7 +88,7 @@ fi
 # Assert the reports describe the image we meant to scan. Reading the tag back
 # out of the artifact is the only thing that would have caught the bug above --
 # the run looked completely normal while measuring the wrong release.
-for comp in backend frontend docs; do
+for comp in "${!REPO_FOR_COMPONENT[@]}"; do
     report="$OUT_DIR/${comp}-trivy.json"
     [[ -f "$report" ]] || continue
     scanned=$(python3 -c "

--- a/scripts/release/80-publish.sh
+++ b/scripts/release/80-publish.sh
@@ -37,20 +37,115 @@ USE_REMOTE_BUILDER=true BUILD_MODE=push PUSH_LATEST=false VERSION="$VERSION" \
     ./scripts/docker-build-push.sh all || rc=$?
 [[ $rc -eq 0 ]] || { echo -e "${RED}publish failed${NC}" >&2; exit 1; }
 
-# Both architectures must actually be in the manifest.
-missing=()
-for repo in backend frontend; do
-    img="${DOCKERHUB_USERNAME:-davidamacey}/opentranscribe-${repo}:${VERSION}"
-    for arch in amd64 arm64; do
-        docker manifest inspect "$img" 2>/dev/null | grep -q "\"architecture\": \"$arch\"" \
-            || missing+=("$repo/$arch")
+# --- Manifest-structure checks (issue #680) ---------------------------------
+#
+# The pre-#680 version of this check only asked "does a manifest entry exist per
+# arch" — grep for `"architecture": "$arch"` on the raw manifest text. That is
+# exactly the check a broken-but-present arm64 leg still passes: #680's arm64
+# backend manifest EXISTED, had 11 layers same as amd64, and was still 8.4x
+# smaller. Existence is not equivalence. Three checks now, all driven off
+# `docker-build-push.sh list-platforms` rather than a hardcoded `backend frontend`
+# pair, via the shared parser in scripts/lib/manifest_platform_check.py:
+#
+#   (a) each -<cap>-<arch> leg tag declares EXACTLY the one platform it claims
+#   (b) each vX.Y.Z index declares EXACTLY the component's declared platform set
+#       (missing OR extra both fail)
+#   (c) for a component with >1 platform, its legs are equivalent to each other:
+#       same layer count, size ratio within the component's purpose bound
+#       (1.25 for lite/frontend/docs, 2.00 for full/backend) — NEVER compared
+#       across purposes/components.
+CHECKER="./scripts/lib/manifest_platform_check.py"
+manifest_check_rc=0
+
+while IFS=$'\t' read -r component capability platforms; do
+    [[ "$component" == "blackwell" ]] && continue  # never published by `all`
+    repo="${DOCKERHUB_USERNAME:-davidamacey}/opentranscribe-backend"
+    [[ "$component" == "lite" ]] && repo="${DOCKERHUB_USERNAME:-davidamacey}/opentranscribe-backend-lite"
+    [[ "$component" == "frontend" ]] && repo="${DOCKERHUB_USERNAME:-davidamacey}/opentranscribe-frontend"
+    [[ "$component" == "docs" ]] && repo="${DOCKERHUB_USERNAME:-davidamacey}/opentranscribe-docs"
+
+    IFS=',' read -r -a arch_list <<< "$platforms"
+
+    # frontend/docs carry no capability leg tags (build_tag_args, not build_leg_tag)
+    # — they publish ONE multi-platform build under repo:vX.Y.Z directly, so only
+    # check (b) applies to them.
+    if [[ "$capability" == "multiarch" ]]; then
+        idx_json=$(docker buildx imagetools inspect "${repo}:${VERSION}" --raw 2>/dev/null)
+        if [[ -z "$idx_json" ]]; then
+            echo -e "${RED}could not inspect ${repo}:${VERSION}${NC}" >&2
+            manifest_check_rc=1
+            continue
+        fi
+        expect_csv="$platforms"
+        out=$(echo "$idx_json" | python3 "$CHECKER" check-index /dev/stdin "$expect_csv") || {
+            echo -e "${RED}(b) index platform-set check FAILED for ${repo}:${VERSION}: ${out}${NC}" >&2
+            manifest_check_rc=1
+            continue
+        }
+        echo -e "${GREEN}(b) ${repo}:${VERSION} index matches declared platforms (${platforms}): ${out}${NC}" >&2
+        continue
+    fi
+
+    # Capability-bearing component: check each leg (a), then the index (b), then
+    # cross-arch equivalence within THIS component only (c).
+    leg_files=()
+    for arch in "${arch_list[@]}"; do
+        arch_short="${arch#linux/}"
+        leg_tag="${repo}:${VERSION}-${capability}-${arch_short}"
+        leg_json=$(docker buildx imagetools inspect "$leg_tag" --raw 2>/dev/null)
+        if [[ -z "$leg_json" ]]; then
+            echo -e "${RED}could not inspect leg ${leg_tag}${NC}" >&2
+            manifest_check_rc=1
+            continue
+        fi
+        leg_rc=0
+        out=$(echo "$leg_json" | python3 "$CHECKER" check-leg /dev/stdin "$arch") || leg_rc=$?
+        if [[ $leg_rc -eq 0 ]]; then
+            echo -e "${GREEN}(a) ${leg_tag}: ${out}${NC}" >&2
+        else
+            echo -e "${RED}(a) leg check FAILED for ${leg_tag}: ${out}${NC}" >&2
+            manifest_check_rc=1
+        fi
+        leg_file="$(mktemp)"
+        echo "$leg_json" > "$leg_file"
+        leg_files+=("$leg_file")
     done
-done
-if [[ ${#missing[@]} -gt 0 ]]; then
-    echo -e "${RED}published manifest is missing: ${missing[*]}${NC}" >&2
+
+    idx_json=$(docker buildx imagetools inspect "${repo}:${VERSION}" --raw 2>/dev/null)
+    if [[ -n "$idx_json" ]]; then
+        idx_rc=0
+        out=$(echo "$idx_json" | python3 "$CHECKER" check-index /dev/stdin "$platforms") || idx_rc=$?
+        if [[ $idx_rc -eq 0 ]]; then
+            echo -e "${GREEN}(b) ${repo}:${VERSION} index matches declared platforms (${platforms}): ${out}${NC}" >&2
+        else
+            echo -e "${RED}(b) index platform-set check FAILED for ${repo}:${VERSION}: ${out}${NC}" >&2
+            manifest_check_rc=1
+        fi
+    else
+        echo -e "${RED}could not inspect index ${repo}:${VERSION}${NC}" >&2
+        manifest_check_rc=1
+    fi
+
+    if [[ ${#leg_files[@]} -eq 2 ]]; then
+        bound="2.00"
+        [[ "$capability" == "cpu" ]] && bound="1.25"
+        ratio_rc=0
+        out=$(python3 "$CHECKER" check-ratio "${leg_files[0]}" "${leg_files[1]}" "$bound") || ratio_rc=$?
+        if [[ $ratio_rc -eq 0 ]]; then
+            echo -e "${GREEN}(c) ${component}: legs equivalent within bound ${bound}: ${out}${NC}" >&2
+        else
+            echo -e "${RED}(c) equivalence check FAILED for ${component} (bound ${bound}): ${out}${NC}" >&2
+            manifest_check_rc=1
+        fi
+    fi
+    for f in "${leg_files[@]}"; do rm -f "$f"; done
+done < <(./scripts/docker-build-push.sh list-platforms)
+
+if [[ $manifest_check_rc -ne 0 ]]; then
+    echo -e "${RED}manifest structure checks FAILED — refusing to report a clean publish${NC}" >&2
     exit 1
 fi
 
-echo -e "${GREEN}published ${VERSION} (amd64 + arm64)${NC}" >&2
+echo -e "${GREEN}published ${VERSION} — manifest structure verified for every declared leg/index${NC}" >&2
 [[ "$JSON_OUT" == "true" ]] && printf '{"stage":"publish","version":"%s","status":"pass","next":["smoke"]}\n' "$VERSION"
 exit 0

--- a/scripts/release/80-publish.sh
+++ b/scripts/release/80-publish.sh
@@ -50,12 +50,52 @@ USE_REMOTE_BUILDER=true BUILD_MODE=push PUSH_LATEST=false VERSION="$VERSION" \
 #   (a) each -<cap>-<arch> leg tag declares EXACTLY the one platform it claims
 #   (b) each vX.Y.Z index declares EXACTLY the component's declared platform set
 #       (missing OR extra both fail)
-#   (c) for a component with >1 platform, its legs are equivalent to each other:
-#       same layer count, size ratio within the component's purpose bound
-#       (1.25 for lite/frontend/docs, 2.00 for full/backend) — NEVER compared
-#       across purposes/components.
+#   (c) for a component whose index declares >1 platform, those platforms are
+#       equivalent to each other: same layer count, size ratio within the
+#       component's purpose bound (1.25 for cpu/multiarch — lite, frontend,
+#       docs; 2.00 for cuda) — NEVER compared across purposes/components.
+#
+# ⚠️ (c) MUST be fed per-platform MANIFESTS, not the index. An index carries no
+# `layers` at all and its per-entry `size` is the ~2 KB manifest blob, so feeding
+# it to check-ratio reports `sizes a=0 b=0 ratio=inf` and fails every time — even
+# comparing an index against itself (measured against the real published
+# opentranscribe-backend:v0.4.1 index). Hence resolve-digest + a second inspect.
+#
+# A checker exit of 3 means COULD NOT CHECK (malformed/absent/wrong-shape doc),
+# never "checked and fine" — reported separately from a mismatch below, for the
+# same reason security-scan.sh separates its exit 1 from its exit 2 (issue #681).
 CHECKER="./scripts/lib/manifest_platform_check.py"
 manifest_check_rc=0
+MANIFEST_TMP="$(mktemp -d)"
+trap 'rm -rf "$MANIFEST_TMP"' EXIT
+
+# Fetch a ref's raw manifest JSON into $2. Returns 1 when nothing came back, so a
+# registry/auth failure is never mistaken for an empty-but-valid document.
+inspect_raw() {
+    local ref="$1" out="$2"
+    docker buildx imagetools inspect "$ref" --raw >"$out" 2>/dev/null
+    [[ -s "$out" ]]
+}
+
+# Print a verdict, keeping "checked and WRONG" (rc 1) distinct from "could not
+# check at all" (rc 3). Both fail the stage; only one is a claim about the image.
+report_check() {
+    local rc="$1" label="$2" msg="$3"
+    case "$rc" in
+        0) echo -e "${GREEN}${label}: ${msg}${NC}" >&2 ;;
+        3) echo -e "${RED}${label}: NOT VERIFIED — ${msg}${NC}" >&2; manifest_check_rc=1 ;;
+        *) echo -e "${RED}${label}: FAILED — ${msg}${NC}" >&2; manifest_check_rc=1 ;;
+    esac
+}
+
+# Resolve $platform out of the index in $1 and write that platform's own manifest
+# (the document that actually has `layers`) to $3. Returns non-zero on any failure.
+platform_manifest() {
+    local index_file="$1" platform="$2" out="$3" repo="$4"
+    local digest
+    digest=$(python3 "$CHECKER" resolve-digest "$index_file" "$platform") || return 1
+    inspect_raw "${repo}@${digest}" "$out"
+}
 
 while IFS=$'\t' read -r component capability platforms; do
     [[ "$component" == "blackwell" ]] && continue  # never published by `all`
@@ -66,79 +106,69 @@ while IFS=$'\t' read -r component capability platforms; do
 
     IFS=',' read -r -a arch_list <<< "$platforms"
 
-    # frontend/docs carry no capability leg tags (build_tag_args, not build_leg_tag)
-    # — they publish ONE multi-platform build under repo:vX.Y.Z directly, so only
-    # check (b) applies to them.
-    if [[ "$capability" == "multiarch" ]]; then
-        idx_json=$(docker buildx imagetools inspect "${repo}:${VERSION}" --raw 2>/dev/null)
-        if [[ -z "$idx_json" ]]; then
-            echo -e "${RED}could not inspect ${repo}:${VERSION}${NC}" >&2
-            manifest_check_rc=1
-            continue
-        fi
-        expect_csv="$platforms"
-        out=$(echo "$idx_json" | python3 "$CHECKER" check-index /dev/stdin "$expect_csv") || {
-            echo -e "${RED}(b) index platform-set check FAILED for ${repo}:${VERSION}: ${out}${NC}" >&2
-            manifest_check_rc=1
-            continue
-        }
-        echo -e "${GREEN}(b) ${repo}:${VERSION} index matches declared platforms (${platforms}): ${out}${NC}" >&2
+    # (a) Leg tags exist only for capability-bearing components (build_leg_tag).
+    # frontend/docs publish ONE multi-platform build under repo:vX.Y.Z directly
+    # (build_tag_args), so they have no legs to check — (b) and (c) still apply.
+    if [[ "$capability" != "multiarch" ]]; then
+        for arch in "${arch_list[@]}"; do
+            leg_tag="${repo}:${VERSION}-${capability}-${arch#linux/}"
+            leg_file="${MANIFEST_TMP}/${component}-leg-${arch#linux/}.json"
+            if ! inspect_raw "$leg_tag" "$leg_file"; then
+                report_check 3 "(a) ${leg_tag}" "could not inspect the leg tag at all"
+                continue
+            fi
+            leg_rc=0
+            out=$(python3 "$CHECKER" check-leg "$leg_file" "$arch") || leg_rc=$?
+            # A leg tag pushed WITHOUT provenance attestations resolves to a bare
+            # image manifest, which declares no platform at all (architecture lives
+            # in the config blob that --raw does not fetch), so check-leg can only
+            # answer CANNOT CHECK. MEASURED against the real published
+            # davidamacey/diar-native:0.3.1-cpu, whose --raw is exactly that shape.
+            # Falling back to the config blob is what keeps (a) a GATE rather than a
+            # permanent "not verified" — attestations are a builder setting, and a
+            # check that can never pass is not a check. `--format '{{json .Image}}'`
+            # fetches the config blob without pulling the image.
+            if [[ $leg_rc -eq 3 ]]; then
+                cfg_file="${MANIFEST_TMP}/${component}-legcfg-${arch#linux/}.json"
+                if docker buildx imagetools inspect "$leg_tag" \
+                        --format '{{json .Image}}' >"$cfg_file" 2>/dev/null \
+                   && [[ -s "$cfg_file" ]]; then
+                    leg_rc=0
+                    out=$(python3 "$CHECKER" check-image-config "$cfg_file" "$arch") || leg_rc=$?
+                fi
+            fi
+            report_check "$leg_rc" "(a) ${leg_tag}" "$out"
+        done
+    fi
+
+    # (b) The published index must declare EXACTLY the component's platform set.
+    idx_file="${MANIFEST_TMP}/${component}-index.json"
+    if ! inspect_raw "${repo}:${VERSION}" "$idx_file"; then
+        report_check 3 "(b) ${repo}:${VERSION}" "could not inspect the index at all"
         continue
     fi
+    idx_rc=0
+    out=$(python3 "$CHECKER" check-index "$idx_file" "$platforms") || idx_rc=$?
+    report_check "$idx_rc" "(b) ${repo}:${VERSION} vs declared (${platforms})" "$out"
 
-    # Capability-bearing component: check each leg (a), then the index (b), then
-    # cross-arch equivalence within THIS component only (c).
-    leg_files=()
-    for arch in "${arch_list[@]}"; do
-        arch_short="${arch#linux/}"
-        leg_tag="${repo}:${VERSION}-${capability}-${arch_short}"
-        leg_json=$(docker buildx imagetools inspect "$leg_tag" --raw 2>/dev/null)
-        if [[ -z "$leg_json" ]]; then
-            echo -e "${RED}could not inspect leg ${leg_tag}${NC}" >&2
-            manifest_check_rc=1
-            continue
-        fi
-        leg_rc=0
-        out=$(echo "$leg_json" | python3 "$CHECKER" check-leg /dev/stdin "$arch") || leg_rc=$?
-        if [[ $leg_rc -eq 0 ]]; then
-            echo -e "${GREEN}(a) ${leg_tag}: ${out}${NC}" >&2
-        else
-            echo -e "${RED}(a) leg check FAILED for ${leg_tag}: ${out}${NC}" >&2
-            manifest_check_rc=1
-        fi
-        leg_file="$(mktemp)"
-        echo "$leg_json" > "$leg_file"
-        leg_files+=("$leg_file")
-    done
-
-    idx_json=$(docker buildx imagetools inspect "${repo}:${VERSION}" --raw 2>/dev/null)
-    if [[ -n "$idx_json" ]]; then
-        idx_rc=0
-        out=$(echo "$idx_json" | python3 "$CHECKER" check-index /dev/stdin "$platforms") || idx_rc=$?
-        if [[ $idx_rc -eq 0 ]]; then
-            echo -e "${GREEN}(b) ${repo}:${VERSION} index matches declared platforms (${platforms}): ${out}${NC}" >&2
-        else
-            echo -e "${RED}(b) index platform-set check FAILED for ${repo}:${VERSION}: ${out}${NC}" >&2
-            manifest_check_rc=1
-        fi
-    else
-        echo -e "${RED}could not inspect index ${repo}:${VERSION}${NC}" >&2
-        manifest_check_rc=1
+    # (c) Cross-arch equivalence, within THIS component only. Applies to every
+    # component whose index declares two platforms — lite AND frontend/docs, which
+    # is what makes the 1.25 bound documented for them in releasing.md real rather
+    # than aspirational.
+    [[ ${#arch_list[@]} -eq 2 ]] || continue
+    bound="1.25"
+    [[ "$capability" == "cuda" ]] && bound="2.00"
+    a_file="${MANIFEST_TMP}/${component}-plat-a.json"
+    b_file="${MANIFEST_TMP}/${component}-plat-b.json"
+    if ! platform_manifest "$idx_file" "${arch_list[0]}" "$a_file" "$repo" \
+       || ! platform_manifest "$idx_file" "${arch_list[1]}" "$b_file" "$repo"; then
+        report_check 3 "(c) ${component}" \
+            "could not resolve both per-platform manifests (${arch_list[0]}, ${arch_list[1]}) from the index"
+        continue
     fi
-
-    if [[ ${#leg_files[@]} -eq 2 ]]; then
-        bound="2.00"
-        [[ "$capability" == "cpu" ]] && bound="1.25"
-        ratio_rc=0
-        out=$(python3 "$CHECKER" check-ratio "${leg_files[0]}" "${leg_files[1]}" "$bound") || ratio_rc=$?
-        if [[ $ratio_rc -eq 0 ]]; then
-            echo -e "${GREEN}(c) ${component}: legs equivalent within bound ${bound}: ${out}${NC}" >&2
-        else
-            echo -e "${RED}(c) equivalence check FAILED for ${component} (bound ${bound}): ${out}${NC}" >&2
-            manifest_check_rc=1
-        fi
-    fi
-    for f in "${leg_files[@]}"; do rm -f "$f"; done
+    ratio_rc=0
+    out=$(python3 "$CHECKER" check-ratio "$a_file" "$b_file" "$bound") || ratio_rc=$?
+    report_check "$ratio_rc" "(c) ${component} legs within bound ${bound}" "$out"
 done < <(./scripts/docker-build-push.sh list-platforms)
 
 if [[ $manifest_check_rc -ne 0 ]]; then

--- a/scripts/release/85-smoke.sh
+++ b/scripts/release/85-smoke.sh
@@ -1,10 +1,30 @@
 #!/bin/bash
-# Install from Docker Hub and verify BOTH architectures, post-publish.
+# Install from Docker Hub and verify capability, post-publish.
 #
 # This is the first stage that tests what a user will actually pull, rather than
-# what was built locally. The arm64 half runs the published image over the remote
-# builder's docker context and asserts /api/version — which proves the build-arg
-# contract survived on the architecture nobody builds locally.
+# what was built locally. issue #680's whole point is that "the manifest exists"
+# and "reports a version string" are NOT the same claim as "has the capability its
+# repository/tag promises" — the broken arm64 backend would have passed the old
+# `$APP_VERSION` echo check. So this stage asserts CAPABILITY, per component:
+#
+#   lite  (CPU-only, opentranscribe-backend-lite): torch.version.cuda must be
+#         EMPTY — a non-empty value here means the "lite" image actually shipped
+#         CUDA wheels, which is the #680 failure mode in the other direction.
+#   full  (CUDA, opentranscribe-backend):          torch.version.cuda must be
+#         NON-EMPTY.
+#   both: record onnxruntime's available execution providers (informational —
+#         differs legitimately by arch/capability, not asserted equal), and run
+#         `diar-server provision-models --mode cpu --json` with no token to
+#         confirm the diar-native binary that was COPYed in is actually
+#         runnable on this architecture (exit 5 TOKEN_DENIED expected — anything
+#         else, especially "exec format error", is exactly what issue #680's
+#         Dockerfile.lite/.prod bug would have produced on arm64 before the
+#         per-TARGETARCH fix).
+#
+# `full` (opentranscribe-backend) ships amd64-only for v0.5.0 (see backend/
+# Dockerfile.prod's diar-native-bin-arm64 stage) — its capability check always
+# runs on amd64 here. `lite` ships both architectures, so its arm64 leg is
+# checked over the remote builder's docker context when available.
 #
 # Exit: 0 verified · 1 failed · 3 live stack running
 
@@ -16,26 +36,77 @@ cd "$REPO_ROOT" || exit 2
 VERSION="${1:-${RELEASE_VERSION:-}}"
 JSON_OUT="${JSON_OUT:-false}"
 REMOTE_CTX="${REMOTE_ARM64_CONTEXT:-remote-arm64}"
-IMG="${DOCKERHUB_USERNAME:-davidamacey}/opentranscribe-backend:${VERSION}"
+HUB="${DOCKERHUB_USERNAME:-davidamacey}"
+IMG_FULL="${HUB}/opentranscribe-backend:${VERSION}"
+IMG_LITE="${HUB}/opentranscribe-backend-lite:${VERSION}"
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
 : "${VERSION:?85-smoke.sh needs a version}"
 
 fail=0
 
-# ── arm64: run the PUBLISHED image natively and ask it what it is ───────────
-if docker context inspect "$REMOTE_CTX" >/dev/null 2>&1; then
-    echo -e "${BLUE}arm64: checking the published image reports its version${NC}" >&2
-    got=$(docker --context "$REMOTE_CTX" run --rm --pull always --entrypoint sh "$IMG" \
-            -c 'echo "$APP_VERSION"' 2>/dev/null | tr -d '\r')
-    if [[ "$got" == "$VERSION" ]]; then
-        echo -e "${GREEN}PASS  arm64 image reports ${got}${NC}" >&2
+# Run capability checks inside an image (optionally over a remote docker
+# context) and assert torch.version.cuda's emptiness matches this component's
+# declared capability.
+assert_cuda_capability() {
+    local label="$1" img="$2" ctx="$3" expect_nonempty="$4"
+
+    local ctx_args=()
+    [[ -n "$ctx" ]] && ctx_args=(--context "$ctx")
+
+    local cuda_ver
+    cuda_ver=$(docker "${ctx_args[@]}" run --rm --pull always "$img" \
+        python3 -c 'import torch; print(torch.version.cuda or "")' 2>/dev/null | tr -d '\r')
+
+    if [[ "$expect_nonempty" == "true" ]]; then
+        if [[ -n "$cuda_ver" ]]; then
+            echo -e "${GREEN}PASS  ${label}: torch.version.cuda='${cuda_ver}' (full/CUDA capability confirmed)${NC}" >&2
+        else
+            echo -e "${RED}FAIL  ${label}: torch.version.cuda is EMPTY — this is supposed to be the CUDA image${NC}" >&2
+            fail=1
+        fi
     else
-        echo -e "${RED}FAIL  arm64 image reports '${got:-<empty>}', expected ${VERSION}${NC}" >&2
+        if [[ -z "$cuda_ver" ]]; then
+            echo -e "${GREEN}PASS  ${label}: torch.version.cuda is empty (CPU-only capability confirmed)${NC}" >&2
+        else
+            echo -e "${RED}FAIL  ${label}: torch.version.cuda='${cuda_ver}' — this is supposed to be the lite/CPU image (issue #680)${NC}" >&2
+            fail=1
+        fi
+    fi
+
+    local providers
+    providers=$(docker "${ctx_args[@]}" run --rm "$img" \
+        python3 -c 'import onnxruntime as ort; print(",".join(ort.get_available_providers()))' 2>/dev/null | tr -d '\r')
+    echo -e "${BLUE}      ${label}: onnxruntime providers = ${providers:-<none reported>}${NC}" >&2
+
+    # diar-server must be the RIGHT-ARCH binary. exit 5 = TOKEN_DENIED (expected,
+    # no token supplied) — anything else, especially a shell "exec format error"
+    # (rc 126) or "cannot execute binary file" (rc 127), means the COPY --from
+    # in this Dockerfile shipped a binary for the wrong architecture (#680).
+    local diar_rc=0
+    docker "${ctx_args[@]}" run --rm --entrypoint diar-server "$img" \
+        provision-models --models-dir /tmp/diar-smoke --mode cpu --json >/dev/null 2>&1 || diar_rc=$?
+    if [[ "$diar_rc" -eq 5 ]]; then
+        echo -e "${GREEN}PASS  ${label}: diar-server runs on this architecture (exit 5 TOKEN_DENIED, as expected)${NC}" >&2
+    else
+        echo -e "${RED}FAIL  ${label}: diar-server exited ${diar_rc}, expected 5 (TOKEN_DENIED) — possible wrong-arch binary (#680)${NC}" >&2
         fail=1
     fi
+}
+
+echo -e "${BLUE}amd64: full/CUDA image capability${NC}" >&2
+assert_cuda_capability "full-amd64" "$IMG_FULL" "" "true"
+
+echo -e "${BLUE}amd64: lite/CPU image capability${NC}" >&2
+assert_cuda_capability "lite-amd64" "$IMG_LITE" "" "false"
+
+if docker context inspect "$REMOTE_CTX" >/dev/null 2>&1; then
+    echo -e "${BLUE}arm64: lite/CPU image capability (over ${REMOTE_CTX})${NC}" >&2
+    assert_cuda_capability "lite-arm64" "$IMG_LITE" "$REMOTE_CTX" "false"
 else
-    echo -e "${YELLOW}SKIP  no '${REMOTE_CTX}' docker context — arm64 unverified${NC}" >&2
+    echo -e "${YELLOW}SKIP  no '${REMOTE_CTX}' docker context — lite arm64 unverified${NC}" >&2
 fi
+# full/CUDA has no arm64 leg for v0.5.0 (see backend/Dockerfile.prod) — nothing
+# to check there yet; do NOT probe IMG_FULL over $REMOTE_CTX.
 
 # ── amd64: the documented one-liner, against Docker Hub ────────────────────
 # Filter by compose project label, not a name prefix -- see 10-preflight.sh's

--- a/scripts/release/85-smoke.sh
+++ b/scripts/release/85-smoke.sh
@@ -53,9 +53,23 @@ assert_cuda_capability() {
     local ctx_args=()
     [[ -n "$ctx" ]] && ctx_args=(--context "$ctx")
 
+    # ⚠️ The exit code is load-bearing, and swallowing it was a fail-open: with
+    # `2>/dev/null` and no rc check, an image that could not run AT ALL (wrong-arch
+    # ELF, no python3, failed pull) yields an EMPTY string — which the lite branch
+    # below reads as "torch.version.cuda is empty, CPU-only confirmed" and PASSES.
+    # "could not check" must never look like "checked and correct" (issue #681's
+    # rule, applied here). So: capture rc, keep stderr, and fail on a bad run.
+    local run_out run_rc=0
+    run_out=$(docker "${ctx_args[@]}" run --rm --pull always "$img" \
+        python3 -c 'import torch; print(torch.version.cuda or "")' 2>&1) || run_rc=$?
+    if [[ $run_rc -ne 0 ]]; then
+        echo -e "${RED}FAIL  ${label}: could NOT run the capability probe (docker rc=${run_rc}) — this is 'not verified', not 'CPU-only'${NC}" >&2
+        echo "      ${run_out}" >&2
+        fail=1
+        return 1
+    fi
     local cuda_ver
-    cuda_ver=$(docker "${ctx_args[@]}" run --rm --pull always "$img" \
-        python3 -c 'import torch; print(torch.version.cuda or "")' 2>/dev/null | tr -d '\r')
+    cuda_ver=$(printf '%s' "$run_out" | tr -d '\r' | tail -n 1)
 
     if [[ "$expect_nonempty" == "true" ]]; then
         if [[ -n "$cuda_ver" ]]; then

--- a/scripts/release/90-promote.sh
+++ b/scripts/release/90-promote.sh
@@ -23,7 +23,7 @@ digest_of() {
 }
 
 fail=0
-for repo in backend frontend docs; do
+for repo in backend backend-lite frontend docs; do
     img="${USER_NS}/opentranscribe-${repo}"
     docker manifest inspect "${img}:${VERSION}" >/dev/null 2>&1 || {
         echo -e "${YELLOW}SKIP  ${repo}: no :${VERSION} published${NC}" >&2; continue; }

--- a/scripts/security-scan.sh
+++ b/scripts/security-scan.sh
@@ -16,6 +16,7 @@ NC='\033[0m' # No Color
 # Configuration
 DOCKERHUB_USERNAME="${DOCKERHUB_USERNAME:-davidamacey}"
 REPO_BACKEND="${DOCKERHUB_USERNAME}/opentranscribe-backend"
+REPO_BACKEND_LITE="${DOCKERHUB_USERNAME}/opentranscribe-backend-lite"
 REPO_FRONTEND="${DOCKERHUB_USERNAME}/opentranscribe-frontend"
 REPO_DOCS="${DOCKERHUB_USERNAME}/opentranscribe-docs"
 SCAN_TARGET="${1:-all}"
@@ -50,13 +51,17 @@ readonly EXIT_COULD_NOT_SCAN=2
 # is now a loud failure rather than a silent green scan.
 declare -A SCAN_COMPONENT_DOCKERFILE=(
     [backend]="backend/Dockerfile.prod"
+    [lite]="backend/Dockerfile.lite"
     [frontend]="frontend/Dockerfile.prod"
     [docs]="docs-site/Dockerfile"
+    [blackwell]="backend/Dockerfile.blackwell"
 )
 declare -A SCAN_COMPONENT_REPO=(
     [backend]="${REPO_BACKEND}"
+    [lite]="${REPO_BACKEND_LITE}"
     [frontend]="${REPO_FRONTEND}"
     [docs]="${REPO_DOCS}"
+    [blackwell]="${REPO_BACKEND}"
 )
 
 # Sorted, one per line — the machine-readable contract other scripts consume.
@@ -644,6 +649,17 @@ main() {
     # returned the banner plus the list.
     if [ "${SCAN_TARGET}" = "list-components" ]; then
         scan_components
+        exit 0
+    fi
+
+    # component<TAB>repo, one per line — the machine-readable contract release
+    # stages (50-scan.sh) derive their component->repo mapping from, so that
+    # mapping has exactly one home instead of being re-hardcoded per caller.
+    if [ "${SCAN_TARGET}" = "list-repos" ]; then
+        local component
+        for component in $(scan_components); do
+            printf '%s\t%s\n' "${component}" "${SCAN_COMPONENT_REPO[${component}]}"
+        done
         exit 0
     fi
 

--- a/scripts/tests/fixtures/manifest-fixtures.py
+++ b/scripts/tests/fixtures/manifest-fixtures.py
@@ -27,11 +27,61 @@ def single_platform(os_: str, arch: str, total_size: int, layer_count: int) -> d
     }
 
 
+def image_manifest(total_size: int, layer_count: int) -> dict:
+    """The REAL shape of `imagetools inspect repo@<digest> --raw`.
+
+    Verified against the published davidamacey/opentranscribe-backend:v0.4.1 amd64
+    manifest: keys are exactly config/layers/mediaType/schemaVersion — there is NO
+    `platform` key (architecture lives in the config blob, which --raw does not
+    fetch). This is what a size/layer comparison must be fed.
+    """
+    return {
+        'schemaVersion': 2,
+        'mediaType': 'application/vnd.oci.image.manifest.v1+json',
+        'config': {'mediaType': 'application/vnd.oci.image.config.v1+json', 'size': 12345},
+        'layers': _layers(total_size, layer_count),
+    }
+
+
 def index(platforms: list[dict], with_attestation: bool = False) -> dict:
     manifests = list(platforms)
     if with_attestation:
         manifests.append({'platform': {'os': 'unknown', 'architecture': 'unknown'}})
     return {'manifests': manifests}
+
+
+def real_index(entries: list[tuple[str, str]], with_attestation: bool = True) -> dict:
+    """The REAL shape of `imagetools inspect repo:tag --raw` on a published tag.
+
+    Verified against opentranscribe-backend:v0.4.1: each entry carries
+    digest/mediaType/platform/size, where `size` is the ~2.4 KB MANIFEST BLOB — there
+    is no `layers` key anywhere. Feeding this document to check-ratio is what produced
+    `sizes a=0 b=0 ratio=inf` before the resolve-digest step existed.
+    """
+    manifests = [
+        {
+            'mediaType': 'application/vnd.oci.image.manifest.v1+json',
+            'digest': 'sha256:' + (arch.encode().hex() * 16)[:64],
+            'size': 2393,
+            'platform': {'os': os_, 'architecture': arch},
+        }
+        for os_, arch in entries
+    ]
+    if with_attestation:
+        manifests.append(
+            {
+                'mediaType': 'application/vnd.oci.image.manifest.v1+json',
+                'digest': f'sha256:{"a" * 64}',
+                'size': 564,
+                'annotations': {'vnd.docker.reference.type': 'attestation-manifest'},
+                'platform': {'os': 'unknown', 'architecture': 'unknown'},
+            }
+        )
+    return {
+        'schemaVersion': 2,
+        'mediaType': 'application/vnd.oci.image.index.v1+json',
+        'manifests': manifests,
+    }
 
 
 FIXTURES = {
@@ -71,6 +121,33 @@ FIXTURES = {
             {'platform': {'os': 'linux', 'architecture': 'arm64'}},
         ]
     ),
+    # --- REAL document shapes (see the two builders above) ---------------------
+    # The published index: declares platforms, carries NO layers. Feeding this to
+    # check-ratio must be CANNOT CHECK, never a ratio verdict.
+    'real-index-amd64-arm64': real_index([('linux', 'amd64'), ('linux', 'arm64')]),
+    # The per-platform manifests the index points at: real v0.4.1 measurements,
+    # carrying layers and NO platform key.
+    'real-manifest-amd64': image_manifest(4_670_571_948, 11),
+    'real-manifest-arm64': image_manifest(802_291_513, 11),
+    # A near-equivalent pair, the shape a healthy lite/frontend index resolves to.
+    'real-manifest-cpu-a': image_manifest(50_205_619, 12),
+    'real-manifest-cpu-b': image_manifest(50_037_923, 12),
+    # The CONFIG BLOB, i.e. `imagetools inspect <ref> --format '{{json .Image}}'`.
+    # This is the ONLY place a bare (attestation-less) leg tag states its platform —
+    # verified 2026-09-05 against the real published davidamacey/diar-native:0.3.1-cpu,
+    # which reports os=linux architecture=amd64 there while its --raw declares none.
+    'image-config-amd64': {
+        'os': 'linux',
+        'architecture': 'amd64',
+        'rootfs': {'type': 'layers'},
+    },
+    'image-config-arm64': {
+        'os': 'linux',
+        'architecture': 'arm64',
+        'rootfs': {'type': 'layers'},
+    },
+    # A config blob with no platform fields at all — must be CANNOT CHECK, never a pass.
+    'image-config-empty': {'rootfs': {'type': 'layers'}},
 }
 
 

--- a/scripts/tests/fixtures/manifest-fixtures.py
+++ b/scripts/tests/fixtures/manifest-fixtures.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Fixture manifest JSON generators for scripts/tests/test-publish-platforms.sh.
+
+Sizes are the REAL measured numbers from issue #680 (backend v0.4.1 amd64/arm64) and
+issue #667's plan pass (frontend amd64/arm64) — not invented — so assertions 3/4 are
+checked against real, previously-observed data rather than a synthetic pair chosen to
+pass.
+"""
+
+import json
+import sys
+
+
+def _layers(total_size: int, count: int) -> list[dict]:
+    # Evenly split total_size across `count` layers — the ratio/layer-count check
+    # only cares about the sum and the count, not per-layer sizes.
+    base = total_size // count
+    layers = [{'size': base} for _ in range(count)]
+    layers[-1]['size'] += total_size - base * count
+    return layers
+
+
+def single_platform(os_: str, arch: str, total_size: int, layer_count: int) -> dict:
+    return {
+        'platform': {'os': os_, 'architecture': arch},
+        'layers': _layers(total_size, layer_count),
+    }
+
+
+def index(platforms: list[dict], with_attestation: bool = False) -> dict:
+    manifests = list(platforms)
+    if with_attestation:
+        manifests.append({'platform': {'os': 'unknown', 'architecture': 'unknown'}})
+    return {'manifests': manifests}
+
+
+FIXTURES = {
+    # Real v0.4.1 backend measurement (issue #680): amd64 4,454 MB total,
+    # arm64 765 MB total, 11 layers each. Ratio = 4670571948 / 802291513 = 5.82.
+    'backend-v041-amd64': single_platform('linux', 'amd64', 4_670_571_948, 11),
+    'backend-v041-arm64': single_platform('linux', 'arm64', 802_291_513, 11),
+    # Real frontend measurement (issue #667's plan pass): near-identical, 12 layers.
+    'frontend-amd64': single_platform('linux', 'amd64', 50_205_619, 12),
+    'frontend-arm64': single_platform('linux', 'arm64', 50_037_923, 12),
+    # A well-formed lite index: exactly amd64+arm64, no attestation noise stripped yet.
+    'lite-index-correct': index(
+        [
+            {'platform': {'os': 'linux', 'architecture': 'amd64'}},
+            {'platform': {'os': 'linux', 'architecture': 'arm64'}},
+        ]
+    ),
+    'lite-index-missing-arm64': index([{'platform': {'os': 'linux', 'architecture': 'amd64'}}]),
+    'lite-index-extra-riscv64': index(
+        [
+            {'platform': {'os': 'linux', 'architecture': 'amd64'}},
+            {'platform': {'os': 'linux', 'architecture': 'arm64'}},
+            {'platform': {'os': 'linux', 'architecture': 'riscv64'}},
+        ]
+    ),
+    'lite-index-with-attestation': index(
+        [
+            {'platform': {'os': 'linux', 'architecture': 'amd64'}},
+            {'platform': {'os': 'linux', 'architecture': 'arm64'}},
+        ],
+        with_attestation=True,
+    ),
+    'backend-leg-amd64-only': single_platform('linux', 'amd64', 100, 1),
+    'backend-leg-two-platforms': index(
+        [
+            {'platform': {'os': 'linux', 'architecture': 'amd64'}},
+            {'platform': {'os': 'linux', 'architecture': 'arm64'}},
+        ]
+    ),
+}
+
+
+def main() -> int:
+    name = sys.argv[1]
+    json.dump(FIXTURES[name], sys.stdout)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/tests/test-publish-platforms.sh
+++ b/scripts/tests/test-publish-platforms.sh
@@ -1,0 +1,275 @@
+#!/bin/bash
+# Regression test for issue #680 — the published arm64 backend manifest was not
+# equivalent to amd64 (765 MB vs 4,454 MB dependency layer, 8.4x smaller) and nothing
+# in the release pipeline would have caught it: 80-publish.sh's old check only asked
+# "does an arm64 manifest EXIST", never "is it the size a real CUDA build should be".
+#
+# Offline, fixture-driven, fast — modelled on scripts/tests/test-scan-not-a-pass.sh.
+# No Docker, no network, no images. Uses REAL measured sizes from issue #680 (backend
+# v0.4.1) and the #667 plan pass (frontend) as fixtures — see
+# scripts/tests/fixtures/manifest-fixtures.py.
+#
+# Each of the 11 assertions below is a MUST-FIRE or MUST-STAY-CLEAN case: every one is
+# run against a deliberately-broken state FIRST (the documented "red"), confirmed to
+# fail for the stated reason, and only then re-run against the real/fixed state to
+# confirm green. That is what "observe the red" means in this repo's testing
+# convention (root CLAUDE.md) and it is not optional ceremony here — three of these
+# assertions (5, 6, 9) exist specifically because a prior version of similar code
+# looked reasonable and was wrong.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+FIXTURES="$SCRIPT_DIR/fixtures/manifest-fixtures.py"
+CHECKER="$REPO_ROOT/scripts/lib/manifest_platform_check.py"
+
+pass=0
+fail=0
+ok() { echo "  ok   - $1"; pass=$((pass + 1)); }
+bad() { echo "  FAIL - $1"; fail=$((fail + 1)); }
+
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+fixture() {
+    python3 "$FIXTURES" "$1"
+}
+
+echo "== 1. list-platforms declares all legs with capability =="
+plat_out="$(cd "$REPO_ROOT" && ./scripts/docker-build-push.sh list-platforms)"
+# RED: prove this fails when a component is missing capability/platforms by
+# checking a component list-platforms is NOT supposed to have any entry for.
+if echo "$plat_out" | grep -q "^nonexistent-component"; then
+    bad "sanity: list-platforms should not know a made-up component (this would be the red state if it did)"
+else
+    ok "RED confirmed: list-platforms has no entry for a nonexistent component"
+fi
+# GREEN: every declared component has a non-empty capability field; backend/lite/
+# frontend/docs/blackwell must all be present.
+missing_cap=0
+for comp in backend lite frontend docs blackwell; do
+    line="$(echo "$plat_out" | awk -F'\t' -v c="$comp" '$1==c')"
+    if [ -z "$line" ]; then
+        bad "list-platforms is missing component '$comp'"
+        missing_cap=1
+        continue
+    fi
+    cap="$(echo "$line" | cut -f2)"
+    [ -n "$cap" ] || { bad "'$comp' has no capability"; missing_cap=1; }
+done
+[ "$missing_cap" -eq 0 ] && ok "list-platforms declares all 5 components with a non-empty capability"
+
+echo "== 2. 80-publish.sh has no literal 'for arch in amd64 arm64' and invokes list-platforms =="
+if grep -qE 'for[[:space:]]+arch[[:space:]]+in[[:space:]]+amd64[[:space:]]+arm64' "$REPO_ROOT/scripts/release/80-publish.sh"; then
+    bad "80-publish.sh still contains the literal hardcoded arch loop"
+else
+    ok "80-publish.sh contains no literal 'for arch in amd64 arm64'"
+fi
+if grep -q 'list-platforms' "$REPO_ROOT/scripts/release/80-publish.sh"; then
+    ok "80-publish.sh invokes list-platforms"
+else
+    bad "80-publish.sh never calls docker-build-push.sh list-platforms"
+fi
+
+echo "== 3. ratio check REJECTS the real v0.4.1 backend pair at bound 2.00 =="
+fixture backend-v041-amd64 > "$TMP_ROOT/be-amd64.json"
+fixture backend-v041-arm64 > "$TMP_ROOT/be-arm64.json"
+rc=0
+out="$(python3 "$CHECKER" check-ratio "$TMP_ROOT/be-amd64.json" "$TMP_ROOT/be-arm64.json" 2.00)" || rc=$?
+if [ "$rc" -eq 0 ]; then
+    bad "ratio check ACCEPTED the real v0.4.1 backend pair (should reject at 5.82 > 2.00): $out"
+else
+    ok "ratio check rejects the real v0.4.1 backend pair: $out"
+fi
+# RED confirmation: at an absurdly loose bound it must accept the SAME data —
+# proves the rejection above is really about the bound, not a broken checker.
+rc=0
+out="$(python3 "$CHECKER" check-ratio "$TMP_ROOT/be-amd64.json" "$TMP_ROOT/be-arm64.json" 10.0)" || rc=$?
+if [ "$rc" -eq 0 ]; then
+    ok "RED confirmed: the same pair passes at a loose bound (10.0) — rejection at 2.00 is the bound, not a broken checker: $out"
+else
+    bad "the same pair should pass at bound 10.0 but did not: $out"
+fi
+
+echo "== 4. ratio check ACCEPTS the real frontend pair (12 layers each) at bound 1.25 =="
+fixture frontend-amd64 > "$TMP_ROOT/fe-amd64.json"
+fixture frontend-arm64 > "$TMP_ROOT/fe-arm64.json"
+rc=0
+out="$(python3 "$CHECKER" check-ratio "$TMP_ROOT/fe-amd64.json" "$TMP_ROOT/fe-arm64.json" 1.25)" || rc=$?
+if [ "$rc" -eq 0 ]; then
+    ok "ratio check accepts the real frontend pair: $out"
+else
+    bad "ratio check rejected the real frontend pair (should pass at 1.25): $out"
+fi
+# RED confirmation: an artificially tight bound must reject the SAME good pair.
+rc=0
+out="$(python3 "$CHECKER" check-ratio "$TMP_ROOT/fe-amd64.json" "$TMP_ROOT/fe-arm64.json" 1.001)" || rc=$?
+if [ "$rc" -ne 0 ]; then
+    ok "RED confirmed: the same good pair fails an artificially tight bound (1.001): $out"
+else
+    bad "the same pair should fail at bound 1.001 but passed: $out"
+fi
+
+echo "== 5. index set-equality rejects an EXTRA platform =="
+fixture lite-index-extra-riscv64 > "$TMP_ROOT/idx-extra.json"
+rc=0
+out="$(python3 "$CHECKER" check-index "$TMP_ROOT/idx-extra.json" "linux/amd64,linux/arm64")" || rc=$?
+if [ "$rc" -eq 0 ]; then
+    bad "index check accepted an index with an undeclared extra platform (riscv64): $out"
+else
+    ok "index check rejects an extra undeclared platform: $out"
+fi
+# RED-confirmation-in-reverse: the CORRECT index (no extra platform) must pass the
+# same declared set, proving the rejection above is about the extra platform.
+fixture lite-index-correct > "$TMP_ROOT/idx-correct.json"
+rc=0
+out="$(python3 "$CHECKER" check-index "$TMP_ROOT/idx-correct.json" "linux/amd64,linux/arm64")" || rc=$?
+[ "$rc" -eq 0 ] && ok "RED confirmed: the correct index (no extra) passes the same check: $out" \
+    || bad "the correct index should pass but did not: $out"
+
+echo "== 6. index set-equality rejects a MISSING platform =="
+fixture lite-index-missing-arm64 > "$TMP_ROOT/idx-missing.json"
+rc=0
+out="$(python3 "$CHECKER" check-index "$TMP_ROOT/idx-missing.json" "linux/amd64,linux/arm64")" || rc=$?
+if [ "$rc" -eq 0 ]; then
+    bad "index check accepted an index missing arm64 — this is issue #680 itself: $out"
+else
+    ok "index check rejects a missing declared platform: $out"
+fi
+
+echo "== 7. a leg tag containing 2 platforms is rejected =="
+fixture backend-leg-two-platforms > "$TMP_ROOT/leg-two.json"
+rc=0
+out="$(python3 "$CHECKER" check-leg "$TMP_ROOT/leg-two.json" "linux/amd64")" || rc=$?
+if [ "$rc" -eq 0 ]; then
+    bad "leg check accepted a tag declaring 2 platforms: $out"
+else
+    ok "leg check rejects a tag declaring more than one platform: $out"
+fi
+# RED confirmation: a genuine single-platform leg matching the expectation passes.
+fixture backend-leg-amd64-only > "$TMP_ROOT/leg-one.json"
+rc=0
+out="$(python3 "$CHECKER" check-leg "$TMP_ROOT/leg-one.json" "linux/amd64")" || rc=$?
+[ "$rc" -eq 0 ] && ok "RED confirmed: a real single-platform leg passes the same check: $out" \
+    || bad "a real single-platform leg should pass but did not: $out"
+
+echo "== 8. cross-purpose comparison is never attempted =="
+# There is no code path in 80-publish.sh that feeds a backend (full/CUDA) manifest
+# and a lite (CPU) manifest — or any two different REPO_FOR_COMPONENT entries — into
+# the same check-ratio call. Grep for the one place ratio checks are invoked and
+# confirm every pairing is within a single component's own amd64/arm64 legs.
+if grep -q 'check-ratio' "$REPO_ROOT/scripts/release/80-publish.sh"; then
+    # Extract the two manifest arguments per check-ratio call and confirm they
+    # share a component prefix (derived from the same $component loop variable).
+    bad_pairs=0
+    while IFS= read -r line; do
+        # A cross-purpose call would reference two DIFFERENT $repo/$component
+        # variables on one line; every real call in 80-publish.sh instead uses the
+        # SAME $component-scoped leg variables for both arguments.
+        if echo "$line" | grep -qE '\$\{?REPO_BACKEND\}?.*\$\{?REPO_BACKEND_LITE\}?|\$\{?REPO_BACKEND_LITE\}?.*\$\{?REPO_BACKEND\}?'; then
+            bad_pairs=$((bad_pairs + 1))
+        fi
+    done < <(grep 'check-ratio' "$REPO_ROOT/scripts/release/80-publish.sh")
+    if [ "$bad_pairs" -eq 0 ]; then
+        ok "no check-ratio call in 80-publish.sh mixes REPO_BACKEND and REPO_BACKEND_LITE"
+    else
+        bad "found $bad_pairs check-ratio call(s) that appear to mix backend and lite repos"
+    fi
+else
+    bad "80-publish.sh never calls check-ratio at all — equivalence is not being checked"
+fi
+
+echo "== 9. every FROM ...@sha256: in Dockerfile.prod/Dockerfile.lite is multi-arch or per-TARGETARCH =="
+check_dockerfile_arch_safety() {
+    local dockerfile="$1"
+    # A single bare `FROM x@sha256:... AS diar-native-bin` with no TARGETARCH
+    # selection anywhere in the file is the RED state issue #680 found: BuildKit
+    # accepts a --platform linux/arm64 build against a single-arch amd64 base with
+    # only a warning, and ships an amd64 ELF under an arm64 tag.
+    if grep -q 'ARG TARGETARCH' "$dockerfile" && grep -qE 'FROM .*-\$\{TARGETARCH\}' "$dockerfile"; then
+        return 0
+    fi
+    return 1
+}
+if check_dockerfile_arch_safety "$REPO_ROOT/backend/Dockerfile.lite"; then
+    ok "Dockerfile.lite selects diar-native-bin per TARGETARCH"
+else
+    bad "Dockerfile.lite has no per-TARGETARCH diar-native selection"
+fi
+if check_dockerfile_arch_safety "$REPO_ROOT/backend/Dockerfile.prod"; then
+    ok "Dockerfile.prod selects diar-native-bin per TARGETARCH (arm64 leg intentionally unresolvable)"
+else
+    bad "Dockerfile.prod has no per-TARGETARCH diar-native selection"
+fi
+# RED: reverting to the pre-#680 single bare FROM (no ARG TARGETARCH, no per-arch
+# stage) must fail the same check — proves the assertion actually distinguishes them.
+cat > "$TMP_ROOT/Dockerfile.pre680" << 'EOF'
+FROM davidamacey/diar-native@sha256:83a709be94d0ca06441fa10aea0680f53b03cc10eb3ce11c4eeb84478400567d AS diar-native-bin
+FROM python:3.13-slim-trixie AS builder
+EOF
+if check_dockerfile_arch_safety "$TMP_ROOT/Dockerfile.pre680"; then
+    bad "the pre-#680 single-arch-only Dockerfile shape incorrectly passed the safety check"
+else
+    ok "RED confirmed: the pre-#680 single bare FROM (no TARGETARCH) fails the same check"
+fi
+
+echo "== 10. platform-table keys == security-scan.sh list-components =="
+scan_known="$(cd "$REPO_ROOT" && ./scripts/security-scan.sh list-components | sort | tr '\n' ' ')"
+table_known="$(echo "$plat_out" | cut -f1 | sort | tr '\n' ' ')"
+if [ "$scan_known" = "$table_known" ]; then
+    ok "docker-build-push.sh's platform table keys match security-scan.sh's list-components: '${scan_known% }'"
+else
+    bad "key sets differ — scan: '$scan_known' vs table: '$table_known'"
+fi
+# RED: assert_platform_table_matches_scan_components must itself fail when the
+# tables disagree. Exercise it directly by sourcing docker-build-push.sh with a
+# deliberately mismatched COMPONENT_PLATFORMS.
+red_out="$(
+    cd "$REPO_ROOT" || exit 99
+    # shellcheck source=/dev/null
+    . ./scripts/docker-build-push.sh
+    # Consumed by assert_platform_table_matches_scan_components, which reads this
+    # global associative array by name after being sourced above — shellcheck
+    # cannot see that cross-function use.
+    # shellcheck disable=SC2034
+    COMPONENT_PLATFORMS=([backend]="linux/amd64")  # drop lite/frontend/docs/blackwell
+    assert_platform_table_matches_scan_components
+)"
+red_rc=$?
+if [ "$red_rc" -ne 0 ]; then
+    ok "RED confirmed: assert_platform_table_matches_scan_components fails on a deliberately mismatched table"
+else
+    bad "assert_platform_table_matches_scan_components should have failed on a mismatched table: $red_out"
+fi
+
+echo "== 11. fixture parser ignores architecture: \"unknown\" attestation entries =="
+fixture lite-index-with-attestation > "$TMP_ROOT/idx-attest.json"
+rc=0
+out="$(python3 "$CHECKER" check-index "$TMP_ROOT/idx-attest.json" "linux/amd64,linux/arm64")" || rc=$?
+if [ "$rc" -eq 0 ]; then
+    ok "index check ignores an architecture:unknown attestation entry and still matches amd64+arm64: $out"
+else
+    bad "index check incorrectly counted an attestation entry as a real platform: $out"
+fi
+# RED: without the unknown-arch guard, an attestation-bearing index would report
+# THREE platforms (amd64, arm64, unknown/unknown) and reject as "extra" — prove this
+# by calling platform_set() directly and checking "unknown/unknown" is absent.
+red_check="$(python3 -c "
+import sys, json
+sys.path.insert(0, '$REPO_ROOT/scripts/lib')
+import manifest_platform_check as m
+doc = json.load(open('$TMP_ROOT/idx-attest.json'))
+platforms = m.platform_set(doc)
+assert 'unknown/unknown' not in platforms, f'attestation entry leaked into platform_set: {platforms}'
+print('ok')
+")"
+if [ "$red_check" = "ok" ]; then
+    ok "RED confirmed: platform_set() does not leak the attestation entry as unknown/unknown"
+else
+    bad "platform_set() leaked the attestation entry: $red_check"
+fi
+
+echo ""
+echo "passed: $pass   failed: $fail"
+[ "$fail" -eq 0 ]

--- a/scripts/tests/test-publish-platforms.sh
+++ b/scripts/tests/test-publish-platforms.sh
@@ -9,13 +9,18 @@
 # v0.4.1) and the #667 plan pass (frontend) as fixtures — see
 # scripts/tests/fixtures/manifest-fixtures.py.
 #
-# Each of the 11 assertions below is a MUST-FIRE or MUST-STAY-CLEAN case: every one is
-# run against a deliberately-broken state FIRST (the documented "red"), confirmed to
-# fail for the stated reason, and only then re-run against the real/fixed state to
-# confirm green. That is what "observe the red" means in this repo's testing
-# convention (root CLAUDE.md) and it is not optional ceremony here — three of these
-# assertions (5, 6, 9) exist specifically because a prior version of similar code
-# looked reasonable and was wrong.
+# Every assertion below is a MUST-FIRE or MUST-STAY-CLEAN case: each is run against a
+# deliberately-broken state FIRST (the documented "red"), confirmed to fail for the
+# stated reason, and only then re-run against the real/fixed state to confirm green.
+# That is what "observe the red" means in this repo's testing convention (root
+# CLAUDE.md) and it is not optional ceremony here — sections 5, 6 and 9 exist because a
+# prior version of similar code looked reasonable and was wrong, and sections 12-19
+# exist because the FIRST version of this gate would have failed every real publish
+# (it fed a manifest INDEX, which carries no layers, to the size comparison).
+#
+# Deliberately no assertion count in this header: run the file, it prints one. The
+# count here said "11" for three sections' worth of additions after it stopped being
+# true, which is exactly how a measurement transcribed into prose rots.
 
 set -uo pipefail
 
@@ -268,6 +273,180 @@ if [ "$red_check" = "ok" ]; then
     ok "RED confirmed: platform_set() does not leak the attestation entry as unknown/unknown"
 else
     bad "platform_set() leaked the attestation entry: $red_check"
+fi
+
+echo "== 12. an INDEX fed to check-ratio is CANNOT-CHECK (3), never a ratio verdict =="
+# This is the shape 80-publish.sh writes to disk: `imagetools inspect <tag> --raw`
+# returns an index with NO `layers` and a per-entry `size` of the ~2.4 KB manifest
+# blob. The first revision of the checker summed absent layers to 0 and reported
+# "ratio=inf exceeds bound" — a verdict drawn from data it never had, which fails
+# even when comparing a healthy index against ITSELF. Measured against the real
+# published opentranscribe-backend:v0.4.1 index before this case existed.
+fixture real-index-amd64-arm64 > "$TMP_ROOT/real-idx.json"
+rc=0
+out="$(python3 "$CHECKER" check-ratio "$TMP_ROOT/real-idx.json" "$TMP_ROOT/real-idx.json" 1.25)" || rc=$?
+if [ "$rc" -eq 3 ]; then
+    ok "check-ratio on an index reports CANNOT CHECK (exit 3): $out"
+elif [ "$rc" -eq 0 ]; then
+    bad "check-ratio ACCEPTED an index it cannot measure — a pass drawn from absent data: $out"
+else
+    bad "check-ratio on an index exited $rc (expected 3 = cannot check, not $rc = mismatch): $out"
+fi
+# RED confirmation: the SAME call on the per-platform manifests the index points at
+# must produce a real verdict, proving exit 3 above is about the document shape.
+fixture real-manifest-cpu-a > "$TMP_ROOT/real-cpu-a.json"
+fixture real-manifest-cpu-b > "$TMP_ROOT/real-cpu-b.json"
+rc=0
+out="$(python3 "$CHECKER" check-ratio "$TMP_ROOT/real-cpu-a.json" "$TMP_ROOT/real-cpu-b.json" 1.25)" || rc=$?
+[ "$rc" -eq 0 ] && ok "RED confirmed: the resolved per-platform manifests DO produce a verdict: $out" \
+    || bad "the resolved per-platform manifest pair should pass at 1.25 but exited $rc: $out"
+# ...and the real #680 pair, in the same real shape, is still rejected.
+fixture real-manifest-amd64 > "$TMP_ROOT/real-be-amd64.json"
+fixture real-manifest-arm64 > "$TMP_ROOT/real-be-arm64.json"
+rc=0
+out="$(python3 "$CHECKER" check-ratio "$TMP_ROOT/real-be-amd64.json" "$TMP_ROOT/real-be-arm64.json" 2.00)" || rc=$?
+[ "$rc" -eq 1 ] && ok "the real #680 v0.4.1 pair is rejected as a MISMATCH (exit 1) in the real doc shape: $out" \
+    || bad "expected exit 1 (mismatch) for the real #680 pair, got $rc: $out"
+
+echo "== 13. a document that declares no platform is CANNOT-CHECK, not '0 platforms' =="
+# A bare image manifest (what a builder that pushes no provenance leaves behind)
+# carries its architecture in the config blob, which --raw does not fetch. Reporting
+# "leg tag declares 0 platform(s)" for one would be a verdict from absent data.
+rc=0
+out="$(python3 "$CHECKER" check-leg "$TMP_ROOT/real-cpu-a.json" "linux/amd64")" || rc=$?
+if [ "$rc" -eq 3 ]; then
+    ok "check-leg on a platform-less image manifest reports CANNOT CHECK (exit 3): $out"
+else
+    bad "expected exit 3 (cannot check) for a platform-less manifest, got $rc: $out"
+fi
+rc=0
+out="$(python3 "$CHECKER" check-index "$TMP_ROOT/real-cpu-a.json" "linux/amd64,linux/arm64")" || rc=$?
+[ "$rc" -eq 3 ] && ok "check-index on a platform-less image manifest also reports CANNOT CHECK: $out" \
+    || bad "expected exit 3 from check-index on a platform-less manifest, got $rc: $out"
+
+echo "== 14. malformed / empty input is CANNOT-CHECK (3), not a mismatch (1) =="
+printf 'not json at all' > "$TMP_ROOT/garbage.json"
+rc=0
+out="$(python3 "$CHECKER" check-index "$TMP_ROOT/garbage.json" "linux/amd64")" || rc=$?
+[ "$rc" -eq 3 ] && ok "malformed JSON exits 3 (cannot check): $out" \
+    || bad "malformed JSON should exit 3, got $rc: $out"
+: > "$TMP_ROOT/empty.json"
+rc=0
+out="$(python3 "$CHECKER" check-index "$TMP_ROOT/empty.json" "linux/amd64")" || rc=$?
+[ "$rc" -eq 3 ] && ok "an empty inspect result exits 3 (cannot check): $out" \
+    || bad "an empty inspect result should exit 3, got $rc: $out"
+rc=0
+out="$(python3 "$CHECKER" check-index "$TMP_ROOT/does-not-exist.json" "linux/amd64")" || rc=$?
+[ "$rc" -eq 3 ] && ok "a missing file exits 3 (cannot check): $out" \
+    || bad "a missing file should exit 3, got $rc: $out"
+
+echo "== 15. resolve-digest turns an index into the per-platform manifest digest =="
+rc=0
+dig="$(python3 "$CHECKER" resolve-digest "$TMP_ROOT/real-idx.json" "linux/arm64")" || rc=$?
+expect_arm="sha256:$(python3 -c "print(('arm64'.encode().hex()*16)[:64])")"
+if [ "$rc" -eq 0 ] && [ "$dig" = "$expect_arm" ]; then
+    ok "resolve-digest returns the arm64 entry's digest: $dig"
+else
+    bad "resolve-digest arm64 gave rc=$rc digest='$dig', expected '$expect_arm'"
+fi
+# Never the attestation entry, and never a platform the index does not declare.
+rc=0
+out="$(python3 "$CHECKER" resolve-digest "$TMP_ROOT/real-idx.json" "unknown/unknown")" || rc=$?
+[ "$rc" -eq 1 ] && ok "resolve-digest refuses the attestation entry (exit 1, mismatch): $out" \
+    || bad "resolve-digest should not resolve unknown/unknown, got rc=$rc: $out"
+rc=0
+out="$(python3 "$CHECKER" resolve-digest "$TMP_ROOT/real-cpu-a.json" "linux/amd64")" || rc=$?
+[ "$rc" -eq 3 ] && ok "resolve-digest on a non-index reports CANNOT CHECK (exit 3): $out" \
+    || bad "resolve-digest on a non-index should exit 3, got $rc: $out"
+
+echo "== 16. 80-publish.sh resolves per-platform manifests before comparing sizes =="
+# Structural, because the functional half needs a registry: the ratio check must be
+# fed repo@<digest> documents, so `resolve-digest` has to appear on the same path as
+# `check-ratio`. Without it the stage inspects the index and compares nothing.
+if grep -q 'resolve-digest' "$REPO_ROOT/scripts/release/80-publish.sh"; then
+    ok "80-publish.sh resolves per-platform digests before check-ratio"
+else
+    bad "80-publish.sh calls check-ratio without ever resolving a per-platform digest — it is comparing indexes"
+fi
+# The ratio check must also cover frontend/docs, whose 1.25 bound releasing.md
+# documents; gating it on leg tags alone silently exempted them.
+if grep -qE 'leg_files\[@\]\}? -eq 2' "$REPO_ROOT/scripts/release/80-publish.sh"; then
+    bad "the equivalence check is still gated on leg-tag count, so frontend/docs are exempt from it"
+else
+    ok "the equivalence check is not gated on capability leg tags (frontend/docs are covered)"
+fi
+
+echo "== 17. 85-smoke's capability probe cannot PASS on a run that never happened =="
+# The lite assertion is "torch.version.cuda is EMPTY". An image that cannot execute at
+# all — wrong-arch ELF, no python3, failed pull — also yields an empty string, so a
+# probe that discards docker's exit status turns "could not check" into "CPU-only
+# confirmed". That is the #680 failure mode wearing a green tick, in the one stage
+# whose whole job is to catch it.
+SMOKE="$REPO_ROOT/scripts/release/85-smoke.sh"
+if grep -q 'run_rc' "$SMOKE" && grep -q 'could NOT run the capability probe' "$SMOKE"; then
+    ok "85-smoke captures the capability probe's exit status and fails on a bad run"
+else
+    bad "85-smoke's capability probe does not check docker's exit status — an unrunnable image passes the lite assertion"
+fi
+# The pre-fix probe was `python3 -c 'import torch; ...' 2>/dev/null | tr -d '\r'` on one
+# line — stderr AND (through the pipe) the exit status both discarded. Assert that exact
+# shape is gone; this fires on the committed pre-fix file, which is what makes it a test
+# rather than a restatement of the line above.
+if grep -q "torch.version.cuda.*2>/dev/null" "$SMOKE"; then
+    bad "85-smoke still reads torch.version.cuda from a run whose stderr and exit status are discarded"
+else
+    ok "the exit-status-discarding probe form is gone from 85-smoke"
+fi
+
+echo "== 18. check (a) can still VERIFY a leg that declares no platform in its manifest =="
+# A leg tag pushed without provenance attestations resolves to a BARE IMAGE MANIFEST,
+# which declares no platform at all. check-leg can only answer CANNOT CHECK for that
+# shape (assertion 13) — so without a fallback, check (a) would be permanently
+# inconclusive whenever attestations are off, and "a check that can never pass" is not
+# a gate. The fallback reads the CONFIG BLOB. Verified against the real published
+# davidamacey/diar-native:0.3.1-cpu: its --raw declares no platform, while
+# `--format '{{json .Image}}'` reports os=linux architecture=amd64.
+fixture image-config-amd64 > "$TMP_ROOT/cfg-amd64.json"
+rc=0
+out="$(python3 "$CHECKER" check-image-config "$TMP_ROOT/cfg-amd64.json" "linux/amd64")" || rc=$?
+if [ "$rc" -eq 0 ]; then
+    ok "a config blob VERIFIES the declared platform (exit 0): $out"
+else
+    bad "check-image-config could not verify a matching config blob (rc=$rc): $out"
+fi
+# RED 1: the same code path must REJECT a config blob for the wrong architecture —
+# otherwise the fallback would be a rubber stamp that turns every leg green.
+rc=0
+out="$(python3 "$CHECKER" check-image-config "$TMP_ROOT/cfg-amd64.json" "linux/arm64")" || rc=$?
+if [ "$rc" -eq 1 ]; then
+    ok "RED confirmed: an amd64 config blob is REJECTED (exit 1) when arm64 was declared: $out"
+else
+    bad "an amd64 config blob checked against linux/arm64 should exit 1, got rc=$rc: $out"
+fi
+# RED 2: a config blob carrying no platform fields must be CANNOT CHECK (3), not a pass.
+fixture image-config-empty > "$TMP_ROOT/cfg-empty.json"
+rc=0
+out="$(python3 "$CHECKER" check-image-config "$TMP_ROOT/cfg-empty.json" "linux/amd64")" || rc=$?
+if [ "$rc" -eq 3 ]; then
+    ok "RED confirmed: a platform-less config blob is CANNOT CHECK (exit 3), not a pass: $out"
+else
+    bad "a platform-less config blob should exit 3 (cannot check), got rc=$rc: $out"
+fi
+
+echo "== 19. 80-publish.sh actually WIRES that fallback into check (a) =="
+# Static: the fallback must be reachable from the leg loop, keyed on the CANNOT-CHECK
+# exit specifically. Gating it on any non-zero rc would swallow a genuine mismatch
+# (exit 1) and re-check it via a different route, turning a real #680-class finding
+# into a pass — so assert on the exact `-eq 3` guard, not merely on the subcommand.
+if grep -q 'check-image-config' "$REPO_ROOT/scripts/release/80-publish.sh"; then
+    ok "80-publish.sh calls check-image-config"
+else
+    bad "80-publish.sh never calls check-image-config — check (a) stays inconclusive without attestations"
+fi
+if grep -qE 'leg_rc -eq 3' "$REPO_ROOT/scripts/release/80-publish.sh"; then
+    ok "the fallback is gated on the CANNOT-CHECK exit (3) specifically, not on any failure"
+else
+    bad "the config-blob fallback is not gated on exit 3 — a real mismatch (exit 1) could be re-checked into a pass"
 fi
 
 echo ""

--- a/scripts/tests/test-scan-not-a-pass.sh
+++ b/scripts/tests/test-scan-not-a-pass.sh
@@ -91,8 +91,8 @@ echo "== security-scan.sh: exit codes distinguish 'found something' from 'never 
 # MUST-FIRE. Before the fix this exited 1 — the same code as "scanned, has
 # findings" — which is what made the two indistinguishable to every caller.
 rc=0
-( cd "$REPO_ROOT" && OUTPUT_DIR="$REPORTS_DIR" ./scripts/security-scan.sh lite ) \
-    > "$TMP_ROOT/scan-lite.out" 2>&1 || rc=$?
+( cd "$REPO_ROOT" && OUTPUT_DIR="$REPORTS_DIR" ./scripts/security-scan.sh bogus ) \
+    > "$TMP_ROOT/scan-bogus.out" 2>&1 || rc=$?
 if [ "$rc" -eq 2 ]; then
     ok "an unknown component exits 2 (could not scan), not 1 (findings)"
 else
@@ -100,12 +100,13 @@ else
 fi
 
 # MUST-STAY-CLEAN: the machine-readable component contract other scripts derive
-# their lists from must actually list the three published images.
+# their lists from must actually list the published images (issue #680 added
+# `lite` and `blackwell` alongside the original three).
 known="$( (cd "$REPO_ROOT" && OUTPUT_DIR="$REPORTS_DIR" ./scripts/security-scan.sh list-components 2>/dev/null) | tr '\n' ' ')"
-if [ "$known" = "backend docs frontend " ]; then
+if [ "$known" = "backend blackwell docs frontend lite " ]; then
     ok "list-components reports the published components: ${known% }"
 else
-    bad "list-components reported '${known:0:120}'; expected 'backend docs frontend '"
+    bad "list-components reported '${known:0:120}'; expected 'backend blackwell docs frontend lite '"
 fi
 
 echo "== run_security_scan: the policy flag tolerates findings, never the absence of a scan =="
@@ -116,7 +117,7 @@ case_unscannable_component_is_fatal() {
     export FAIL_ON_SECURITY_ISSUES=false
     export SKIP_SECURITY_SCAN=false
     local rc=0
-    OUTPUT_DIR="$REPORTS_DIR" run_security_scan lite > "$TMP_ROOT/rss-lite.out" 2>&1 || rc=$?
+    OUTPUT_DIR="$REPORTS_DIR" run_security_scan bogus > "$TMP_ROOT/rss-bogus.out" 2>&1 || rc=$?
     return "$rc"
 }
 rc=0
@@ -279,7 +280,7 @@ case_parallel_unscannable_component() {
     export SKIP_SECURITY_SCAN=false
     export FAIL_ON_SECURITY_ISSUES=false
     local rc=0
-    run_parallel_scans lite > "$TMP_ROOT/parallel-lite.out" 2>&1 || rc=$?
+    run_parallel_scans bogus > "$TMP_ROOT/parallel-bogus.out" 2>&1 || rc=$?
     return "$rc"
 }
 rc=0
@@ -289,7 +290,7 @@ if [ "$rc" -ne 0 ]; then
 else
     bad "run_parallel_scans returned 0 for a component that cannot be scanned"
 fi
-if grep -qF "$SUCCESS_BANNER" "$TMP_ROOT/parallel-lite.out"; then
+if grep -qF "$SUCCESS_BANNER" "$TMP_ROOT/parallel-bogus.out"; then
     bad "the summary printed '$SUCCESS_BANNER' for a component that was never scanned"
 else
     ok "the summary does NOT claim success for a component that was never scanned"
@@ -323,7 +324,7 @@ case_pull_dispatch_refuses_unknown() {
     assert_components_scannable() { return 0; }  # bypass the earlier guard
     run_security_scan() { return 0; }
     local rc=0
-    run_parallel_scans lite > "$TMP_ROOT/parallel-nopull.out" 2>&1 || rc=$?
+    run_parallel_scans bogus > "$TMP_ROOT/parallel-nopull.out" 2>&1 || rc=$?
     return "$rc"
 }
 rc=0


### PR DESCRIPTION
## The defect

`davidamacey/opentranscribe-backend:latest` publishes a `linux/arm64` manifest that is a
**CPU-only image under the same tag as the GPU image, with no signal anywhere**. Measured from
the published manifests (read-only, nothing pulled): amd64 **4,454 MB** / arm64 **765 MB**,
11 layers each, dependency layer **8.4x** smaller.

Docker selects by platform automatically, so an ARM user got it **without opting in and with no
warning**. The failure mode is the bad kind: the image pulls quickly, starts fine, and dies later
at model-load time inside a Celery worker.

Nothing in the pipeline could have caught it. `80-publish.sh`'s check grepped the manifest for
`"architecture": "arm64"` — which a degraded-but-present leg passes — and `85-smoke.sh` asserted
`echo $APP_VERSION`, which any image that boots will satisfy.

## The 8.4x delta was CORRECT dependency resolution, not a failed build

This is the load-bearing finding, and it determines the shape of the fix.

There is no aarch64 wheel for `torch 2.8.0+cu128`, and the 14 `nvidia-*-cu12` dependencies are
gated `platform_machine == "x86_64"`. An arm64 "full" build therefore resolves, correctly, to a
CPU-only dependency set. **The build did exactly what it was told.** So the fix is not to make
the two images match — it is to stop shipping two different capabilities under one tag.

⚠️ **v0.5.0 FLIPS this, which is why the gate does not key on size.** `torch-2.11.0+cu128-…-aarch64.whl`
now exists and the `nvidia-*` deps have lost the arch marker. A size-tuned threshold would newly
**PASS** on the exact same structural defect while nothing had been fixed. The gate therefore
asserts **declared platform sets** (missing *and* extra), with size only as a within-capability
sanity bound.

## Measured BuildKit finding: a cross-platform digest pin does not error

`backend/Dockerfile.lite` pinned the same digest as `Dockerfile.prod` — `diar-native:0.3.1`, the
**CUDA amd64** image — while its comment claimed CPU-provider libs.

**CONTROL (pre-fix):** `docker buildx build --platform linux/arm64` against that single-arch amd64
digest **exits 0**. BuildKit emits only `InvalidBaseImagePlatform`, `COPY --from` succeeds, and the
image ships an **amd64 ELF** that fails at container start with `exec format error`.

**AFTER (real cross-arch build through the real `Dockerfile.lite`, `--target diar-native-bin`,
local output, nothing pushed):**

| leg | `file /usr/local/bin/diar-server` | `libonnxruntime_providers_cuda.so` |
|---|---|---|
| `linux/arm64` | `ELF 64-bit LSB pie executable, ARM aarch64` | absent |
| `linux/amd64` | `ELF 64-bit LSB pie executable, x86-64` | absent |

amd64 now correctly gets the **CPU** diar-native image rather than the CUDA one it was mis-pinned to.
Digests verified against the registry: `b00b4bb5…` = `0.3.1-cpu`, `63e7a727…` = `0.3.1-cpu-arm64`.

`Dockerfile.prod`'s arm64 row is deliberately an **unresolvable tag** rather than a wrong digest, so
an arm64 leg fails loudly at the pull step. Verified with a structural probe:

```
--platform linux/amd64 → exit 0   (BuildKit prunes the unused arm64 stage)
--platform linux/arm64 → exit 1   ERROR: failed to solve: …UNAVAILABLE-NO-CUDA-ARM64-BUILD-SEE-ISSUE-680: not found
```

## The fix: capability in the repository, restated in the tag

| repo | capability | legs | index | `:latest` |
|---|---|---|---|---|
| `opentranscribe-backend` | `cuda` | `vX.Y.Z-cuda-amd64` | `vX.Y.Z` | digest-copy |
| `opentranscribe-backend-lite` | `cpu` | `vX.Y.Z-cpu-amd64`, `vX.Y.Z-cpu-arm64` | `vX.Y.Z` | digest-copy |
| `opentranscribe-frontend` / `-docs` | `multiarch` | — | `vX.Y.Z` | digest-copy |

Single home: `./scripts/docker-build-push.sh list-platforms`. `80-publish.sh`, `40-build.sh` and
`50-scan.sh` all derive from it instead of hardcoding architectures. **`PLATFORMS` is now an
explicit override, not a both-arch default** — that default is the mechanism #680 names.

### Scope: THREE artifacts for v0.5.0

`full-amd64`, `lite-amd64`, `lite-arm64`. **`full-cuda-arm64` is deferred** because
`davidamacey/diar-native` publishes no CUDA arm64 tag (only `*-cpu-arm64` / `*-provision-arm64`,
confirmed against Docker Hub) — an **external prerequisite, not a hardware limitation**. The leg is
reserved in the grammar and not built.

### Blackwell SAFETY fix — and it is NOT published here

`build_backend_blackwell` previously built **unscanned** (no `security-scan.sh` arm), **unlabelled**
(no OCI identity labels), and **pushed unconditionally with a hardcoded `--push`, ignoring
`BUILD_MODE`** — so a `BUILD_MODE=local` run pushed to Docker Hub anyway. It now honours
`BUILD_MODE`, appends to `BUILT_COMPONENTS`, and is excluded from `all`/`auto`. **This PR publishes
no blackwell image.**

## Three defects found while auditing the first commit, fixed here

1. **The new manifest gate could never have passed a real publish.** `imagetools inspect --raw`
   returns two shapes: an INDEX declares platforms but has no `layers` (its per-entry `size` is the
   ~2.4 KB manifest blob), while a per-platform MANIFEST has layers but declares no platform. The
   ratio check was fed the index, so it reported `sizes a=0 b=0 ratio=inf` — **measured against the
   real published v0.4.1 index, it fails even comparing an index against itself**. Worse, the
   layer-count half *passed* on no data (`0 == 0`). Fixed with `resolve-digest` + a second inspect.
2. **`85-smoke.sh` could pass an image that never ran.** The lite assertion is "`torch.version.cuda`
   is EMPTY" — and an image that cannot execute at all also prints an empty string. The probe
   discarded docker's exit status, so a wrong-arch ELF would have **passed the very check written to
   catch it**. Now captures rc and fails on a bad run.
3. **`nvidia_gpu_offer_available()` was dead code**, while `pin_diar_native_image_for_blackwell`
   (which *writes a sticky `.env` pin*) and `gpu_split_active` each re-derived a subset of its
   conditions — so a lite/arm64 deployment would have pinned a Blackwell CUDA image. Wired in, with
   lite added as a fourth reason.

Also: `flower` had no `docker-compose.lite.yml` override, no profile and no `scale: 0`, so it starts
on every lite deployment **from the full image** — on arm64 (now the default) `docker compose up`
would have failed outright with "no matching manifest for linux/arm64".

Checker exit codes are now three-valued — `0` verified / `1` verified-and-WRONG / `3` could-not-check
— the same rule `security-scan.sh` applies to its 1-vs-2 (#681).

## Docs

The "Apple Silicon MPS acceleration, M2 Max: 1-hour video → ~15-20 minutes" claim is removed rather
than softened, in six places. Docker Desktop on macOS has no Metal passthrough, and
`backend/app/transcription/CLAUDE.md` already documents the MPS branch as unreachable in every
containerised deployment (`_detect_optimal_device` gates on `platform.system() == "darwin"`, never
true inside the Linux container). macOS is now documented as CPU-only via the `--lite` image.

`.github/workflows/docker-publish.yml` is **retired**: its `imagetools create -t …:latest …:latest-amd64`
step would have overwritten the index `90-promote.sh` copies by digest, silently breaking the
":latest and :vX.Y.Z are the same bytes" guarantee. Its backend arm64 job was already `if: false`, so
it assembled an amd64-only index by hand — the shape of this bug.

## ⚠️ Before the first lite publish

**`davidamacey/opentranscribe-backend-lite` does not exist on Docker Hub yet** (`/v2/repositories/…`
returns 404). It must be created before `80-publish.sh` can push to it.

## Gates

- `scripts/tests/test-publish-platforms.sh` — **41 passed, 0 failed** (19 sections; every new
  assertion observed RED against the pre-fix tree via `git archive`)
- `scripts/tests/test-scan-not-a-pass.sh` — **19 passed, 0 failed**
- `backend/tests/unit/test_compose_file_selection.py` — **30 passed** (the deliberate
  `test_lite_mode_is_not_reachable_by_a_shipped_deployment` tripwire fired exactly as designed and is
  **inverted, not deleted**, so the same three facts stay asserted)
- 257 passed across the compose/shell/install/precommit-parity unit modules
- `bash -n` + `shellcheck -S warning` clean on all touched scripts; `ruff check`/`format` clean
- `scripts/audit-tests.py tests` — 0 un-allowlisted findings
- Both pre-commit tiers: `run --all-files` **exit 0**, `--hook-stage pre-push` **exit 0**
- `scripts/release/release-criteria.yaml` **untouched** (verified against `master`)
- **No image built for a registry and nothing pushed.** Newest Docker Hub tag is still `v0.4.1`
  (2026-04-15); no `v0.5.0` exists.

## Related

- #713 — architecture-blocked verification matrix (what could not be verified on this hardware)
- #667 — the lite-reachability half (multi-arch lite image publication)

Closes #680
