### PR TITLE
fix(deploy): nginx robots.txt + X-Robots-Tag hardening (issue #668)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -560,7 +560,14 @@ JWT_ALGORITHM=HS256
 RATE_LIMIT_API_PER_MINUTE=100
 # RATE_LIMIT_AUTH_PER_MINUTE=10
 # RATE_LIMIT_ENABLED=true
-# leave empty unless you add your own proxy
+# Leave empty for a direct (no-proxy) deployment — resolve_client_ip then trusts the
+# socket peer and ignores X-Forwarded-For entirely, which is the safe default.
+# The bundled nginx/prod/PKI overlays (docker-compose.nginx.yml, .prod.yml, .pki*.yml)
+# already set this themselves, to the proxy's own docker network range — you only need
+# to set it here if you put your OWN reverse proxy in front of a plain (non-overlay)
+# deployment. Never set it to a wide LAN range (10.0.0.0/8, 192.168.0.0/16): any host
+# on that range could then forge X-Forwarded-For and pick its own rate-limit identity
+# (issue #668).
 RATE_LIMIT_TRUSTED_PROXIES=
 # REQUIRED in production — every mailed credential link is built from it
 FRONTEND_URL=http://localhost:5173

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -31,6 +31,7 @@ from app.core.version import APP_VERSION
 from app.middleware.audit import AuditMiddleware
 from app.middleware.csrf import CSRFMiddleware
 from app.middleware.observability import ObservabilityMiddleware
+from app.middleware.robots import RobotsHeaderMiddleware
 
 # Set up logging (text or structured JSON per settings.LOG_FORMAT)
 configure_logging()
@@ -972,6 +973,10 @@ app.add_middleware(
 
 # Configure maximum upload size (50GB)
 app.router.default_max_upload_size = 50 * 1024 * 1024 * 1024  # type: ignore[attr-defined]  # 50GB
+
+# Mark every API response as non-indexable (issue #668, finding 3). Response-header-only,
+# so its position relative to the other middleware below is not load-bearing.
+app.add_middleware(RobotsHeaderMiddleware)
 
 # Add Audit Middleware for request ID tracking (FedRAMP AU-2/AU-3)
 app.add_middleware(AuditMiddleware)

--- a/backend/app/middleware/robots.py
+++ b/backend/app/middleware/robots.py
@@ -1,0 +1,33 @@
+"""Tell crawlers not to index API responses (issue #668, finding 3).
+
+`frontend/static/robots.txt` covers the pages a crawler discovers by following links, but a
+crawler that hits an API URL directly (a shared link, a stray reference, a misconfigured
+sitemap) never reads that file — it just requests the resource. `X-Robots-Tag` is the
+per-response equivalent: it works even when nothing served an HTML page to read `<meta
+robots>` from, and search engines honour it identically on any content type.
+
+Scoped to `API_PREFIX` only. The frontend SPA and `/docs/` are legitimate to index on a
+deliberately public instance (issue #628's demo); nothing here should stop that.
+"""
+
+from __future__ import annotations
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.types import ASGIApp
+
+from app.core.config import settings
+
+
+class RobotsHeaderMiddleware(BaseHTTPMiddleware):
+    """Adds `X-Robots-Tag: noindex, nofollow` to every response under `API_PREFIX`."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        super().__init__(app)
+        self._prefix = settings.API_PREFIX
+
+    async def dispatch(self, request: Request, call_next):
+        response = await call_next(request)
+        if request.url.path.startswith(self._prefix):
+            response.headers["X-Robots-Tag"] = "noindex, nofollow"
+        return response

--- a/backend/tests/unit/test_668_nginx_hardening.py
+++ b/backend/tests/unit/test_668_nginx_hardening.py
@@ -1,0 +1,190 @@
+"""Issue #668 — nginx/reverse-proxy hardening.
+
+Verified against `master` before making any change here (see the branch's PR description
+for the full write-up):
+
+* **Finding 1** (`RATE_LIMIT_TRUSTED_PROXIES` empty behind nginx collapses every per-IP
+  rate limit into one global bucket) is **already fixed on master**. Every proxy-fronting
+  compose overlay (`docker-compose.nginx.yml`, `.prod.yml`, `.pki.yml`, `.pki-dev.yml`)
+  ships a coded `${RATE_LIMIT_TRUSTED_PROXIES:-127.0.0.1/32,172.16.0.0/12}` default
+  (`backend/tests/unit/test_proxy_trust_overlays.py` pins this), and
+  `app/utils/client_ip.resolve_client_ip` fails closed with no trusted proxy configured
+  (`backend/tests/unit/test_client_ip_resolution.py`). This file adds the one thing that
+  was still missing: an *empirical* test that two distinct client IPs behind a trusted
+  proxy land in independent rate-limit buckets, per the issue's own instruction not to
+  trust a config-file read for this class of bug.
+* **Finding 2** (nginx buffers the full request body before auth can reject it) is
+  **already fixed on master** — `nginx/site.conf.template` sets
+  `proxy_request_buffering off` on both `location /api/` (the upload path) and
+  `location /s3/` (direct MinIO uploads). Pinned below so a future edit cannot drop it
+  silently the way the issue warned a server-level-only fix would.
+* **Finding 3** (no `robots.txt`, no `X-Robots-Tag` on API responses) was **not** fixed —
+  this is the actual change on this branch: `frontend/static/robots.txt` (served through
+  nginx's catch-all `location /` in every proxy topology, and directly by Vite in dev) and
+  `app.middleware.robots.RobotsHeaderMiddleware`.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _request(peer: str, **headers) -> SimpleNamespace:
+    return SimpleNamespace(
+        client=SimpleNamespace(host=peer),
+        headers={k.replace("_", "-"): v for k, v in headers.items()},
+    )
+
+
+@pytest.fixture(autouse=True)
+def _restore_resolver_module():
+    yield
+    import app.utils.client_ip as client_ip
+
+    importlib.reload(client_ip)
+
+
+def _module_with_proxies(monkeypatch, trusted: str):
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "RATE_LIMIT_TRUSTED_PROXIES", trusted)
+    import app.utils.client_ip as client_ip
+
+    return importlib.reload(client_ip)
+
+
+# ─── Finding 1: empirically, not by reading config ───────────────────────────────
+
+
+def test_two_clients_behind_a_trusted_proxy_get_independent_rate_limit_keys(monkeypatch):
+    """The exact empirical check issue #668 asked for.
+
+    Two browsers behind the same nginx (same socket peer, the proxy's own address)
+    sending different `X-Forwarded-For` values must resolve to two different rate-limit
+    keys. Reading `resolve_client_ip` is what the key function actually calls — this is
+    not a re-implementation, it is the real dependency the limiter is built on
+    (`app/auth/rate_limit.py::_get_key_func`).
+    """
+    mod = _module_with_proxies(monkeypatch, "172.20.0.0/16")  # the nginx container's subnet
+
+    client_a = _request("172.20.0.5", X_Forwarded_For="203.0.113.10")
+    client_b = _request("172.20.0.5", X_Forwarded_For="203.0.113.20")
+
+    key_a = mod.resolve_client_ip(client_a)
+    key_b = mod.resolve_client_ip(client_b)
+
+    assert key_a == "203.0.113.10"
+    assert key_b == "203.0.113.20"
+    assert key_a != key_b, (
+        "two distinct clients behind the proxy collapsed onto the same rate-limit bucket"
+    )
+
+
+def test_an_untrusted_direct_client_cannot_assert_its_own_bucket(monkeypatch):
+    """The other half of the same empirical check: a client with no proxy in front of it
+    (or one that reaches the backend port directly, bypassing nginx) must not be able to
+    pick its own rate-limit identity by sending a forged header."""
+    mod = _module_with_proxies(monkeypatch, "172.20.0.0/16")
+
+    attacker = _request("203.0.113.99", X_Forwarded_For="10.10.10.10")
+
+    assert mod.resolve_client_ip(attacker) == "203.0.113.99"
+
+
+def test_rate_limiter_key_func_is_the_same_resolver_under_test(monkeypatch):
+    """Guards the test above against drifting from the real limiter: if `_get_key_func`
+    stopped calling `resolve_client_ip`, the two tests above would still pass while
+    testing nothing about the actual rate limiter."""
+    import inspect
+
+    from app.auth import rate_limit
+
+    assert "resolve_client_ip" in inspect.getsource(rate_limit._get_key_func)
+
+
+# ─── Finding 2: nginx body-buffering pin ──────────────────────────────────────────
+
+
+def test_upload_locations_disable_request_buffering():
+    """A server-level `client_max_body_size` alone is not enough — it must be paired with
+    `proxy_request_buffering off` on every location that accepts a large body, or nginx
+    buffers the whole request (up to 15G) before the app's auth layer ever runs."""
+    template = (REPO_ROOT / "nginx" / "site.conf.template").read_text(encoding="utf-8")
+
+    for location in ("location /api/ {", "location /s3/ {"):
+        start = template.index(location)
+        # The location block; next "    }" at the same 4-space indent closes it.
+        end = template.index("\n    }", start)
+        block = template[start:end]
+        assert "proxy_request_buffering off;" in block, (
+            f"{location} accepts large uploads but does not disable request buffering "
+            "— an unauthenticated POST can fill nginx's buffer before FastAPI sees it"
+        )
+
+
+# ─── Finding 3: robots.txt + X-Robots-Tag (the actual fix on this branch) ─────────
+
+
+def test_robots_txt_disallows_api_and_media_paths():
+    robots = (REPO_ROOT / "frontend" / "static" / "robots.txt").read_text(encoding="utf-8")
+
+    assert "User-agent: *" in robots
+    for path in ("/api/", "/files/", "/s3/", "/minio/", "/flower/"):
+        assert f"Disallow: {path}" in robots, f"robots.txt does not disallow {path}"
+
+
+def _tiny_app() -> Starlette:
+    from app.middleware.robots import RobotsHeaderMiddleware
+
+    async def api_endpoint(request: Request):
+        return PlainTextResponse("ok")
+
+    async def spa_endpoint(request: Request):
+        return PlainTextResponse("<html></html>")
+
+    app = Starlette(
+        routes=[
+            Route("/api/health", api_endpoint),
+            Route("/", spa_endpoint),
+        ]
+    )
+    app.add_middleware(RobotsHeaderMiddleware)
+    return app
+
+
+def test_x_robots_tag_present_on_api_responses():
+    client = TestClient(_tiny_app())
+    response = client.get("/api/health")
+
+    assert response.status_code == 200
+    assert response.headers.get("X-Robots-Tag") == "noindex, nofollow"
+
+
+def test_x_robots_tag_absent_outside_the_api_prefix():
+    """The SPA and `/docs/` must stay indexable for a deliberately public instance
+    (issue #628's demo) — the header is scoped to `API_PREFIX` only."""
+    client = TestClient(_tiny_app())
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert "X-Robots-Tag" not in response.headers
+
+
+def test_robots_middleware_is_registered_on_the_real_app():
+    import inspect
+
+    from app import main
+
+    source = inspect.getsource(main)
+    assert "RobotsHeaderMiddleware" in source

--- a/frontend/static/robots.txt
+++ b/frontend/static/robots.txt
@@ -1,0 +1,16 @@
+# OpenTranscribe (issue #668, finding 3)
+#
+# Most content here sits behind authentication, but the login page, embedded docs, and
+# any other unauthenticated surface are crawlable by default. Disallow the API and media
+# paths a crawler could otherwise walk at machine speed; leave the app shell itself open
+# so a deliberately public instance (see issue #628's demo) can still have its landing
+# page indexed if it wants that.
+#
+# Deployments that want the opposite (index everything, or nothing) should replace this
+# file — it is a static asset, not something the app enforces.
+User-agent: *
+Disallow: /api/
+Disallow: /files/
+Disallow: /s3/
+Disallow: /minio/
+Disallow: /flower/


### PR DESCRIPTION
## Summary

Issue #668 filed three nginx/reverse-proxy hardening findings. Verified each against `master` @ `ec9b707d` before changing anything.

### 1. `RATE_LIMIT_TRUSTED_PROXIES` empty behind nginx collapsing rate limits — ALREADY FIXED on master, no code change

Every proxy-fronting overlay (`docker-compose.nginx.yml`, `.prod.yml`, `.pki.yml`, `.pki-dev.yml`) already ships a coded `${RATE_LIMIT_TRUSTED_PROXIES:-127.0.0.1/32,172.16.0.0/12}` default, pinned by `backend/tests/unit/test_proxy_trust_overlays.py`. `app/utils/client_ip.resolve_client_ip` already fails closed with no trusted proxy configured (ignores forwarding headers entirely rather than trusting a wildcard), pinned by `test_client_ip_resolution.py`. This branch adds one thing that was still missing: an *empirical* test — two distinct client IPs behind a trusted proxy resolve to independent rate-limit keys, and an untrusted direct client cannot forge its own bucket — per the issue's own instruction not to trust a config-file read for this class of bug. See `test_668_nginx_hardening.py::test_two_clients_behind_a_trusted_proxy_get_independent_rate_limit_keys` / `test_an_untrusted_direct_client_cannot_assert_its_own_bucket`.

### 2. nginx buffering the full request body before auth can reject it — ALREADY FIXED on master, no code change

`nginx/site.conf.template` already sets `proxy_request_buffering off` on both `location /api/` (the upload path) and `location /s3/` (direct MinIO uploads), alongside the existing `client_max_body_size 15G`. Added a regression test (`test_upload_locations_disable_request_buffering`) pinning it, since the issue specifically warned a server-level-only fix (missing on one location while present on another) would silently do nothing.

### 3. No `robots.txt`, no `X-Robots-Tag` — NOT fixed. This is the actual change on this branch.

- `frontend/static/robots.txt` — disallows `/api/`, `/files/`, `/s3/`, `/minio/`, `/flower/`. Served through nginx's catch-all `location /` in every proxy topology (nginx/prod/PKI all proxy `/` to the frontend container), and directly by Vite in dev.
- `backend/app/middleware/robots.py` (`RobotsHeaderMiddleware`) — adds `X-Robots-Tag: noindex, nofollow` to every response under `API_PREFIX`, so a crawler that reaches an API URL directly (never having read `robots.txt`) still gets told not to index it. Scoped to the API only — the SPA and `/docs/` stay indexable for a deliberately public instance (issue #628's demo). Registered in `main.py`; response-header-only, so its position relative to the other middleware is not order-sensitive.
- Clarified the `RATE_LIMIT_TRUSTED_PROXIES` comment in `.env.example`, which still read as though every deployment needed to set it manually — misleading now that the bundled overlays default it themselves.

## Not addressed (with reason)

- The issue's "consider a startup warning when the nginx overlay is active and the var is empty" suggestion is now largely moot: every nginx-fronting overlay sets a coded default, so that empty/silent state no longer occurs on the shipped topologies. Not added.
- "Make `client_max_body_size` an `envsubst` variable (`NGINX_MAX_BODY`)" — a real usability improvement but a different piece of work (template variable + docs), not a security fix; left out to keep this PR reviewable and scoped to the security findings.

## Testing

`backend/tests/unit/test_668_nginx_hardening.py`, 8 tests. Red-checked against an unmodified `git archive HEAD` (i.e. current master) in an isolated `/tmp` copy, run with the repo's own `backend/venv`:

```
FAILED test_robots_middleware_is_registered_on_the_real_app
FAILED test_x_robots_tag_present_on_api_responses
FAILED test_x_robots_tag_absent_outside_the_api_prefix
FAILED test_robots_txt_disallows_api_and_media_paths
4 failed, 4 passed   # the 4 passes are findings 1/2, confirmed already fixed
```

Green on this branch: `8 passed`.

`cd backend && python3 ../scripts/audit-tests.py tests` → `0 open findings`.

## Gates

- `scripts/safe-precommit.sh run --all-files` → exit 0
- `scripts/safe-precommit.sh run --all-files --hook-stage pre-push` → exit 0 (frontend production build + recursive `bandit -r backend/` both passed)

Closes #668