### PR TITLE
fix(security): rate-limit LLM connection-test and model-discovery handlers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -559,6 +559,9 @@ JWT_ALGORITHM=HS256
 # CONCURRENT_SESSION_POLICY=terminate_oldest  # or "reject"
 RATE_LIMIT_API_PER_MINUTE=100
 # RATE_LIMIT_AUTH_PER_MINUTE=10
+# LLM connection-test / model-discovery handlers fetch a caller-supplied base_url
+# server-side (issue #676); kept tighter than the general API limit.
+# RATE_LIMIT_LLM_OUTBOUND_PER_MINUTE=10
 # RATE_LIMIT_ENABLED=true
 # leave empty unless you add your own proxy
 RATE_LIMIT_TRUSTED_PROXIES=

--- a/backend/app/api/endpoints/llm_settings.py
+++ b/backend/app/api/endpoints/llm_settings.py
@@ -14,12 +14,17 @@ from uuid import UUID
 from fastapi import APIRouter
 from fastapi import Depends
 from fastapi import HTTPException
+from fastapi import Request
+from fastapi import Response
 from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
 from app import models
 from app import schemas
 from app.api.endpoints.auth import get_current_active_user
+from app.auth.rate_limit import get_llm_outbound_rate_limit
+from app.auth.rate_limit import limiter
+from app.auth.rate_limit import user_or_ip_key
 from app.db.base import get_db
 from app.services import llm_context_window
 from app.services import llm_reasoning
@@ -786,15 +791,22 @@ def delete_all_user_configurations(
 
 
 @router.post("/test", response_model=schemas.ConnectionTestResponse)
+@limiter.limit(get_llm_outbound_rate_limit(), key_func=user_or_ip_key)
 def test_llm_connection(
     *,
+    request: Request,
     test_request: schemas.ConnectionTestRequest,
+    response: Response = None,  # type: ignore[assignment]  # required by slowapi
     db: Session = Depends(get_db),
     current_user: models.User = Depends(get_current_active_user),
 ) -> Any:
     """
     Test connection to LLM provider without saving settings.
     If config_id is provided and no api_key, will use the stored API key from that config.
+
+    Rate-limited (issue #676): this handler makes a server-side outbound request to a
+    caller-supplied ``base_url`` and sits behind ``get_current_active_user``, not an
+    admin gate — see ``get_llm_outbound_rate_limit``.
     """
     _assert_safe_llm_endpoint(test_request.base_url, "LLM test-connection")
     start_time = time.time()
@@ -1215,12 +1227,18 @@ def get_config_api_key(
 
 
 @router.get("/ollama/models")
+@limiter.limit(get_llm_outbound_rate_limit(), key_func=user_or_ip_key)
 async def get_ollama_models(
+    request: Request,
     base_url: str,
+    response: Response = None,  # type: ignore[assignment]  # required by slowapi
     current_user: models.User = Depends(get_current_active_user),
 ) -> Any:
     """
     Get available models from an Ollama instance
+
+    Rate-limited (issue #676): fetches a caller-supplied ``base_url`` server-side —
+    see ``get_llm_outbound_rate_limit``.
     """
     import aiohttp
 
@@ -1398,10 +1416,13 @@ def _get_http_error_message(status_code: int, models_url: str, error_text: str =
 
 
 @router.get("/openai-compatible/models")
+@limiter.limit(get_llm_outbound_rate_limit(), key_func=user_or_ip_key)
 async def get_openai_compatible_models(
+    request: Request,
     base_url: str,
     api_key: str | None = None,
     config_id: str | None = None,
+    response: Response = None,  # type: ignore[assignment]  # required by slowapi
     db: Session = Depends(get_db),
     current_user: models.User = Depends(get_current_active_user),
 ) -> Any:
@@ -1410,6 +1431,9 @@ async def get_openai_compatible_models(
 
     Supports: OpenAI, vLLM, OpenRouter, and other OpenAI-compatible providers.
     If config_id is provided and no api_key, will use the stored API key from that config.
+
+    Rate-limited (issue #676): fetches a caller-supplied ``base_url`` server-side —
+    see ``get_llm_outbound_rate_limit``.
     """
     import aiohttp
 

--- a/backend/app/api/endpoints/llm_settings.py
+++ b/backend/app/api/endpoints/llm_settings.py
@@ -883,6 +883,7 @@ def test_llm_connection(
 
 @router.post("/test-current", response_model=schemas.ConnectionTestResponse)
 def test_active_configuration(
+    request: Request,
     db: Session = Depends(get_db),
     current_user: models.User = Depends(get_current_active_user),
 ) -> Any:
@@ -947,7 +948,12 @@ def test_active_configuration(
     # so calling it in-process without it binds `db` to the `fastapi.params.Depends` OBJECT.
     # Harmless only while these two callers never set `config_id` on the request they build —
     # the first one that does gets an AttributeError on a Depends instance.
-    result = test_llm_connection(test_request=test_request, current_user=current_user, db=db)
+    # `request=request` is required for the same reason (issue #676 made it keyword-only, for
+    # the outbound rate limiter's per-user/per-IP key); omitting it is a TypeError at call time,
+    # which is what broke both of these endpoints.
+    result = test_llm_connection(
+        request=request, test_request=test_request, current_user=current_user, db=db
+    )
 
     # Only write back test status if the current user owns the config
     if user_config.user_id == current_user.id:
@@ -964,6 +970,7 @@ def test_active_configuration(
 @router.post("/test-config/{config_uuid}", response_model=schemas.ConnectionTestResponse)
 def test_specific_configuration(
     config_uuid: str,
+    request: Request,
     db: Session = Depends(get_db),
     current_user: models.User = Depends(get_current_active_user),
 ) -> Any:
@@ -998,7 +1005,12 @@ def test_specific_configuration(
     # so calling it in-process without it binds `db` to the `fastapi.params.Depends` OBJECT.
     # Harmless only while these two callers never set `config_id` on the request they build —
     # the first one that does gets an AttributeError on a Depends instance.
-    result = test_llm_connection(test_request=test_request, current_user=current_user, db=db)
+    # `request=request` is required for the same reason (issue #676 made it keyword-only, for
+    # the outbound rate limiter's per-user/per-IP key); omitting it is a TypeError at call time,
+    # which is what broke both of these endpoints.
+    result = test_llm_connection(
+        request=request, test_request=test_request, current_user=current_user, db=db
+    )
 
     # Only write back test status if the current user owns the config
     if user_config.user_id == current_user.id:

--- a/backend/app/auth/rate_limit.py
+++ b/backend/app/auth/rate_limit.py
@@ -7,6 +7,8 @@ Falls back to in-memory storage if Redis is unavailable.
 Configuration is managed via settings:
 - RATE_LIMIT_AUTH_PER_MINUTE: Rate limit for auth endpoints (default: 10)
 - RATE_LIMIT_API_PER_MINUTE: Rate limit for general API endpoints (default: 100)
+- RATE_LIMIT_LLM_OUTBOUND_PER_MINUTE: Rate limit for handlers that fetch a caller-supplied
+  LLM base_url (default: 10)
 - RATE_LIMIT_ENABLED: Enable/disable rate limiting (default: True)
 - RATE_LIMIT_TRUSTED_PROXIES: Comma-separated list of trusted proxy IPs/CIDRs
 """
@@ -100,6 +102,35 @@ def _get_key_func() -> Callable[[Request], str]:
     return key_func
 
 
+def user_or_ip_key(request: Request) -> str:
+    """Rate-limit key: the authenticated user's id, falling back to client IP.
+
+    Used for handlers where a per-IP bucket is meaningless — a router with no
+    admin gate, behind nginx, where every request currently shares one IP-derived
+    bucket per proxy hop until ``RATE_LIMIT_TRUSTED_PROXIES`` is configured (issue
+    #668). Keying on the user id sidesteps that: it is set by
+    ``get_current_active_user`` onto ``request.state.user_id`` while resolving the
+    endpoint's own ``current_user`` dependency, which FastAPI runs *before* calling
+    the ``@limiter.limit``-wrapped endpoint function, so it is already present by
+    the time this key func runs. Falls back to the shared IP resolver for any
+    request that never resolved a user (should not happen on an authenticated
+    route, but a key func must never raise).
+
+    Args:
+        request: The current request.
+
+    Returns:
+        ``f"user:{id}"`` when a user id is known, else the resolved client IP.
+    """
+    user_id = getattr(request.state, "user_id", None)
+    if user_id is not None:
+        return f"user:{user_id}"
+
+    from app.utils.client_ip import resolve_client_ip
+
+    return resolve_client_ip(request)
+
+
 def _create_limiter() -> Limiter:
     """
     Create and configure the rate limiter instance.
@@ -179,6 +210,19 @@ def get_api_rate_limit() -> str:
         Rate limit string in slowapi format (e.g., "100/minute").
     """
     return f"{settings.RATE_LIMIT_API_PER_MINUTE}/minute"
+
+
+def get_llm_outbound_rate_limit() -> str:
+    """Rate limit string for handlers that fetch a caller-supplied LLM ``base_url``.
+
+    Covers ``POST /llm-settings/test`` and the ``GET .../models`` discovery
+    handlers (issue #676) — deliberately tighter than :func:`get_api_rate_limit`,
+    see the ``RATE_LIMIT_LLM_OUTBOUND_PER_MINUTE`` docstring in ``core/config.py``.
+
+    Returns:
+        Rate limit string in slowapi format (e.g., "10/minute").
+    """
+    return f"{settings.RATE_LIMIT_LLM_OUTBOUND_PER_MINUTE}/minute"
 
 
 def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) -> Response:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -340,6 +340,13 @@ class Settings(BaseSettings):
     RATE_LIMIT_AUTH_PER_MINUTE: int = 10
     # Rate limit for general API endpoints
     RATE_LIMIT_API_PER_MINUTE: int = 100
+    # Rate limit for handlers that make a server-side outbound request to a caller-supplied
+    # base_url (LLM connection-test + model-discovery, issue #676). Deliberately tighter than
+    # the general API limit: a connection test is a human-scale action, and this router has
+    # no admin gate, so an uncapped limit here is an amplification/resource-exhaustion surface
+    # even though the target itself is DNS-pinned against private IPs (see
+    # `_assert_safe_llm_endpoint`/`_pin_llm_endpoint` in `app/api/endpoints/llm_settings.py`).
+    RATE_LIMIT_LLM_OUTBOUND_PER_MINUTE: int = 10
     # Enable rate limiting (disable for testing)
     RATE_LIMIT_ENABLED: bool = os.getenv("RATE_LIMIT_ENABLED", "true").lower() == "true"
     # Trusted proxy IPs for rate limiting (comma-separated)

--- a/backend/tests/api/endpoints/test_llm_settings_rate_limit.py
+++ b/backend/tests/api/endpoints/test_llm_settings_rate_limit.py
@@ -1,0 +1,195 @@
+"""Rate-limit coverage for the LLM connection-test / model-discovery handlers (issue #676).
+
+`POST /llm-settings/test`, `GET /llm-settings/ollama/models` and
+`GET /llm-settings/openai-compatible/models` make a server-side outbound request to a
+caller-supplied `base_url`, gated only on `get_current_active_user` (no admin gate) on a
+router that had **no rate limit at all** — an authenticated user could drive unbounded
+outbound requests from the backend container. The SSRF *target* (private IP / DNS
+rebinding / redirect) was already hardened before this issue
+(`_assert_safe_llm_endpoint` / `_pin_llm_endpoint` in `app.api.endpoints.llm_settings`,
+backed by `app.utils.url_validation`'s DNS-pinning); what this closes is the *volume*
+bound. See the issue for the full history.
+
+These tests flip the module-level `limiter` (normally disabled under
+`RATE_LIMIT_ENABLED=false` in `tests/conftest.py`) on for the duration of the test only,
+and reset its storage on the way out so no count leaks into another test file.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import status
+
+from app.auth.rate_limit import limiter
+from app.core.config import settings
+
+_BASE = "/api/llm-settings"
+_LOOPBACK = "http://127.0.0.1:11434"
+
+
+@pytest.fixture
+def rate_limiting_enabled():
+    """Turn the real slowapi limiter on for one test, then clean up after it.
+
+    `RATE_LIMIT_ENABLED=false` in `tests/conftest.py` builds the module-level
+    `limiter` singleton with `enabled=False` at import time — every other test in
+    the suite relies on that so it isn't rate-limited by accident. `Limiter.enabled`
+    is a plain mutable attribute (not baked into the decorator), so it can be
+    flipped per-test; `limiter.reset()` clears the storage bucket the flipped-on
+    window created so the next test (rate-limited or not) starts clean.
+    """
+    was_enabled = limiter.enabled
+    limiter.enabled = True
+    try:
+        yield
+    finally:
+        limiter.enabled = was_enabled
+        try:
+            limiter.reset()
+        except Exception:
+            # `.reset()` talks to the configured Redis storage directly, unlike a
+            # normal rate-limit check (which degrades to in-memory on its own, see
+            # `_create_limiter`'s docstring). Host test runs routinely have no
+            # Redis reachable at `settings.REDIS_URL` (dev's is auth'd on a
+            # non-default port; conftest deliberately does not wire it up — see
+            # its Redis note). Deployments where the limiter really did run
+            # against Redis during the test still had their state cleared by the
+            # *successful* branch above; this only guards the common "no Redis on
+            # the host" case from failing an otherwise-passing test at teardown.
+            pass
+
+
+def _hit_ollama_models(client, headers):
+    return client.get(
+        f"{_BASE}/ollama/models",
+        params={"base_url": _LOOPBACK},
+        headers=headers,
+    )
+
+
+def test_ollama_models_is_rate_limited_per_user(client, user_token_headers, rate_limiting_enabled):
+    """The Nth+1 request within the window is refused with 429, not fetched.
+
+    Each call 400s on the SSRF guard (loopback, private endpoints not allowed) without
+    ever reaching the network — so this isolates the rate limit itself. The limit
+    string is baked into the `@limiter.limit(...)` decorator at import time from
+    `RATE_LIMIT_LLM_OUTBOUND_PER_MINUTE`'s coded default (10/minute), so the test
+    exercises that default rather than a monkeypatched value.
+    """
+    limit = settings.RATE_LIMIT_LLM_OUTBOUND_PER_MINUTE
+    responses = [_hit_ollama_models(client, user_token_headers) for _ in range(limit)]
+    for resp in responses:
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST, resp.text
+
+    blocked = _hit_ollama_models(client, user_token_headers)
+    assert blocked.status_code == status.HTTP_429_TOO_MANY_REQUESTS, blocked.text
+
+
+def test_openai_compatible_models_is_rate_limited_per_user(
+    client, user_token_headers, rate_limiting_enabled
+):
+    limit = settings.RATE_LIMIT_LLM_OUTBOUND_PER_MINUTE
+    for _ in range(limit):
+        resp = client.get(
+            f"{_BASE}/openai-compatible/models",
+            params={"base_url": _LOOPBACK},
+            headers=user_token_headers,
+        )
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST, resp.text
+
+    blocked = client.get(
+        f"{_BASE}/openai-compatible/models",
+        params={"base_url": _LOOPBACK},
+        headers=user_token_headers,
+    )
+    assert blocked.status_code == status.HTTP_429_TOO_MANY_REQUESTS, blocked.text
+
+
+def test_llm_test_connection_is_rate_limited_per_user(
+    client, user_token_headers, rate_limiting_enabled
+):
+    """`POST /test` against a loopback `base_url` is refused by `_assert_safe_llm_endpoint`
+    before any outbound call, exercising the same limiter without a real network hop.
+    """
+    limit = settings.RATE_LIMIT_LLM_OUTBOUND_PER_MINUTE
+    payload = {
+        "provider": "openai",
+        "model_name": "does-not-matter",
+        "api_key": "sk-fake",
+        "base_url": _LOOPBACK,
+    }
+    for _ in range(limit):
+        resp = client.post(f"{_BASE}/test", headers=user_token_headers, json=payload)
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST, resp.text
+
+    blocked = client.post(f"{_BASE}/test", headers=user_token_headers, json=payload)
+    assert blocked.status_code == status.HTTP_429_TOO_MANY_REQUESTS, blocked.text
+
+
+def test_rate_limit_bucket_is_keyed_per_user_not_globally(
+    client, user_token_headers, admin_token_headers, rate_limiting_enabled
+):
+    """A second authenticated user is not punished by the first user's usage.
+
+    Both requests originate from the same TestClient (same IP), so this only passes
+    if the bucket key is the resolved user id (`user_or_ip_key`) rather than the
+    shared IP — the exact gap #676 flags behind an unconfigured
+    `RATE_LIMIT_TRUSTED_PROXIES` (issue #668).
+    """
+    limit = settings.RATE_LIMIT_LLM_OUTBOUND_PER_MINUTE
+    for _ in range(limit):
+        resp = _hit_ollama_models(client, user_token_headers)
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST, resp.text
+
+    # user_token_headers' bucket is now exhausted...
+    assert _hit_ollama_models(client, user_token_headers).status_code == (
+        status.HTTP_429_TOO_MANY_REQUESTS
+    )
+
+    # ...but a different authenticated user still gets served.
+    other_resp = _hit_ollama_models(client, admin_token_headers)
+    assert other_resp.status_code == status.HTTP_400_BAD_REQUEST, other_resp.text
+
+
+def test_llm_allow_private_endpoints_flag_still_works_under_rate_limiting(
+    client, user_token_headers, rate_limiting_enabled, monkeypatch
+):
+    """The `LLM_ALLOW_PRIVATE_ENDPOINTS` escape hatch for self-hosted local LLMs is
+    untouched by adding a rate limit — a single allowed request is not rejected.
+    """
+    monkeypatch.setattr(settings, "LLM_ALLOW_PRIVATE_ENDPOINTS", True)
+
+    from unittest.mock import patch
+
+    class _Response:
+        status = 200
+
+        async def json(self):
+            return {"models": []}
+
+        async def text(self):
+            return ""
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_exc):
+            return False
+
+    class _Session:
+        def __init__(self, *_a, **_kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_exc):
+            return False
+
+        def get(self, *_a, **_kw):
+            return _Response()
+
+    with patch("aiohttp.ClientSession", _Session):
+        resp = _hit_ollama_models(client, user_token_headers)
+    assert resp.status_code == status.HTTP_200_OK, resp.text
+    assert resp.json()["success"] is True


### PR DESCRIPTION
## Summary

Closes #676.

`POST /llm-settings/test`, `GET /llm-settings/ollama/models`, and
`GET /llm-settings/openai-compatible/models` make a server-side outbound request to a
caller-supplied `base_url`, gated only on `get_current_active_user` (no admin gate) on a
router with **no rate limit at all**.

Per the issue: the SSRF *target* was already hardened before this issue —
`_assert_safe_llm_endpoint`/`_pin_llm_endpoint` in `app/api/endpoints/llm_settings.py`,
backed by `app/utils/url_validation.py`'s DNS pinning (redirects disabled,
`allow_redirects=False`, and the pinned target — not the hostname — is what's actually
dialed, closing the DNS-rebinding window). What was missing, and what this closes, is a
bound on request *volume*: with no admin gate and self-registration possibly enabled, an
authenticated user could drive unbounded outbound requests from the backend container —
an amplification / resource-exhaustion surface.

## Changes

- `RATE_LIMIT_LLM_OUTBOUND_PER_MINUTE` (default `10`/minute) — deliberately tighter than
  the general API limit; a connection test is a human-scale action.
- `app.auth.rate_limit.user_or_ip_key()` — buckets on the authenticated user's id
  (`request.state.user_id`, set by `get_current_active_user` before the decorated handler
  runs), falling back to client IP only when no user id is known. Keying on IP alone would
  collapse into one shared bucket behind nginx until `RATE_LIMIT_TRUSTED_PROXIES` is
  configured (issue #668) — the exact caveat #676 calls out.
- `@limiter.limit(get_llm_outbound_rate_limit(), key_func=user_or_ip_key)` applied to all
  three handlers.
- `LLM_ALLOW_PRIVATE_ENDPOINTS` escape hatch for self-hosted local LLMs is untouched —
  covered by a dedicated test.

## Testing

New `backend/tests/api/endpoints/test_llm_settings_rate_limit.py`:
- the limit firing (429) on all three handlers after the configured count
- two different authenticated users get independent buckets (proves user-keying, not IP)
- the `LLM_ALLOW_PRIVATE_ENDPOINTS` escape hatch still works under the limit

Verified RED against pre-fix code first, via a `git archive HEAD` tree (15 requests, no
429 — the bug reproduced), then GREEN against the fix in this worktree. Both
`safe-precommit.sh` tiers (commit-stage and `--hook-stage pre-push`) pass, and
`scripts/audit-tests.py tests` reports 0 open findings.

## Not in scope

Real SSRF hardening (target validation, DNS pinning, redirect handling) is **pre-existing**
and unchanged by this PR — see `_assert_safe_llm_endpoint`/`_pin_llm_endpoint` in
`llm_settings.py`. This PR only adds the missing volume bound.