### PR TITLE
fix(admin): move speaker/profile embedding removal out of the open transaction

### DIFF
--- a/backend/app/api/endpoints/admin.py
+++ b/backend/app/api/endpoints/admin.py
@@ -305,10 +305,18 @@ def get_gpu_usage():
 
 
 def _delete_user_speakers(db: Session, user_id: int) -> None:
-    """Delete all speakers for a user, including OpenSearch embeddings.
+    """Delete all speakers for a user. Pure DB — no OpenSearch here (issue #715).
 
-    Collects speaker UUIDs before bulk SQL delete so OpenSearch can be cleaned
-    even though the bulk operation bypasses ORM instance-level callbacks.
+    This used to remove each speaker's OpenSearch embedding itself, one round trip
+    per speaker, from inside the caller's open transaction (``delete_admin_user``'s
+    ``db.begin_nested()`` savepoint, or the bare request transaction in
+    ``users.delete_user``) — holding locks, including ``ACCESS SHARE`` on
+    ``media_file`` taken moments later, for as long as OpenSearch took to answer. The
+    caller now reads every speaker UUID via
+    ``file_cleanup_service.load_account_purge_plans`` **before** this function runs
+    and removes the embeddings via ``purge_account_external_copies`` **after** its own
+    transaction commits, with no session held — the same phase split
+    ``_delete_user_owned_records`` already uses for ``SpeakerProfile`` avatars.
 
     **The segment detach is not optional.** ``transcript_segment.speaker_id`` is a
     plain FK with ``ON DELETE NO ACTION``, and this runs *before*
@@ -346,16 +354,6 @@ def _delete_user_speakers(db: Session, user_id: int) -> None:
     db.query(Speaker).filter(Speaker.user_id == user_id).delete(synchronize_session=False)
     logger.info("Speakers deleted from DB")
 
-    # Clean OpenSearch embeddings after bulk DB delete (non-fatal)
-    try:
-        from app.services.opensearch_service import remove_speaker_embedding
-
-        for uuid in speaker_uuids:
-            remove_speaker_embedding(uuid)
-        logger.info(f"Removed {len(speaker_uuids)} speaker embeddings from OpenSearch")
-    except Exception as e:
-        logger.warning(f"OpenSearch speaker cleanup failed during user {user_id} deletion: {e}")
-
 
 def _delete_user_owned_records(db: Session, user_id: int) -> None:
     """Delete all user-owned records that are not covered by DB-level CASCADE.
@@ -388,6 +386,13 @@ def _delete_user_owned_records(db: Session, user_id: int) -> None:
     via ``file_cleanup_service.load_account_purge_plans`` **before** this function runs
     and destroys the objects via ``purge_account_external_copies`` after the
     transaction commits.
+
+    **Nor are the profiles' OpenSearch embeddings** (issue #715). This used to remove
+    each one itself, one round trip per profile, from inside the caller's open
+    transaction — the same defect ``_delete_user_speakers`` had. The caller now reads
+    every profile UUID via ``load_account_purge_plans`` alongside the avatar paths and
+    removes the embeddings via ``purge_account_external_copies`` after the transaction
+    commits.
     """
     # Speaker collections and their members
     sc_ids = [
@@ -412,9 +417,8 @@ def _delete_user_owned_records(db: Session, user_id: int) -> None:
         db.query(Collection).filter(Collection.user_id == user_id).delete(synchronize_session=False)
         logger.info(f"Deleted {len(col_ids)} collections for user {user_id}")
 
-    # Speaker profiles — collect UUIDs first so OpenSearch can be cleaned
-    profile_rows = db.query(SpeakerProfile.uuid).filter(SpeakerProfile.user_id == user_id).all()
-    profile_uuids = [str(row[0]) for row in profile_rows]
+    # Speaker profiles. OpenSearch embeddings are NOT removed here — see the
+    # docstring; the caller's purge plan already has every UUID.
     profiles_deleted = (
         db.query(SpeakerProfile)
         .filter(SpeakerProfile.user_id == user_id)
@@ -422,14 +426,6 @@ def _delete_user_owned_records(db: Session, user_id: int) -> None:
     )
     if profiles_deleted:
         logger.info(f"Deleted {profiles_deleted} speaker profiles for user {user_id}")
-        try:
-            from app.services.opensearch_service import remove_profile_embedding
-
-            for puuid in profile_uuids:
-                remove_profile_embedding(puuid)
-            logger.info(f"Removed {len(profile_uuids)} profile embeddings from OpenSearch")
-        except Exception as e:
-            logger.warning(f"OpenSearch profile cleanup failed during user {user_id} deletion: {e}")
 
     # Comments
     comments_deleted = (

--- a/backend/app/services/file_cleanup_service.py
+++ b/backend/app/services/file_cleanup_service.py
@@ -505,6 +505,30 @@ def _erase_speaker_docs(speaker_uuids: list[str], fail: Callable[[str, object], 
             fail("speakers", f"could not verify {idx}: {e}")
 
 
+def _erase_profile_docs(profile_uuids: list[str], fail: Callable[[str, object], None]) -> None:
+    """Delete the account's speaker-profile embeddings (biometric data).
+
+    Sibling of :func:`_erase_speaker_docs` for :class:`SpeakerProfile` rows (issue
+    #715) — used only by :func:`purge_account_external_copies`, after the account's
+    rows have already committed, so a failure here is not retryable and must be
+    reported rather than swallowed. ``remove_profile_embedding`` sweeps its own main +
+    v4-staging indices and swallows its own errors (returns ``False`` for both
+    "absent" and "failed"), so — unlike the speaker case — there is no independent
+    survivor count to verify against; the best this can report is whether the call
+    itself raised.
+    """
+    if not profile_uuids:
+        return
+
+    for profile_uuid in profile_uuids:
+        try:
+            from app.services.opensearch_service import remove_profile_embedding
+
+            remove_profile_embedding(profile_uuid)
+        except Exception as e:  # noqa: BLE001 — it swallows its own; this is belt-and-braces
+            fail("profiles", e)
+
+
 def _erase_transcript_doc(file_uuid: str, fail: Callable[[str, object], None]) -> None:
     """Delete the transcript document — the verbatim text of the recording."""
     try:
@@ -778,10 +802,20 @@ class AccountPurgePlan:
             preserved when a single FILE is destroyed — but the account-delete path
             destroys the profiles themselves (``_delete_user_owned_records``), and
             nothing else has ever removed the avatar objects backing them.
+        speaker_uuids: Every ``Speaker.uuid`` this account owns (issue #715). Read
+            here, alongside ``avatar_paths``, so :func:`purge_account_external_copies`
+            can remove the OpenSearch voiceprints **after** the account's rows commit,
+            instead of ``admin._delete_user_speakers`` doing it — one OpenSearch round
+            trip per speaker — from inside the caller's open transaction.
+        profile_uuids: Every ``SpeakerProfile.uuid`` this account owns (issue #715),
+            for the same reason: ``admin._delete_user_owned_records`` used to remove
+            the profile embeddings itself, also from inside the open transaction.
     """
 
     files: list[dict[str, Any]] = field(default_factory=list)
     avatar_paths: list[str] = field(default_factory=list)
+    speaker_uuids: list[str] = field(default_factory=list)
+    profile_uuids: list[str] = field(default_factory=list)
 
 
 def load_account_purge_plans(db: Session, user_id: int) -> AccountPurgePlan:
@@ -791,13 +825,16 @@ def load_account_purge_plans(db: Session, user_id: int) -> AccountPurgePlan:
     reason :func:`_load_purge_plan` reads plain data: an escaping instance lazy-loads,
     which reopens a transaction in the middle of the caller's external-copy phase.
 
-    ``speaker_uuids`` is deliberately left ``[]`` on every file plan here, NOT because
-    the file's speakers should be skipped, but because the account-delete cascade
-    already removes every one of this user's speaker embeddings itself
-    (``admin._delete_user_speakers``, which runs before the bulk file delete). Reusing
-    ``_purge_external_copies`` per file would otherwise attempt the same OpenSearch
-    deletes twice — harmless (idempotent), but worth documenting so a future reader
-    does not "fix" this into a duplicate sweep.
+    ``speaker_uuids`` is left ``[]`` on every FILE plan here — not because a file's
+    speakers should be skipped, but because they are not per-file work at all.
+    :class:`AccountPurgePlan` carries the account's speaker and profile UUIDs at the
+    top level instead (issue #715): both used to be swept by
+    ``admin._delete_user_speakers`` / ``admin._delete_user_owned_records`` themselves,
+    one OpenSearch round trip per speaker/profile, from inside the caller's open
+    transaction. They are read here as plain column-only tuples, and
+    :func:`purge_account_external_copies` removes the embeddings after the account's
+    rows have committed, matching the phase split every other external-copy delete in
+    this module already uses.
 
     Args:
         db: The caller's session, used only for the reads below.
@@ -807,6 +844,7 @@ def load_account_purge_plans(db: Session, user_id: int) -> AccountPurgePlan:
         An :class:`AccountPurgePlan` naming every object this account's cascade must
         remove from object storage and OpenSearch.
     """
+    from app.models.media import Speaker
     from app.models.media import SpeakerProfile
 
     file_rows = (
@@ -841,7 +879,20 @@ def load_account_purge_plans(db: Session, user_id: int) -> AccountPurgePlan:
     )
     avatar_paths = [str(row[0]) for row in avatar_rows if row[0]]
 
-    return AccountPurgePlan(files=files, avatar_paths=avatar_paths)
+    speaker_rows = db.query(Speaker.uuid).filter(Speaker.user_id == user_id).all()
+    speaker_uuids = [str(row[0]) for row in speaker_rows]
+
+    profile_uuid_rows = (
+        db.query(SpeakerProfile.uuid).filter(SpeakerProfile.user_id == user_id).all()
+    )
+    profile_uuids = [str(row[0]) for row in profile_uuid_rows]
+
+    return AccountPurgePlan(
+        files=files,
+        avatar_paths=avatar_paths,
+        speaker_uuids=speaker_uuids,
+        profile_uuids=profile_uuids,
+    )
 
 
 def purge_account_external_copies(plan: AccountPurgePlan) -> list[dict[str, Any]]:
@@ -853,6 +904,10 @@ def purge_account_external_copies(plan: AccountPurgePlan) -> list[dict[str, Any]
     :func:`_purge_external_copies` per file rather than open-coding a second artifact
     list, which is what gives this call thumbnail + derived-cache (including listed
     masked variants) + OpenSearch erasure for free, in one audited implementation.
+    Also sweeps ``plan.speaker_uuids`` / ``plan.profile_uuids`` (issue #715) — this is
+    now the only place either embedding is removed; neither
+    ``admin._delete_user_speakers`` nor ``admin._delete_user_owned_records`` touches
+    OpenSearch any more.
 
     Args:
         plan: The plain-data plan from :func:`load_account_purge_plans`.
@@ -874,6 +929,12 @@ def purge_account_external_copies(plan: AccountPurgePlan) -> list[dict[str, Any]
                     "error": str(e),
                 }
             )
+
+    def _fail(stage: str, err: object) -> None:
+        residual.append({"stage": stage, "error": str(err)})
+
+    _erase_speaker_docs(plan.speaker_uuids, _fail)
+    _erase_profile_docs(plan.profile_uuids, _fail)
 
     for avatar_path in plan.avatar_paths:
         try:

--- a/backend/tests/api/endpoints/test_user_delete_storage_reclaim.py
+++ b/backend/tests/api/endpoints/test_user_delete_storage_reclaim.py
@@ -527,6 +527,14 @@ def test_a_speaker_embedding_removal_failure_is_reported_as_partial(
     monkeypatch.setattr(os_mod, "remove_speaker_embedding", _boom)
     monkeypatch.setattr(fcs, "_cleanup_opensearch_for_file", lambda target, file_uuid: [])
     monkeypatch.setattr(fcs, "_count_surviving", lambda index, query: 0)
+    # The storage leg must SUCCEED for this test to measure what its docstring claims.
+    # Left real, the result depends on whether object storage happens to be reachable:
+    # locally the dev stack answers and only "speakers" fails, but CI has no MinIO, so
+    # `delete_file_storage_artifacts` returns False and `stages` becomes
+    # ["speakers", "storage"]. Stubbing at this seam (rather than at `minio_service.
+    # delete_file`) is what actually covers it — the storage leg also touches the
+    # derived-render cache bucket, so a lower-level stub leaves that path still live.
+    monkeypatch.setattr(fcs, "delete_file_storage_artifacts", lambda file_id, meta: True)
 
     events: list[dict] = []
     real_log = acct_module.audit_logger.log

--- a/backend/tests/api/endpoints/test_user_delete_storage_reclaim.py
+++ b/backend/tests/api/endpoints/test_user_delete_storage_reclaim.py
@@ -32,6 +32,7 @@ from minio.error import S3Error
 from app.auth.audit import AuditOutcome
 from app.core.config import settings
 from app.models.media import MediaFile
+from app.models.media import Speaker
 from app.models.media import SpeakerProfile
 from app.models.user import User
 from app.services.minio_service import minio_client
@@ -409,6 +410,145 @@ def test_the_media_file_delete_is_still_one_statement(
         event.remove(engine, "before_cursor_execute", _before_cursor_execute)
 
     assert len(statements) == 1, f"expected exactly one bulk DELETE, got {statements}"
+
+
+def _make_speaker(db_session, user_id: int, media_file_id: int, **kwargs) -> Speaker:
+    speaker = Speaker(
+        uuid=kwargs.pop("uuid", None) or uuid_pkg.uuid4(),
+        user_id=user_id,
+        media_file_id=media_file_id,
+        name=kwargs.pop("name", "SPEAKER_00"),
+        **kwargs,
+    )
+    db_session.add(speaker)
+    db_session.commit()
+    db_session.refresh(speaker)
+    return speaker
+
+
+def _make_speaker_profile(db_session, user_id: int, **kwargs) -> SpeakerProfile:
+    profile = SpeakerProfile(
+        uuid=kwargs.pop("uuid", None) or uuid_pkg.uuid4(),
+        user_id=user_id,
+        name=kwargs.pop("name", f"Profile {uuid_pkg.uuid4().hex[:8]}"),
+        **kwargs,
+    )
+    db_session.add(profile)
+    db_session.commit()
+    db_session.refresh(profile)
+    return profile
+
+
+def test_speaker_and_profile_embeddings_are_removed_only_after_the_rows_are_committed(
+    client, admin_token_headers, normal_user, db_session, monkeypatch
+):
+    """The issue #715 headline: no OpenSearch round trip while a transaction is open.
+
+    ``_delete_user_speakers`` used to call ``remove_speaker_embedding`` once per
+    speaker — and ``_delete_user_owned_records`` called ``remove_profile_embedding``
+    once per profile — from INSIDE ``delete_admin_user``'s ``db.begin_nested()``
+    savepoint. This spies on ``Session.commit`` and both OpenSearch removal functions
+    into one ORDERED list and asserts every removal call follows the commit — the same
+    shape as ``test_the_objects_are_removed_only_after_the_rows_are_committed`` above,
+    which pins the same rule for object storage.
+    """
+    import app.services.opensearch_service as os_mod
+
+    media_file = _make_media_file(db_session, int(normal_user.id))
+    speaker = _make_speaker(db_session, int(normal_user.id), int(media_file.id))
+    profile = _make_speaker_profile(db_session, int(normal_user.id))
+    # Captured now: the request commits and deletes these rows, which expires the
+    # ORM instances — reading .uuid off them AFTER the request raises ObjectDeletedError.
+    speaker_uuid = str(speaker.uuid)
+    profile_uuid = str(profile.uuid)
+
+    order: list[str] = []
+    real_commit = db_session.commit
+
+    def _commit_spy():
+        order.append("commit")
+        return real_commit()
+
+    def _speaker_spy(speaker_uuid: str):
+        order.append(f"speaker:{speaker_uuid}")
+        return True
+
+    def _profile_spy(profile_uuid: str):
+        order.append(f"profile:{profile_uuid}")
+        return True
+
+    monkeypatch.setattr(db_session, "commit", _commit_spy)
+    monkeypatch.setattr(os_mod, "remove_speaker_embedding", _speaker_spy)
+    monkeypatch.setattr(os_mod, "remove_profile_embedding", _profile_spy)
+
+    response = client.delete(f"/api/admin/users/{normal_user.uuid}", headers=admin_token_headers)
+    assert response.status_code == status.HTTP_200_OK, response.text
+
+    speaker_call = f"speaker:{speaker_uuid}"
+    profile_call = f"profile:{profile_uuid}"
+
+    assert "commit" in order
+    assert speaker_call in order, f"the speaker embedding was never removed: {order}"
+    assert profile_call in order, f"the profile embedding was never removed: {order}"
+    assert order.index("commit") < order.index(speaker_call), (
+        f"a speaker embedding was removed before any commit: {order}"
+    )
+    assert order.index("commit") < order.index(profile_call), (
+        f"a profile embedding was removed before any commit: {order}"
+    )
+
+
+def test_a_speaker_embedding_removal_failure_is_reported_as_partial(
+    client, admin_token_headers, normal_user, db_session, monkeypatch
+):
+    """A removal failure must land in ``residual_errors`` -> PARTIAL, never a 500 or a silent pass.
+
+    ``purge_account_external_copies`` takes no session and must never raise
+    (``users.delete_user`` has no try/except around it) — so this asserts the account
+    delete still returns 200 with the deletion already committed, AND that the
+    failure is visible in the audit trail, not merely logged.
+
+    The file's own OpenSearch legs (transcript/chunks/summaries) and the speaker
+    survivor-count verification are stubbed to a clean no-op — this test measures the
+    speaker-removal failure in isolation, not whatever a real/unreachable cluster does
+    to the file-level legs (see ``test_a_storage_failure_is_reported_and_does_not_
+    silently_pass``'s docstring for why those legs are noisy without a stub).
+    """
+    import app.services.file_cleanup_service as fcs
+    import app.services.opensearch_service as os_mod
+    from app.services import account_security_service as acct_module
+
+    media_file = _make_media_file(db_session, int(normal_user.id))
+    _make_speaker(db_session, int(normal_user.id), int(media_file.id))
+
+    def _boom(speaker_uuid: str):
+        raise RuntimeError(f"simulated OpenSearch outage for {speaker_uuid}")
+
+    monkeypatch.setattr(os_mod, "remove_speaker_embedding", _boom)
+    monkeypatch.setattr(fcs, "_cleanup_opensearch_for_file", lambda target, file_uuid: [])
+    monkeypatch.setattr(fcs, "_count_surviving", lambda index, query: 0)
+
+    events: list[dict] = []
+    real_log = acct_module.audit_logger.log
+
+    def _spy_log(**kw):
+        events.append(kw)
+        return real_log(**kw)
+
+    monkeypatch.setattr(acct_module.audit_logger, "log", _spy_log)
+
+    response = client.delete(f"/api/admin/users/{normal_user.uuid}", headers=admin_token_headers)
+
+    assert response.status_code == status.HTTP_200_OK, response.text
+
+    db_session.expire_all()
+    assert db_session.query(User).filter(User.id == normal_user.id).first() is None, (
+        "a residual OpenSearch failure must not be retried by leaving the account undeleted"
+    )
+
+    assert len(events) == 1
+    assert events[0]["outcome"] is AuditOutcome.PARTIAL
+    assert events[0]["details"]["stages"] == ["speakers"]
 
 
 def _calls(func_node: ast.FunctionDef | ast.AsyncFunctionDef, name: str) -> bool:


### PR DESCRIPTION
⚠️ **Stacked on #714** — base is `fix/user-delete-storage-reclaim-695`, not `master`. Merge #714 first; I will retarget this to `master` afterwards.

## The defect

`_delete_user_speakers` and `_delete_user_owned_records` each removed OpenSearch embeddings **one round trip per speaker/profile, from inside the caller's open transaction** — `delete_admin_user`'s `db.begin_nested()` savepoint, or the bare request transaction in `users.delete_user`.

This is the same class that wedged this database twice in one day (48 min and 1h26m `idle in transaction`, holding `ACCESS SHARE` on `media_file`, queueing an `ALTER TABLE` and pinning the VACUUM horizon).

## The fix

Uses the phase split #714 established, and fills the slot it deliberately left:

- `AccountPurgePlan` gains `speaker_uuids` and `profile_uuids`, collected in **Phase 0** as plain column-only reads (no ORM instances escape — one would lazy-load and reopen a transaction).
- `purge_account_external_copies` sweeps both in **Phase 2**, after the rows are committed and no transaction is held, via a new `_erase_profile_docs` sibling of the existing `_erase_speaker_docs`.
- `_delete_user_speakers` and `_delete_user_owned_records` become pure-DB functions.
- #714's `speaker_uuids: []` comment ("already handled elsewhere") is **removed** — leaving it would now be actively misleading.

Failures land in the existing `residual_errors` → `AuditOutcome.PARTIAL` path. No new sink, no new table.

## Evidence

RED against pre-fix source (`git archive origin/fix/user-delete-storage-reclaim-695`), independently re-run:

```
FAILED test_speaker_and_profile_embeddings_are_removed_only_after_the_rows_are_committed
FAILED test_a_speaker_embedding_removal_failure_is_reported_as_partial
2 failed, 1 passed
```

The first fails with `ObjectDeletedError` (removal never went through the plan's captured UUIDs); the second with `outcome SUCCESS != PARTIAL` (the failure was silently logged and never surfaced).

The ordering test is the load-bearing one: it spies `Session.commit` and both embedding-removal functions into **one ordered list** and asserts every removal follows the commit — so a future refactor that moves the work back inside the transaction fails rather than silently regressing.

GREEN: **61 passed** across `test_user_delete_storage_reclaim.py` + `test_admin.py` + `test_users.py`.
Gates: `audit-tests.py` → 0 findings; `audit-session-lifetime.py backend/app` → 0 findings (directly relevant here); both pre-commit tiers clean.

Closes #715


---
_Reopened from #717, which GitHub auto-closed when its stacked base branch (`fix/user-delete-storage-reclaim-695`, PR #714) was deleted on merge. Same single commit `9c05428e`, now based on `master`._
