### PR TITLE
fix(api): allow-list mutable transcript segment fields (#722)

### DIFF
--- a/backend/app/api/endpoints/files/crud.py
+++ b/backend/app/api/endpoints/files/crud.py
@@ -1076,11 +1076,17 @@ def update_single_transcript_segment(
             status_code=status.HTTP_404_NOT_FOUND, detail="Transcript segment not found"
         )
 
-    # Update fields
+    # Update fields. Explicit allow-list rather than a blind setattr loop over
+    # whatever the schema happens to declare — `TranscriptSegmentUpdate` is the wire
+    # contract, not a safe-to-apply set of ORM attribute names (issue #722: an earlier
+    # blind loop let a client rewrite the segment's primary key, and separately crash
+    # the request by sending a UUID into the integer `speaker_id` FK).
+    mutable_segment_fields = ("start_time", "end_time", "text")
     update_fields = segment_update.model_dump(exclude_unset=True)
     text_changed = "text" in update_fields and update_fields["text"] != segment.text
-    for field, value in update_fields.items():
-        setattr(segment, field, value)
+    for field in mutable_segment_fields:
+        if field in update_fields:
+            setattr(segment, field, update_fields[field])
 
     # If the text changed, re-run redaction detection for THIS segment only so the
     # edited text never bypasses masking. The API process preloads no ML detectors,

--- a/backend/app/schemas/media.py
+++ b/backend/app/schemas/media.py
@@ -329,11 +329,21 @@ class TranscriptSegmentBase(BaseModel):
 
 
 class TranscriptSegmentUpdate(BaseModel):
-    id: int | None = None  # Optional since segment is identified by UUID in URL
+    """Fields a client may edit via ``PUT .../transcript/segments/{segment_uuid}``.
+
+    Deliberately excludes ``id`` (the segment is identified by the path UUID, and the
+    primary key must never be client-writable) and ``speaker_id`` (speaker reassignment
+    has its own endpoint, ``PUT /transcripts/segments/{uuid}/speaker``, which resolves
+    the UUID to the ORM's integer FK correctly — see issue #722). ``extra="forbid"`` so a
+    client sending either (or any other unsupported field) gets a 422, not a silently
+    dropped write.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
     start_time: float | None = None
     end_time: float | None = None
     text: str | None = None
-    speaker_id: UUID | None = None
 
 
 class TranscriptSegment(TranscriptSegmentBase, UUIDBaseSchema):

--- a/backend/tests/api/endpoints/test_resource_detail_routes.py
+++ b/backend/tests/api/endpoints/test_resource_detail_routes.py
@@ -142,6 +142,57 @@ def test_editing_a_segment_can_move_its_timings(
     assert body["display_timestamp"] == "2:05"
 
 
+def test_editing_a_segment_cannot_rewrite_its_primary_key(
+    client, db_session, user_token_headers, normal_user
+):
+    """Issue #722: ``id`` reached the ORM via a blind ``setattr`` loop and let a client
+    move a segment's primary key to any id it chose, including one already in use
+    (which then raised an unhandled ``UniqueViolation`` -> 500). The field is vestigial
+    — the handler resolves the segment from the path ``segment_uuid`` — so it must be
+    rejected outright rather than merely ignored-if-harmless.
+    """
+    media_file = make_media_file(db_session, int(normal_user.id))
+    segment = _make_segment(db_session, media_file)
+    original_id = segment.id
+
+    response = client.put(
+        _segment_url(media_file.uuid, segment.uuid),
+        headers=user_token_headers,
+        json={"id": original_id + 99000000, "text": "MUTATED"},
+    )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    db_session.expire_all()
+    db_session.refresh(segment)
+    assert segment.id == original_id
+    assert segment.text == "original text"
+
+
+def test_editing_a_segment_rejects_a_speaker_id_on_this_route(
+    client, db_session, user_token_headers, normal_user
+):
+    """Issue #722: a schema-valid ``speaker_id`` UUID reached the ORM's integer
+    ``speaker_id`` FK via the same blind ``setattr`` loop and raised an unhandled
+    ``DatatypeMismatch`` -> 500. Speaker reassignment has its own endpoint
+    (``PUT /transcripts/segments/{uuid}/speaker``, which resolves the uuid to the
+    integer FK correctly) — this route must reject the field, never 500 or silently
+    write it.
+    """
+    media_file = make_media_file(db_session, int(normal_user.id))
+    segment = _make_segment(db_session, media_file)
+
+    response = client.put(
+        _segment_url(media_file.uuid, segment.uuid),
+        headers=user_token_headers,
+        json={"speaker_id": str(uuid_pkg.uuid4())},
+    )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    db_session.expire_all()
+    db_session.refresh(segment)
+    assert segment.speaker_id is None
+
+
 def test_a_segment_from_another_file_is_404(client, db_session, user_token_headers, normal_user):
     """The segment lookup is filtered by the file in the path, not just by uuid.
 


### PR DESCRIPTION
## Summary

`update_single_transcript_segment` (`backend/app/api/endpoints/files/crud.py`) applied the request body to the ORM object via an unfiltered `setattr` loop over `segment_update.model_dump(exclude_unset=True)`. Two fields on `TranscriptSegmentUpdate` reached it and should never have:

- `id` (`int`, the ORM primary key): a client could rewrite a segment's primary key with an **HTTP 200** and nothing in the response indicating anything unusual happened. Aimed at an id already in use, it instead raised an unhandled `UniqueViolation` -> 500.
- `speaker_id` (`UUID`): the ORM column is `Integer, ForeignKey("speaker.id")`, so a schema-valid `uuid4` raised an unhandled `psycopg2.errors.DatatypeMismatch` -> 500.

Both were reachable by any authenticated user with `editor` permission on the file.

## Fix

- `TranscriptSegmentUpdate` (`backend/app/schemas/media.py`) drops both fields entirely.
  - `id` was vestigial — the handler resolves the segment from the path `segment_uuid`, never reads `id`.
  - `speaker_id` reassignment already has a dedicated, correctly-typed endpoint, `PUT /transcripts/segments/{segment_uuid}/speaker`, which resolves the UUID to the integer FK correctly. Grepped `frontend/src` and the test suite for any caller sending `speaker_id` to the segment-update route — **none found**; `TranscriptDisplay.svelte`'s speaker-change handler calls `updateSegmentSpeaker` -> the dedicated endpoint exclusively. Removal has no caller to update.
  - The schema now sets `extra="forbid"`, so a client sending either field (or any other unsupported one) gets a 422 instead of a silently dropped write.
- `update_single_transcript_segment` replaces the blind `setattr` loop with an explicit allow-list (`start_time`, `end_time`, `text`), so a future field added to the schema can't reach the ORM without a deliberate update here too — closing the class of bug, not just the two instances.

## Tests

Two regression tests added to `backend/tests/api/endpoints/test_resource_detail_routes.py`:
- `test_editing_a_segment_cannot_rewrite_its_primary_key`
- `test_editing_a_segment_rejects_a_speaker_id_on_this_route`

Watched both **fail against unfixed code** first, via a `git archive HEAD` tree (never swapping files in the shared checkout) against real Postgres:
- `speaker_id` payload: unhandled `psycopg2.errors.DatatypeMismatch: column "speaker_id" is of type integer but expression is of type uuid`
- `id` payload: request succeeded (200), consistent with the reported silent PK rewrite

After the fix: `25 passed` in `test_resource_detail_routes.py` (including both new tests), plus the pre-existing `test_file_mutation_permissions.py` (viewer/editor segment-edit permission tests) and the two segment-edit redaction suites (`test_scan_coverage.py`, `test_segment_edit_redetection.py`) — `51 passed`, no regressions from removing the fields or forbidding extras.

`cd backend && python3 ../scripts/audit-tests.py tests` — 0 open findings.

`scripts/safe-precommit.sh run --all-files` and `--hook-stage pre-push` — both exit 0.

Closes #722