### PR TITLE
fix(testing): guard CUDA device visibility in the default test selection

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -107,6 +107,12 @@ testpaths = ["tests"]
 # test (54.6 s), so it cannot fire on a merely slow test — tighten it once the suite is fast.
 # Both require pytest-timeout, which is therefore MANDATORY in requirements-dev/-ci: a
 # missing plugin makes --timeout a collection error, not a no-op (issue #431).
+# `-m 'not integration and not gpu'` is now load-bearing for CUDA device VISIBILITY, not
+# only test selection (issue #719): tests/conftest.py's pytest_configure asks whether this
+# exact expression can ever select a `gpu`-marked test and, since it cannot, sets
+# CUDA_VISIBLE_DEVICES=-1 before any worker imports torch. Changing this default without
+# checking tests/conftest.py's `_selection_may_run_gpu_tests` can silently re-open every
+# GPU to the fast suite again.
 addopts = "-n auto --dist loadgroup --tb=short -q --strict-markers --durations=25 --timeout=300 -m 'not integration and not gpu'"
 markers = [
     "slow: marks tests as slow",
@@ -114,7 +120,7 @@ markers = [
     "pki: PKI certificate tests",
     "e2e: end-to-end browser tests",
     "integration: integration tests requiring running dev environment",
-    "gpu: tests requiring a physical GPU — deselected from the fast suite, run by the gate",
+    "gpu: tests requiring a physical GPU — deselected from the fast suite, run by the gate, and the only selection that keeps CUDA devices visible (issue #719)",
     "models: tests requiring ML model weights (Presidio/GLiNER/toxicity) — skipped in fast CI",
     "ddl_exclusive: performs schema DDL (DROP/ALTER TABLE) needing full DB-wide exclusivity, not just self-consistency — see tests/conftest.py's advisory-lock isolation (issue #389)",
 ]

--- a/backend/tests/CLAUDE.md
+++ b/backend/tests/CLAUDE.md
@@ -57,6 +57,18 @@ what it appears to. A green one from the wrong schema is worse.
   `norecursedirs=["tests/e2e"]`. **`--strict-markers` makes an unregistered marker a collection
   error** — register any new marker in `[tool.pytest.ini_options] markers` or collection fails.
   (The e2e markers live in `tests/e2e/pytest.ini`, which is a separate rootdir config.)
+- **CUDA device guard (issue #719).** `conftest.py`'s `pytest_configure` asks pytest's own
+  `Expression` parser whether the active `-m` selection can ever satisfy `gpu` (satisfiability,
+  not a `"gpu" in markexpr` substring check — the default expression `not integration and not
+  gpu` CONTAINS that substring and must still leave the guard ON). When it cannot, it sets
+  `CUDA_VISIBLE_DEVICES=-1` before any worker imports torch, so `torch.cuda.is_available()`
+  reads `False` for the whole run. `-m gpu` and `-m integration` (two files carry both markers)
+  keep real device access. A `gpu`-marked test that somehow runs under the guard **ERRORS**
+  (`pytest.fail`, message contains `cuda-device-guard`) rather than skipping on "CUDA not
+  available" — a skip there would look like a pass. Escape hatch: `OT_TEST_CUDA_VISIBLE_DEVICES`
+  (`=1` sets it and bypasses the marker check, `=all` leaves the ambient value alone, `=""` is an
+  explicit blind). An ambient `CUDA_VISIBLE_DEVICES` in the shell does **not** release the guard —
+  the block deliberately does not use `os.environ.setdefault`. Tests: `unit/test_cuda_device_guard.py`.
 - `@pytest.mark.models` = needs Presidio/GLiNER/toxicity weights; those modules also
   `importorskip` + `preload()`-skip, so fast CI passes without weights.
 - Module-level `skipif` env gates → suite: `RUN_PKI_TESTS`→`test_pki_auth`, `RUN_MFA_TESTS`→
@@ -272,7 +284,10 @@ an_already_shared_tag` passed throughout, because a broken store produces absenc
   skips (`ensure_container`); without `-o addopts= -m gpu` pytest deselects every test; without
   the gitignored `benchmark/test_audio/*.wav` fixtures each test skips individually; and without
   a visible CUDA device `torch_cuda` skips. `run-diarization-gpu-tests.sh` hard-fails on the
-  first three rather than handing you a green vacuum.
+  first three rather than handing you a green vacuum. **The CUDA device guard (issue #719,
+  above) is a fifth potential source of that state** — but the hook converts it to a hard
+  `pytest.fail` (`cuda-device-guard` in the message) rather than a fifth silent skip, so a
+  `gpu`-marked test that runs without `-m gpu` errors loudly instead of passing vacuously.
 - **`tests/integration/test_scheduled_backup_restore_roundtrip.py` needs the backend image
   built** (`./opentr.sh build` or `./opentr.sh start dev --build`) — its Tier-1 "trustworthy
   evidence" test runs the real `backup_service.run_pg_dump` inside a throwaway container from

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -4,7 +4,9 @@
 # HTTPException.detail, which is typed str while every lifecycle gate raises an
 # object. Declared once here rather than as a cast at every call site — casts
 # bury the assertion, and widening a production signature to suit a test is worse.
+import itertools
 import os
+import re
 import socket
 import sys
 import tempfile
@@ -130,6 +132,149 @@ os.environ["POSTGRES_HOST"] = "localhost"
 # Ensure we use the correct port (Docker exposes on 5176)
 if "POSTGRES_PORT" not in os.environ or os.environ.get("POSTGRES_PORT") == "5432":
     os.environ["POSTGRES_PORT"] = "5176"
+
+# --- CUDA device guard (issue #719) -----------------------------------------
+# The fast suite opened a ~300 MiB CUDA primary context on EVERY xdist worker
+# that happened to import torch, on whichever device is default (device 0) —
+# multiplied by `-n auto`, that is tens of contexts on cards this project does
+# not own (GPU 0/2 are reserved for unrelated work; root CLAUDE.md). Nothing in
+# the harness restricted device visibility before this.
+#
+# WHY THIS LIVES IN `pytest_configure`, NOT AT MODULE LEVEL:
+# `import torch` is not the freeze point — the first CUDA *call* is. Setting
+# CUDA_VISIBLE_DEVICES after even one `torch.cuda.is_available()` leaves
+# `is_available()` True while `device_count()` reads 0: an inconsistent state
+# WORSE than no guard, because `hardware_detection._detect_optimal_device` then
+# takes the cuda branch and calls `torch.cuda.set_device(0)` against a device
+# that doesn't exist. `pytest_configure` runs before torch is ever imported in
+# every invocation shape checked (fast suite, `-m gpu`, `-m integration`, an
+# e2e run via `import tests.conftest`).
+#
+# WHY A HOOK AND NEVER A MODULE-LEVEL ASSIGNMENT:
+# `tests/e2e/conftest.py` does `import tests.conftest` purely for its module
+# body's side effects — the e2e run has its OWN pytest.ini/rootdir, so hooks
+# defined here do NOT register for it. A module-level `os.environ[...] = ...`
+# would therefore blind every e2e run with no hook available to ever release
+# it. Putting the guard in `pytest_configure` means e2e is untouched by
+# construction: the module body runs, the hook does not.
+_CUDA_GUARD_SENTINEL = "-1"
+_CUDA_GUARD_HATCH = "OT_TEST_CUDA_VISIBLE_DEVICES"
+_CUDA_GUARD_APPLIED = pytest.StashKey[bool]()
+
+# pytest expression grammar keywords that are never marker names.
+_MARKEXPR_KEYWORDS = {"not", "and", "or", "True", "False", "None"}
+
+
+def _selection_may_run_gpu_tests(markexpr: str) -> bool:
+    """Return whether some marker set containing "gpu" satisfies `markexpr`.
+
+    The default markexpr is `not integration and not gpu`, which CONTAINS the
+    substring "gpu" — a naive `if "gpu" in markexpr` would disable the guard on
+    every default run, invisibly. Two files are marked BOTH `integration` and
+    `gpu` (`test_diar_native_smoke_live.py`, `test_gpu_scale_smoke_live.py`), so
+    the gate's `-m integration` phase legitimately selects gpu tests and must
+    NOT be blinded either. Satisfiability — is there an assignment of the
+    expression's own marker names (forcing gpu=True) that evaluates True — is
+    the only predicate that gets both cases right.
+    """
+    if not markexpr.strip():
+        # An empty markexpr selects everything, including `gpu` tests. Blinding
+        # here would silently turn a `gpu`-marked test into a "CUDA not
+        # available" skip — a green vacuum. pytest_runtest_setup below turns
+        # that into a loud, non-skippable failure instead of relying on this
+        # function to somehow return True for "everything".
+        return False
+    names = sorted((set(re.findall(r"[A-Za-z_]\w*", markexpr)) - _MARKEXPR_KEYWORDS) | {"gpu"})
+    if len(names) > 12:
+        # Combinatorial guard: 2**12 = 4096 evaluations, comfortably fast. A
+        # markexpr naming more than 12 distinct markers is not realistic here;
+        # refuse rather than hang.
+        return False
+    try:
+        from _pytest.mark.expression import Expression  # private API
+    except ImportError:
+        # Fail toward the SAFE direction: if we cannot ask pytest what the
+        # expression means, assume it might select gpu tests and leave CUDA
+        # visible. test_the_marker_predicate_rejects_the_default_expression's
+        # fallback case (7.5) pins this so it can never regress silently.
+        return True
+    expr = Expression.compile(markexpr)
+    for combo in itertools.product((False, True), repeat=len(names)):
+        env = dict(zip(names, combo, strict=True))
+        if not env["gpu"]:
+            continue
+        if expr.evaluate(lambda n, _env=env: _env.get(n, False)):
+            return True
+    return False
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Restrict CUDA device visibility unless the selection may run gpu tests.
+
+    Escape hatch `OT_TEST_CUDA_VISIBLE_DEVICES`: "1" sets CUDA_VISIBLE_DEVICES
+    and skips the marker check entirely; "all" leaves it exactly as inherited
+    from the parent shell; "" is an explicit blind; unset means the marker
+    predicate above decides.
+
+    Deliberately does NOT use `os.environ.setdefault` (unlike lines 39/95/98/120
+    in this same file) — an ambient CUDA_VISIBLE_DEVICES already set in the
+    developer's shell must NOT release the guard. `setdefault` would make that
+    the single most likely way this ships broken; test 7.7
+    (`test_an_ambient_cuda_visible_devices_does_not_release_the_guard`) exists
+    to catch a regression back to it.
+    """
+    hatch = os.environ.get(_CUDA_GUARD_HATCH)
+    if hatch is not None:
+        if hatch != "all":
+            os.environ["CUDA_VISIBLE_DEVICES"] = hatch
+        config.stash[_CUDA_GUARD_APPLIED] = False
+        return
+
+    markexpr = config.getoption("markexpr", default="") or ""
+    if _selection_may_run_gpu_tests(markexpr):
+        config.stash[_CUDA_GUARD_APPLIED] = False
+        return
+
+    os.environ["CUDA_VISIBLE_DEVICES"] = _CUDA_GUARD_SENTINEL
+    # PCI_BUS_ID makes pytest's/torch's device ordinals agree with `nvidia-smi`,
+    # GPU_DEVICE_ID and Docker `device_ids`. Measured on this host: CUDA's
+    # default FASTEST_FIRST ordering does NOT match nvidia-smi (nvidia-smi
+    # 0=A6000/1=RTX3080Ti/2=A6000, torch default order 0=A6000/1=A6000/
+    # 2=RTX3080Ti) — so under the default ordering, CUDA_VISIBLE_DEVICES=1
+    # would select nvidia-smi GPU 2, a card reserved for unrelated work. This
+    # is a real behaviour change on multi-GPU hosts, applied here rather than
+    # left implicit.
+    os.environ.setdefault("CUDA_DEVICE_ORDER", "PCI_BUS_ID")
+    config.stash[_CUDA_GUARD_APPLIED] = True
+
+
+def pytest_runtest_setup(item: pytest.Item) -> None:
+    """Hard-fail a `gpu`-marked test collected under the guard, never skip it.
+
+    Closes the empty-markexpr hole loudly: `-m ''` (or no `-m` at all) selects
+    everything including `gpu` tests, which `_selection_may_run_gpu_tests`
+    treats as blind by design. Without this, a `gpu` test run that way would
+    SKIP on "CUDA not available" — a green vacuum, this repo's signature
+    failure mode (issue #431). A per-item `pytest.fail(pytrace=False)` is used
+    rather than a session-level UsageError in `pytest_collection_modifyitems`:
+    a UsageError raised inside an xdist worker can break the collection
+    protocol, per the measured plan for issue #719.
+    """
+    if not item.config.stash.get(_CUDA_GUARD_APPLIED, False):
+        return
+    if item.get_closest_marker("gpu") is None:
+        return
+    pytest.fail(
+        "cuda-device-guard: this test is marked @pytest.mark.gpu but CUDA "
+        "devices are hidden (CUDA_VISIBLE_DEVICES="
+        f"{os.environ.get('CUDA_VISIBLE_DEVICES')!r}). Select it explicitly "
+        "with `-m gpu` (or set OT_TEST_CUDA_VISIBLE_DEVICES) rather than "
+        "letting it run blind — a skip here would look like a pass.",
+        pytrace=False,
+    )
+
+
+# --- end CUDA device guard --------------------------------------------------
 
 # Import app modules after setting environment variables (they check env during import)
 from app.core.config import settings  # noqa: E402

--- a/backend/tests/unit/test_cuda_device_guard.py
+++ b/backend/tests/unit/test_cuda_device_guard.py
@@ -1,0 +1,212 @@
+"""CUDA device guard (issue #719).
+
+The fast suite used to open a CUDA context on every visible GPU from any xdist
+worker that happened to import torch, including cards this project does not
+own. `tests/conftest.py`'s `pytest_configure`/`pytest_runtest_setup` now hide
+every device from the default selection and hard-fail a `gpu`-marked test that
+somehow ran under the guard instead of silently skipping it.
+
+This module intentionally carries NO `gpu` marker — it is exercised by the
+default fast-suite selection, which is the state the guard must produce.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+from tests.conftest import _selection_may_run_gpu_tests
+
+_GUARD_SENTINEL = "-1"
+
+
+def test_the_default_selection_has_no_visible_cuda_device() -> None:
+    """7.1: in-process, runs inside an xdist worker under the default -n auto."""
+    hatch = os.environ.get("OT_TEST_CUDA_VISIBLE_DEVICES")
+    if hatch is not None and hatch != "all":
+        assert os.environ.get("CUDA_VISIBLE_DEVICES") == hatch
+    elif hatch == "all":
+        # Guard deliberately not applied: CUDA_VISIBLE_DEVICES is whatever the
+        # parent shell handed us. Assert the ONLY thing that is actually
+        # guaranteed — that the guard left it exactly as `OT_TEST_EXPECT_CVD`
+        # (set by the "all" case of test_the_escape_hatch_selects_the_requested_
+        # devices below) rather than overwriting it with the sentinel. torch is
+        # deliberately not imported in this branch: the ambient value may be a
+        # real device, and importing torch would open a context on it.
+        expected = os.environ.get("OT_TEST_EXPECT_CVD")
+        assert expected is not None, "expects OT_TEST_EXPECT_CVD to be set by the caller"
+        assert os.environ.get("CUDA_VISIBLE_DEVICES") == expected
+        return
+    else:
+        assert os.environ.get("CUDA_VISIBLE_DEVICES") == _GUARD_SENTINEL
+
+    import torch
+
+    assert torch.cuda.device_count() == 0
+    assert torch.cuda.is_available() is False
+
+
+@pytest.mark.gpu
+def test_gpu_probe_sees_released_device_visibility() -> None:
+    """7.2: deselected by default; driven explicitly by test 7.3 in a subprocess."""
+    assert os.environ.get("CUDA_VISIBLE_DEVICES") != _GUARD_SENTINEL
+
+
+def test_a_gpu_selection_is_not_blinded() -> None:
+    """7.3: `-m gpu` must not be blinded by the guard (anti-vacuum control)."""
+    env = dict(os.environ)
+    env.pop("CUDA_VISIBLE_DEVICES", None)
+    env.pop("OT_TEST_CUDA_VISIBLE_DEVICES", None)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            __file__ + "::test_gpu_probe_sees_released_device_visibility",
+            "-o",
+            "addopts=",
+            "-m",
+            "gpu",
+            "-q",
+            "-n0",
+            "-p",
+            "no:cacheprovider",
+        ],
+        cwd=os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0
+    assert "1 passed" in result.stdout
+
+
+def test_a_gpu_marked_test_cannot_run_blinded() -> None:
+    """7.4: an empty markexpr selects `gpu` tests too — must ERROR, never skip."""
+    env = dict(os.environ)
+    env.pop("CUDA_VISIBLE_DEVICES", None)
+    env.pop("OT_TEST_CUDA_VISIBLE_DEVICES", None)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            __file__ + "::test_gpu_probe_sees_released_device_visibility",
+            "-o",
+            "addopts=",
+            "-q",
+            "-n0",
+        ],
+        cwd=os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 1
+    assert "cuda-device-guard" in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("markexpr", "expected"),
+    [
+        ("not integration and not gpu", False),
+        ("gpu", True),
+        ("integration", True),
+        ("not integration", True),
+        ("not gpu", False),
+        ("slow", True),
+        ("gpu and not slow", True),
+        ("e2e or gpu", True),
+        ("", False),
+    ],
+)
+def test_the_marker_predicate_rejects_the_default_expression(markexpr: str, expected: bool) -> None:
+    """7.5: table-driven, prototyped against real `_pytest.mark.expression`."""
+    assert _selection_may_run_gpu_tests(markexpr) is expected
+
+
+def test_the_marker_predicate_fails_safe_without_the_private_api(monkeypatch) -> None:
+    """7.5 fallback case: no silent blind if `_pytest.mark.expression` moves."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _blocked_import(name, *args, **kwargs):
+        if name == "_pytest.mark.expression":
+            raise ImportError("simulated")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _blocked_import)
+    assert _selection_may_run_gpu_tests("not integration and not gpu") is True
+
+
+@pytest.mark.parametrize("hatch_value", ["-1", "all"])
+def test_the_escape_hatch_selects_the_requested_devices(hatch_value: str) -> None:
+    """7.6: only `-1`/`all` are used, so this never exposes a real card."""
+    env = dict(os.environ)
+    env["OT_TEST_CUDA_VISIBLE_DEVICES"] = hatch_value
+    env["CUDA_VISIBLE_DEVICES"] = "0"
+    ambient = env["CUDA_VISIBLE_DEVICES"]
+    # Read by the "all" branch of test_the_default_selection_has_no_visible_cuda_device
+    # so it can assert the ambient value survived rather than merely returning early.
+    env["OT_TEST_EXPECT_CVD"] = ambient
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            __file__ + "::test_the_default_selection_has_no_visible_cuda_device",
+            "-o",
+            "addopts=",
+            "-m",
+            "not integration and not gpu",
+            "-q",
+            "-n0",
+            "-p",
+            "no:cacheprovider",
+        ],
+        cwd=os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0
+    assert "1 passed" in result.stdout
+    if hatch_value != "all":
+        assert ambient == "0"  # documents the ambient value the hatch overrode
+
+
+def test_an_ambient_cuda_visible_devices_does_not_release_the_guard() -> None:
+    """7.7: the `setdefault` trap — an ambient value must not survive."""
+    env = dict(os.environ)
+    env.pop("OT_TEST_CUDA_VISIBLE_DEVICES", None)
+    env["CUDA_VISIBLE_DEVICES"] = "0"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            __file__ + "::test_the_default_selection_has_no_visible_cuda_device",
+            "-o",
+            "addopts=",
+            "-m",
+            "not integration and not gpu",
+            "-q",
+            "-n0",
+            "-p",
+            "no:cacheprovider",
+        ],
+        cwd=os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0
+    assert "1 passed" in result.stdout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,8 @@ skips = ["*_test.py", "test_*.py"]
 # Deleting this table is NOT the fix: with no ini at all pytest falls back to collecting from
 # the cwd, which pulls in `frontend/node_modules`.
 # `backend/tests/unit/test_pytest_config_consistency.py` fails if the two drift apart.
+# `-m 'not integration and not gpu'` is now load-bearing for CUDA device VISIBILITY, not
+# only test selection (issue #719) — see the matching note in backend/pyproject.toml.
 testpaths = ["backend/tests"]
 python_files = ["test_*.py", "*_test.py"]
 python_classes = ["Test*"]
@@ -124,7 +126,7 @@ markers = [
     "pki: PKI certificate tests",
     "e2e: end-to-end browser tests",
     "integration: integration tests requiring running dev environment",
-    "gpu: tests requiring a physical GPU — deselected from the fast suite, run by the gate",
+    "gpu: tests requiring a physical GPU — deselected from the fast suite, run by the gate, and the only selection that keeps CUDA devices visible (issue #719)",
     "models: tests requiring ML model weights (Presidio/GLiNER/toxicity) — skipped in fast CI",
     "ddl_exclusive: performs schema DDL (DROP/ALTER TABLE) needing full DB-wide exclusivity, not just self-consistency — see tests/conftest.py's advisory-lock isolation (issue #389)",
 ]

--- a/scripts/run-diarization-gpu-tests.sh
+++ b/scripts/run-diarization-gpu-tests.sh
@@ -19,7 +19,10 @@
 #   * They self-skip unless OPENTRANSCRIBE_IN_CONTAINER=1 or /.dockerenv exists, so a
 #     host run reports "3 skipped" and looks fine.
 #   * pyproject's addopts selector is `-m 'not integration and not gpu'`, so without
-#     `-o addopts= -m gpu` pytest deselects all of them and exits 0.
+#     `-o addopts= -m gpu` pytest deselects all of them and exits 0. Since issue #719
+#     `-o addopts= -m gpu` is ALSO what keeps CUDA devices visible at all: the fast
+#     selector now hides every device (tests/conftest.py's pytest_configure), so argv
+#     without `-m gpu` gets a `cuda-device-guard` pytest.fail, not a silent skip.
 #   * BENCHMARK_ROOT (/app/benchmark/test_audio) is gitignored: with the fixtures
 #     absent every test skips individually, again exiting 0. This script refuses to
 #     run in that state rather than hand you a vacuous pass.

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -267,6 +267,11 @@ else
     if $EXPORT_CAPABILITY; then
         EXPORT_ENV=(env RUN_EXPORT_CAPABILITY_TEST=1)
     fi
+    # -m integration is one of only two selections (with -m gpu below) that the CUDA
+    # device guard (issue #719, tests/conftest.py's pytest_configure) leaves un-blinded:
+    # two files under tests/integration/ carry BOTH `integration` and `gpu` markers
+    # (test_diar_native_smoke_live.py, test_gpu_scale_smoke_live.py), so this phase
+    # legitimately needs real device visibility and must stay in that set.
     run_phase_watching_skips "Integration-marked tests" \
         "${EXPORT_ENV[@]}" "$VENV_PY" -m pytest tests/integration/ tests/test_selective_reprocess.py tests/eval/ \
         -o addopts="" -m integration -q --tb=short --timeout="${INTEGRATION_TEST_TIMEOUT:-900}"
@@ -289,6 +294,13 @@ run_phase "Dependency parity: venv vs container" \
 # this gate is the ONLY place they run — they were silently ungated before #297.
 # Each module still carries its own runtime skip guard, so this is a no-op on a
 # machine without CUDA; pass --skip-gpu to drop the phase entirely.
+#
+# `-o addopts="" -m gpu` is the other selection (with -m integration above) that the
+# CUDA device guard (issue #719) leaves un-blinded — CUDA_VISIBLE_DEVICES is left as
+# inherited rather than forced to -1, because `-m gpu` satisfies
+# tests/conftest.py's `_selection_may_run_gpu_tests`. Running this phase's pytest
+# invocation with a DIFFERENT -m expression that happens not to select `gpu` would
+# make every gpu test in it error with `cuda-device-guard` instead of running.
 #
 # ⚠️ This phase runs in the VENV, so the three container-only diarization suites
 # (test_diarizer_lifecycle / test_diarization_perf_gates / test_diarization_regression)


### PR DESCRIPTION
## Problem

The fast backend suite opened a CUDA primary context (~300 MiB) on every xdist worker that happened to import torch, on whatever device is default (device 0) — multiplied by `-n auto` (48 workers here), tens of contexts on cards this project does not own. GPU 0 and GPU 2 are reserved for unrelated work; the suite measured 8.9 GB on GPU 0 alone.

## Fix

`backend/tests/conftest.py`'s new `pytest_configure` hook asks pytest's own `Expression` parser whether the *active* `-m` selection can ever satisfy `gpu` — satisfiability, not a `"gpu" in markexpr` substring check, because the default expression `not integration and not gpu` contains that substring and must still leave the guard **on**. Two files carry both `integration` and `gpu` markers, so `-m integration` (the gate's own selection) legitimately needs real devices and stays un-blinded.

When the selection cannot run `gpu` tests, `CUDA_VISIBLE_DEVICES=-1` is set before any worker imports torch (the freeze point is the first CUDA *call*, not `import torch` — this was verified). `CUDA_DEVICE_ORDER=PCI_BUS_ID` is set alongside it: measured on this host, CUDA's default device ordering does **not** match `nvidia-smi` (nvidia-smi 0=A6000/1=RTX3080Ti/2=A6000 vs torch default 0=A6000/1=A6000/2=RTX3080Ti), so without this fix `CUDA_VISIBLE_DEVICES=1` would silently select the wrong physical card once any code path re-enables a device.

A `gpu`-marked test that runs anyway under the guard **errors** (`pytest.fail`, `cuda-device-guard` in the message) instead of skipping on "CUDA not available" — a skip there would read as a pass, this repo's known green-vacuum failure mode.

Escape hatch: `OT_TEST_CUDA_VISIBLE_DEVICES` — `1`/`-1` sets it directly and bypasses the marker check, `all` leaves the ambient value exactly as inherited, `""` is an explicit blind. The block deliberately does **not** use `os.environ.setdefault` (unlike three other spots in the same file) — an ambient `CUDA_VISIBLE_DEVICES` already set in a developer's shell must not silently release the guard.

The guard lives entirely in a pytest hook, never a module-level assignment: `tests/e2e/conftest.py` imports `tests.conftest` purely for its module-body side effects under a separate rootdir, so hooks defined here never register for e2e — a module-level env assignment would have blinded every e2e run permanently with no way to undo it.

## Also fixed, found while doing this

Nothing outside the guard's own footprint — comments in `backend/pyproject.toml`, root `pyproject.toml`, `backend/tests/CLAUDE.md`, `scripts/run-diarization-gpu-tests.sh`, and `scripts/run-integration-tests.sh` document the new load-bearing meaning of `-m 'not integration and not gpu'` and `-m gpu`. No shell logic changed anywhere; every script keeps working unmodified.

## Behaviour changes worth flagging

- **`tests/onnx/` parity tests now run on CPU instead of real CUDA.** They were previously unmarked and ran real CUDA in the fast suite (likely a large share of the measured 8.9 GB). The parity assertions compare PyTorch against ONNX on the *same* device, so they stay meaningful — just slower and CPU-only now.
- **`CUDA_DEVICE_ORDER=PCI_BUS_ID` is a real ordering change on multi-GPU hosts** whenever a `gpu`-marked test run releases the guard, documented in the conftest comment.

## Follow-up, explicitly out of scope

The released `-m gpu` state is deliberately **not** pinned to `GPU_DEVICE_ID` — doing so would break `test_gpu_scale_smoke_live.py`, which needs two cards visible at once.

## Testing

- `backend/tests/unit/test_cuda_device_guard.py` — 7 tests (16 collected cases incl. parametrization), all pass locally (in-process + subprocess).
- Red-check: ran the new test file against the pre-fix `conftest.py` via a `git archive HEAD` tree — collection fails immediately (`ImportError: cannot import name '_selection_may_run_gpu_tests'`), since the module depends entirely on the new hook.
- Measured GPU memory via `nvidia-smi` before/after running `tests/unit/test_diarizer_engine_selection.py` (the test named in the issue as opening a context): **0, 5558 MiB / 1, 4149 MiB / 2, 18 MiB unchanged** before and after — no new CUDA context opened.
- `cd backend && python3 ../scripts/audit-tests.py tests` — 0 open findings.
- `scripts/safe-precommit.sh run --all-files` — exit 0.
- `scripts/safe-precommit.sh run --all-files --hook-stage pre-push` — exit 0.

Not verified: real multi-GPU behavior of the `-m gpu` phase against actual diarization workloads (out of scope for this change — it doesn't touch that code path, only test-harness device visibility).

Closes #719
