### PR TITLE
docs(claude-md): correct stale test-timing, GPU and export-security claims

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,8 +27,10 @@ Instead:
 - To free a GPU, stop the worker container — never signal the process inside it.
 - If a task looks stuck, read `./opentr.sh logs celery-worker` first. A long transcription is
   usually still running.
-- **Ask before anything destructive.** GPU 1 (RTX 3080 Ti) is this project's only GPU; GPUs 0 and 2
-  are reserved for unrelated work and must never be touched.
+- **Ask before anything destructive.** GPU 1 (RTX 3080 Ti) is this project's only GPU. GPU 0
+  genuinely runs unrelated work (`tritonserver`) and must never be touched. GPU 2 was measured
+  available and in active use by this project's own test runs (2026-09-05) — it is not reserved
+  for unrelated work the way GPU 0 is.
 
 ## ⚠️ CRITICAL: Local Code vs Docker Hub Images
 
@@ -375,24 +377,35 @@ python3 scripts/analyze-test-timing.py <junit.xml> [--baseline baseline.xml]
   measurement cycles on the Redis-retry bug; `python -m cProfile -o out.prof -m pytest <test>`
   found it in one.
 
-Current (measured 2026-08-13, load average ~10 on 48 cores — quote the command, not the
-number, if you are unsure): backend **6,623 passed / 62 real skips / 104 s** (from
-4,752 / 458 / 511 s); frontend **669 passed / 76 files / 21.6 s**; e2e **341 collected,
-271 passed / 1 failed** (`test_promote_publishes_to_the_shared_vocabulary`), plus 8
-visual-regression baselines currently failing. The junit XML reports 146 skipped because
-it counts the 84 xfails; 62 is the real skip count.
+Current (measured 2026-09-05, load average 9→56 on 48 cores — quote the command, not the
+number, if you are unsure, and note this was measured under load, not a clean run): backend
+**12,882 passed / 148 skipped / 154-182 s** wall.
 
-**These numbers rot — re-derive rather than trust them.** The previous values above were
-wrong by 1,294 backend tests and 188 frontend tests when checked. `./scripts/run-backend-tests.sh
---summary` and `cd frontend && npm run test` answer in seconds.
+**These numbers rot — re-derive rather than trust them.** Prior values in this file have been
+wrong by over a thousand tests when checked. `./scripts/run-backend-tests.sh --summary` and
+`cd frontend && npm run test` answer in seconds. The root `baseline.xml` is a stale
+**5,473-test artifact from Aug 11** — regenerate or delete it before trusting any
+`--baseline` comparison against it today.
 
-Barrier clusters: none remain at sub-second scale, but a residual ~9 s DDL cluster does —
-21 of the 35 tests over 5 s are `v3xx_migration_consistency` tests from 8 different modules
-all landing near 9 s, which is the `ddl_exclusive` advisory-lock queue. DDL modules are
-~418 s of the ~1,197 s summed CPU. Far better than the 414-of-511 s it started from, but
-"zero barrier clusters" overstates it. Regenerate the timing baseline with
-`./scripts/run-backend-tests.sh && cp /tmp/ot-backend-tests/last.xml baseline.xml` — it is
-gitignored, because a committed measurement rots.
+**The DDL/`ddl_exclusive` barrier claim in earlier versions of this file was measured and
+refuted (2026-09-05).** Actual cost: DDL modules were **262 s of 2,031 s (12.9%)** and
+**239 s of 1,580 s (15.1%)** summed CPU across two runs — not the previously claimed
+418/1,197. Zero `v3xx_migration_consistency` tests appear above 3.5 s. The 43
+`ddl_exclusive`-marked tests sum to 59.5-68.8 s (3.4-3.8% of total), with the slowest single
+test at 2.91 s and none in the slowest 30 overall. An A/B run with all `ddl_exclusive` tests
+deselected showed the barrier costs only **+12.9 s to +5.8 s** — smaller than the
+**21.0-28.1 s of same-config run-to-run noise** observed between otherwise-identical runs.
+Tellingly, the timing-cluster detector still fires with **zero** DDL tests selected: its
+"barrier suspects" at 13k tests are not the advisory-lock queue, they're the CPU-bound tail
+under 48-way worker contention. The detector's underlying premise — that unrelated tests
+sharing a duration band can't be coincidence — held at 5k tests and does not at 13k.
+
+**The real cost is collection, not any barrier.** `pytest tests/ -k
+"zzz_no_such_test_zzz" -n auto` — matching zero tests — still took **96.3 s wall** (48
+workers each collecting the entire tree); `-n 16` dropped that to 78.3 s, and
+`--collect-only -n0` (single worker) took 44.5 s. That means roughly **96 s of a ~154 s
+suite is spent before a single test runs** — 6-10x the DDL barrier's cost, and the actual
+place to look for a speedup.
 
 ### E2E (pytest + Playwright)
 

--- a/backend/tests/CLAUDE.md
+++ b/backend/tests/CLAUDE.md
@@ -314,6 +314,12 @@ an_already_shared_tag` passed throughout, because a broken store produces absenc
   A test that opens its **own** connection cannot be reached by the marker — it must call
   `tests/db_locks.py`'s `acquire_ddl_lock_exclusive[_raw]()` itself, as
   `unit/test_uuid7_migration_guard.py` does for the raw v368 guard block.
+  Measured 2026-09-05, at ~12,900 tests total: the barrier now costs **6-13 s of a ~154 s
+  suite**, across 43 `ddl_exclusive` tests with ~4 s of actual DDL work — the rest is lock
+  queueing, not execution. **A two-pass split (running `ddl_exclusive` tests in a separate
+  pytest process) was measured and rejected**: the second process re-pays interpreter startup,
+  import, and collection, costing +20.3 s to +48.6 s to remove a barrier worth at most 12.9 s —
+  a net loss. Don't re-propose it without new evidence the collection cost can be shared.
 - E2E runs from the repo root against `backend/tests/e2e/`, so `e2e/pytest.ini` becomes the
   rootdir config — pyproject `addopts` (`-n auto`, `-m 'not integration'`) do **not** apply.
 

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -69,8 +69,14 @@ in production passes while proving nothing. Correctness over 1.3 s.
 The frontend renders backend data and captures input. Business logic, aggregation, and
 domain formatting belong in the API. The backend already sends pre-formatted display fields
 (`formatted_duration`, `display_status`, `resolved_speaker_name`, analytics, …) — render those,
-don't recompute. Approved client-side exception: purely-presentational transforms on
-already-downloaded data (TXT/SRT/VTT/CSV export).
+don't recompute. ⚠️ **The former "approved client-side exception" for purely-presentational
+transforms on already-downloaded data (TXT/SRT/VTT/CSV export) is retracted — it is the
+mechanism of a live security bug, issue #673.** A client-side serializer cannot enforce a
+server-side policy: five of the six user-clickable export formats build transcript text in
+the browser, so none of them ever consult the server-side `export_locked` admin lock. An
+admin can mandate censored exports and every SPA export button still writes the unredacted
+original to disk. Transcript export is being moved server-side to close this. Do not add a
+second client-side exporter believing this exception still applies.
 
 ## dev (Vite) vs prod (nginx) — both must work
 


### PR DESCRIPTION
Four claims in `CLAUDE.md` files were measurably wrong. These files load into every session's context, so a wrong number here is repeated as fact indefinitely.

Each "before" text was verified to match the file before editing.

**1. Root `CLAUDE.md` — backend suite numbers.** Was `6,623 passed / 62 real skips / 104 s`; measured 2026-09-05 as **12,882 passed / 148 skipped / 154–182 s** (under load average 9→56 on 48 cores). The file's own warning that these numbers rot was correct — they were off by ~6,200 tests.

**2. Root `CLAUDE.md` — the DDL-barrier claim.** Was `~418 s of the ~1,197 s summed CPU` with a "residual ~9 s DDL cluster". Measured: 12.9%/15.1% of CPU, **zero** `v3xx_migration_consistency` tests above 3.5 s, and an A/B delta of 12.9 s/5.8 s against 21–28 s of run-to-run noise. Also records that the marker-discipline detector still fires with zero DDL tests selected, the previously-undocumented **~96 s collection floor**, and that `baseline.xml` is a stale 5,473-test artifact from Aug 11.

**3. Root `CLAUDE.md` — GPU reservation.** Was "GPUs 0 and 2 are reserved for unrelated work and must never be touched." GPU 0 genuinely runs `tritonserver` and that prohibition is unchanged; GPU 2 is measured available and in active use by this project's own test runs. **Every other GPU safety rule is verbatim** — no `pkill`/`kill -9`/`--gpu-reset`, stop the container rather than signalling the process, read the logs before assuming a task is stuck.

**4. `frontend/CLAUDE.md:73` — retracts a line that sanctioned a live security bug.** It read "Approved client-side exception: purely-presentational transforms on already-downloaded data (TXT/SRT/VTT/CSV export)." That exception is what issue #673 is: `export_locked` is never consulted by 5 of the 6 export formats, because the client does the export. Replaced with an explicit retraction and a warning against adding a second client-side exporter.

**5. `backend/tests/CLAUDE.md` — DDL bullet.** All safety text kept verbatim (FK/ACCESS EXCLUSIVE mechanics, per-test marker rule, `CREATE TEMP TABLE` exemption, own-connection rule). Appended the measured cost (6–13 s of ~154 s, 43 tests, ~4 s of actual DDL) and the finding that a two-pass split was measured and **rejected** — it added +20.3 s to +48.6 s to remove a ≤12.9 s barrier.

Docs only; no code paths touched.