### PR TITLE
fix(install): don't fail an install on a required entry that only a borrowed manifest lists

### DIFF
--- a/backend/tests/unit/test_release_manifest.py
+++ b/backend/tests/unit/test_release_manifest.py
@@ -217,6 +217,105 @@ def test_a_fresh_install_downloads_every_compose_overlay_the_manifest_lists(tmp_
         assert (workdir / overlay).is_file(), f"{overlay} was not written to the install dir"
 
 
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
+def test_a_pinned_install_survives_a_required_entry_the_tag_predates(tmp_path):
+    """issue #723 — a REQUIRED manifest entry added TODAY must not retroactively break the
+    install of an ALREADY PUBLISHED release.
+
+    `download_release_manifest_artifacts()` fetches the manifest from the pinned ref first,
+    but falls back to the default branch when that ref predates release-manifest.txt
+    entirely (issue #683). That fallback list is then NEWER than the tag it is applied to, so
+    it can list a required entry the tag genuinely never shipped — exactly what happened when
+    `NOTICE` was added required (91128ecb) while v0.4.1 (published before release-manifest.txt
+    existed) was still the latest release: the pinned manifest fetch 404ed, the fallback to
+    master borrowed a manifest listing NOTICE as required, and the download of NOTICE from the
+    v0.4.1 tag 404ed too, which install-failed EVERY fresh install.
+
+    This drives that exact shape with a SYNTHETIC required entry rather than pinning on NOTICE
+    itself, per the issue's acceptance criteria: the regression is the class (a borrowed,
+    newer-than-the-tag manifest listing something the tag lacks), not this one instance.
+    A pinned install must still succeed — skipping the entry, not failing closed.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+
+    old_tag = "v0.0.0-predates-manifest"
+    synthetic_required_entry = "SYNTHETIC_REQUIRED_FILE_723"
+
+    borrowed_manifest = tmp_path / "borrowed-release-manifest.txt"
+    borrowed_manifest.write_text(f"docker-compose.yml\n{synthetic_required_entry}\n")
+
+    # Stub curl:
+    #   * the OLD TAG's own manifest fetch 404s (it predates release-manifest.txt)
+    #   * the DEFAULT BRANCH's manifest fetch succeeds, returning the borrowed manifest
+    #     above — which lists a REQUIRED entry the old tag never shipped
+    #   * the GitHub API call inside resolve_default_branch() reports "master"
+    #   * every artifact download from the old tag succeeds EXCEPT the synthetic entry,
+    #     which 404s — simulating a file that simply does not exist at that old ref
+    stub = bin_dir / "curl"
+    stub.write_text(
+        "#!/bin/bash\n"
+        "url=''; out=''\n"
+        "while [ $# -gt 0 ]; do\n"
+        '  case "$1" in\n'
+        '    -o) out="$2"; shift 2 ;;\n'
+        '    http*) url="$1"; shift ;;\n'
+        "    *) shift ;;\n"
+        "  esac\n"
+        "done\n"
+        '  case "$url" in\n'
+        "    *api.github.com*)\n"
+        '      echo \'{"default_branch": "master"}\'\n'
+        "      exit 0\n"
+        "      ;;\n"
+        f"    */master/release-manifest.txt)\n"
+        f'      cp {borrowed_manifest} "$out"\n'
+        "      exit 0\n"
+        "      ;;\n"
+        f"    */{old_tag}/release-manifest.txt)\n"
+        # This tag predates the manifest — the pinned-ref fetch must fail.
+        "      exit 1\n"
+        "      ;;\n"
+        f"    *{synthetic_required_entry})\n"
+        # This tag never shipped the synthetic file the borrowed manifest requires.
+        "      exit 1\n"
+        "      ;;\n"
+        "    *)\n"
+        '      [ -n "$out" ] && printf "stub-content\\n" > "$out"\n'
+        "      exit 0\n"
+        "      ;;\n"
+        "  esac\n"
+    )
+    stub.chmod(0o755)
+
+    workdir = tmp_path / "install"
+    workdir.mkdir()
+
+    snippet = (
+        "set -uo pipefail\nset -e\n"
+        "RED=''; GREEN=''; YELLOW=''; BLUE=''; NC=''\n"
+        + _extract_function(INSTALLER, "resolve_default_branch")
+        + "\n"
+        + _extract_function(INSTALLER, "download_release_manifest_artifacts")
+        + "\ndownload_release_manifest_artifacts\n"
+    )
+    proc = subprocess.run(
+        ["bash", "-c", snippet],
+        capture_output=True,
+        text=True,
+        cwd=str(workdir),
+        env={"PATH": f"{bin_dir}:/usr/bin:/bin", "OPENTRANSCRIBE_BRANCH": old_tag},
+    )
+    assert proc.returncode == 0, (
+        f"a pinned install at {old_tag} failed because today's manifest requires "
+        f"{synthetic_required_entry}, which {old_tag} never shipped — a REQUIRED addition to "
+        f"the manifest retroactively broke an already-published release's install "
+        f"(issue #723):\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    )
+    assert (workdir / "docker-compose.yml").is_file()
+    assert not (workdir / synthetic_required_entry).exists()
+
+
 def test_opentr_sh_is_not_shipped_and_the_shipped_script_covers_it():
     """opentr.sh is deliberately absent (issue #613): its backup/restore path uses bare
     `docker compose`, and the base compose file ALONE is an invalid project — measured

--- a/opentranscribe.sh
+++ b/opentranscribe.sh
@@ -1585,9 +1585,16 @@ case "${1:-help}" in
         # Releases published before release-manifest.txt existed have no list to read, and
         # following the pin (above) means we now ask them for one. Borrow the list from the
         # default branch in that case — the ARTIFACTS still come from $GITHUB_RAW, i.e. the
-        # pinned release, so this cannot un-pin the install. The manifest's `optional` flag
-        # absorbs entries the older release does not have. Same fallback as
+        # pinned release, so this cannot un-pin the install. Same fallback as
         # setup-opentranscribe.sh's download_release_manifest_artifacts(); see issue #683.
+        #
+        # issue #723: a borrowed manifest is NEWER than $BRANCH, so it can list a REQUIRED
+        # entry that tag never shipped (NOTICE, added required in 91128ecb). `optional`
+        # alone does not absorb that — it only helps entries someone remembered to flag,
+        # and a required-on-principle file is deliberately never flagged optional. So once
+        # the manifest is known to be borrowed, a download failure for ANY entry means
+        # "this tag predates the file" and is skipped rather than fatal.
+        MANIFEST_BORROWED=0
         echo "  Downloading release-manifest.txt..."
         if ! curl -fsSL "$GITHUB_RAW/release-manifest.txt" -o release-manifest.txt.new; then
             rm -f release-manifest.txt.new
@@ -1596,8 +1603,10 @@ case "${1:-help}" in
             if [ -n "$MANIFEST_FALLBACK_BRANCH" ] && [ "$MANIFEST_FALLBACK_BRANCH" != "$BRANCH" ] &&
                 curl -fsSL "https://raw.githubusercontent.com/attevon-llc/OpenTranscribe/${MANIFEST_FALLBACK_BRANCH}/release-manifest.txt" \
                     -o release-manifest.txt.new; then
+                MANIFEST_BORROWED=1
                 echo -e "  ${YELLOW}⚠️${NC}  $BRANCH predates release-manifest.txt — using the file list from '${MANIFEST_FALLBACK_BRANCH}'."
-                echo -e "     Config files are still downloaded from $BRANCH."
+                echo -e "     Config files are still downloaded from $BRANCH; files that release"
+                echo -e "     does not have are skipped, whether or not the manifest marks them optional."
             else
                 rm -f release-manifest.txt.new
                 echo -e "  ${RED}✗${NC} could not fetch release-manifest.txt from $BRANCH"
@@ -1634,8 +1643,12 @@ case "${1:-help}" in
                         echo -e "  ${YELLOW}⚠️${NC} $artifact_path (optional, not in this release)"
                         ;;
                     *)
-                        echo -e "  ${RED}✗${NC} $artifact_path (REQUIRED — download failed)"
-                        update_failed=1
+                        if [ "$MANIFEST_BORROWED" -eq 1 ]; then
+                            echo -e "  ${YELLOW}⚠️${NC} $artifact_path (required by a newer manifest, but $BRANCH predates it — skipped)"
+                        else
+                            echo -e "  ${RED}✗${NC} $artifact_path (REQUIRED — download failed)"
+                            update_failed=1
+                        fi
                         ;;
                 esac
             fi

--- a/scripts/verify-install-paths.sh
+++ b/scripts/verify-install-paths.sh
@@ -173,11 +173,22 @@ check_fresh_install() {
     fi
     pass "fresh install at ${tag}: all required artifacts downloaded"
 
+    # issue #723: when the manifest had to be borrowed from the default branch (this tag
+    # predates release-manifest.txt), a REQUIRED entry the borrowed manifest lists but $tag
+    # never shipped (e.g. NOTICE) is expected to be missing, and download_release_manifest_
+    # artifacts() now skips it instead of failing the install. Demanding it here would fail
+    # a gate the installer itself considers a pass, and is exactly the class of bug #723
+    # found: a REQUIRED addition to today's manifest retroactively breaking every already
+    # published release's install.
+    local manifest_borrowed=false
     if grep -q "predates release-manifest.txt" "$log"; then
+        manifest_borrowed=true
         info "used the fallback manifest (this release predates release-manifest.txt)"
     fi
 
-    # Every non-optional manifest entry must be on disk.
+    # Every non-optional manifest entry must be on disk -- unless the manifest itself was
+    # borrowed from a newer ref, in which case a missing entry means "this tag predates the
+    # file", not a broken install.
     local missing=() path flags
     while IFS= read -r line; do
         case "$line" in '' | '#'*) continue ;; esac
@@ -185,6 +196,7 @@ check_fresh_install() {
         flags=$(printf '%s' "$line" | cut -s -f2)
         [[ -n "$path" ]] || continue
         case ",$flags," in *,optional,*) continue ;; esac
+        [[ "$manifest_borrowed" == true ]] && continue
         [[ -f "$workdir/$path" ]] || missing+=("$path")
     done <"$workdir/release-manifest.txt"
 

--- a/setup-opentranscribe.sh
+++ b/setup-opentranscribe.sh
@@ -519,9 +519,17 @@ download_release_manifest_artifacts() {
     # preferred. Only when the pinned ref predates the manifest do we borrow the list
     # from the default branch. The ARTIFACTS are always fetched from the pinned ref
     # ($github_raw) either way — only the file *list* falls back, so this cannot
-    # reintroduce an unpinned install. The manifest's `optional` flag is what absorbs
-    # the skew: a file a newer manifest lists but an older release does not have is
-    # reported and skipped, not fatal.
+    # reintroduce an unpinned install.
+    #
+    # issue #723: a borrowed manifest is NEWER than the tag it is being applied to, so
+    # it can list a REQUIRED entry the tag genuinely never shipped (e.g. NOTICE, added
+    # required in 91128ecb the same day this was found). The `optional` flag alone does
+    # not absorb that skew — it only helps entries someone remembered to mark, and a
+    # required-on-principle file like NOTICE is deliberately never marked optional. So
+    # when the manifest had to be borrowed, a download failure for ANY entry is treated
+    # as "this tag predates the file" and skipped, never fatal — the tag's own manifest
+    # (the normal, non-borrowed case) is still enforced at full strictness.
+    local manifest_borrowed=0
     if ! curl -fsSL --connect-timeout 10 --max-time 30 \
         "$github_raw/release-manifest.txt" -o release-manifest.txt.new; then
         rm -f release-manifest.txt.new
@@ -533,9 +541,10 @@ download_release_manifest_artifacts() {
             curl -fsSL --connect-timeout 10 --max-time 30 \
                 "https://raw.githubusercontent.com/attevon-llc/OpenTranscribe/${default_branch}/release-manifest.txt" \
                 -o release-manifest.txt.new; then
+            manifest_borrowed=1
             echo -e "  ${YELLOW}⚠️${NC}  ${branch} predates release-manifest.txt — using the file list from '${default_branch}'."
             echo "     Deployment files are still downloaded from ${branch}; files that release"
-            echo "     does not have are skipped only if the manifest marks them optional."
+            echo "     does not have are skipped, whether or not the manifest marks them optional."
         else
             rm -f release-manifest.txt.new
             echo -e "${RED}❌ Failed to download release-manifest.txt from ${branch}${NC}"
@@ -595,8 +604,12 @@ download_release_manifest_artifacts() {
                     echo -e "  ${YELLOW}⚠️${NC}  $artifact_path (optional, not in this release)"
                     ;;
                 *)
-                    echo -e "  ${RED}✗${NC}  $artifact_path (REQUIRED — download failed)"
-                    install_failed=1
+                    if [ "$manifest_borrowed" -eq 1 ]; then
+                        echo -e "  ${YELLOW}⚠️${NC}  $artifact_path (required by a newer manifest, but ${branch} predates it — skipped)"
+                    else
+                        echo -e "  ${RED}✗${NC}  $artifact_path (REQUIRED — download failed)"
+                        install_failed=1
+                    fi
                     ;;
             esac
         fi


### PR DESCRIPTION
## Summary

Closes #723 (P0 — every published-release install broken on master).

`setup-opentranscribe.sh`/`opentranscribe.sh update-full` already fell back to the default
branch's `release-manifest.txt` when a pinned release predates the manifest entirely (issue
#683). That fallback list is **newer** than the tag it gets applied to, and neither script
treated that as special: a REQUIRED entry the fallback manifest lists but the old tag never
shipped still failed the whole install.

`NOTICE` tripped it the day it was added required (91128ecb, #710): v0.4.1 predates
`release-manifest.txt`, so every fresh install borrowed today's manifest, was told `NOTICE`
is required, and 404ed fetching it from v0.4.1, which does not have it. v0.5.0 is not yet
released, so this is the only install path today and it is broken for everyone.

## Fix

Track when the manifest was borrowed from the default branch
(`manifest_borrowed`/`MANIFEST_BORROWED`) and, only in that case, downgrade a REQUIRED entry's
download failure to a skip instead of a fatal error — the tag predates the file, that is not a
broken install. A release that ships its own manifest is unaffected and stays at full
strictness (a genuinely missing required file in a self-describing release still fails
closed). Applied in three places, since all three carry the same skew:

- `setup-opentranscribe.sh::download_release_manifest_artifacts` (fresh install)
- `opentranscribe.sh`'s `update-full` inline download loop
- `scripts/verify-install-paths.sh::check_fresh_install` — asserted every non-optional
  manifest entry landed on disk, and would otherwise fail the CI gate for behavior the
  installer itself now treats as a pass

`scripts/release-tests/test-upgrade.sh::_replay_release_manifest` was checked and is not
affected — it stages a deployment's after-tree from the LOCAL checkout, not two different
refs, so there is no ref skew for it to have.

**Does NOT mark `NOTICE` optional.** That would only clear this one instance and leave the
next manifest addition to break every published install the same way — and it would
contradict `NOTICE`'s own required-on-principle rationale.

## Regression test

`backend/tests/unit/test_release_manifest.py::test_a_pinned_install_survives_a_required_entry_the_tag_predates`
drives a **synthetic** REQUIRED entry (not `NOTICE`, per the issue's acceptance criteria —
this pins the class, not the instance) through the real `download_release_manifest_artifacts`
loop against a stubbed `curl`, asserting a pinned install of an old tag still succeeds when
today's manifest requires something that tag never shipped.

Watched red against the pre-fix code first: `git archive HEAD` into `/tmp/redcheck`, copied
the new test in, ran it there — `1 failed` (`exit 1` from the fatal-required-failure path).
Green on the working tree after the fix — full file: `13 passed`.

## Verification

- `cd backend && python3 ../scripts/audit-tests.py tests` → 0 open findings
- `scripts/safe-precommit.sh run --all-files` → all hooks passed (commit-stage tier)
- `scripts/safe-precommit.sh run --all-files --hook-stage pre-push` → all hooks passed
  (push-stage tier, incl. `bandit -r backend/` and the frontend production `vite build`)

Not merging — leaving for review per repo convention.