### PR TITLE
fix(frontend): audit and fix premature-interaction timing races (#649)

### DIFF
--- a/frontend/src/components/PlyrMiniPlayer.svelte
+++ b/frontend/src/components/PlyrMiniPlayer.svelte
@@ -3,7 +3,7 @@
   import Plyr from 'plyr';
   import 'plyr/dist/plyr.css';
   import WaveformPlayer from '$components/WaveformPlayer.svelte';
-  import { waitForMediaMetadata, HAVE_METADATA } from '$lib/utils/mediaReady';
+  import { applyMediaSeek, waitForMediaMetadata, HAVE_METADATA } from '$lib/utils/mediaReady';
 
   export let mediaUrl: string;
   export let contentType: string;
@@ -61,30 +61,14 @@
       fullscreen: { iosNative: false, fallback: true },
     });
 
-    let hasStartedPlayback = false;
-
-    function seekAndPlay() {
-      if (hasStartedPlayback || !player) return;
-      hasStartedPlayback = true;
-      // Seek to the requested start once metadata is ready, then autoplay.
-      applySeek(startTime, { play: autoplay });
-    }
-
-    const media = (player as any).media as HTMLMediaElement | undefined;
-    if (media) {
-      const onCanPlay = () => {
-        seekAndPlay();
-        media.removeEventListener('canplay', onCanPlay);
-      };
-      media.addEventListener('canplay', onCanPlay);
-      // Handle already-ready media (e.g., from browser cache)
-      if (media.readyState >= 3) {
-        seekAndPlay();
-      }
-      media.addEventListener('seeked', () => { seeking = false; }, { once: true });
-      media.addEventListener('playing', () => { seeking = false; }, { once: true });
-      media.addEventListener('error', () => { seeking = false; }, { once: true });
-    }
+    // Issue the initial seek immediately rather than gating it on `canplay`
+    // (readyState >= HAVE_FUTURE_DATA). That was STRICTER than the
+    // `loadedmetadata` gate #647 removed from VideoPlayer, and it waited on
+    // buffering data at position 0 that the seek is about to discard anyway —
+    // with no fallback if `canplay` never fired (#649). `applySeek` below
+    // issues the raw `currentTime` assignment up front and only awaits
+    // metadata to resync Plyr's own clock, same as VideoPlayer.seekToTime.
+    applySeek(startTime, { play: autoplay });
 
     player.on('timeupdate', () => {
       if (player) {
@@ -98,7 +82,12 @@
       }
     });
 
+    // Persistent (not `{ once: true }`) handlers so a later `hotSwapSource`
+    // seek still clears the spinner — the previous once-only raw media
+    // listeners were consumed by the FIRST seek, so a hot-swapped presigned
+    // URL fell back to the 15s timer every time after that (#649).
     player.on('playing', () => { seeking = false; dispatch('play'); });
+    player.on('seeked', () => { seeking = false; });
     player.on('pause', () => { dispatch('pause'); });
     player.on('error', () => { seeking = false; });
     player.on('ready', () => { dispatch('ready'); });
@@ -115,31 +104,43 @@
     }
   }
 
-  // Metadata-safe seek primitive. Plyr silently drops a seek if its internal
-  // duration isn't ready yet, which makes the player start from 0. Wait for
-  // loadedmetadata/canplay, then set BOTH the Plyr and raw-media currentTime.
+  // Metadata-safe seek primitive. Issues the seek to the media element FIRST,
+  // without waiting for metadata — assigning `currentTime` before
+  // `loadedmetadata` is NOT discarded per spec, so the previous
+  // wait-then-seek order only delayed the browser's own range request for no
+  // benefit (the #645/#647 bug, unfixed here until now). Plyr's OWN
+  // `currentTime` setter still bails while its internal duration is 0, so we
+  // resync `player.currentTime` once metadata lands purely to keep its
+  // progress bar honest — that resync is what waits, never the seek itself.
   async function applySeek(time: number, { play }: { play: boolean }) {
     if (!player || !mediaElement) return;
     const media = mediaElement;
 
-    if (media.readyState < HAVE_METADATA) {
-      // Shared with VideoPlayer — see $lib/utils/mediaReady. The raw
-      // `media.currentTime` assignment below always lands even if Plyr's own
-      // setter bails, so no extra settling delay is needed here.
-      await waitForMediaMetadata(media);
-    }
-
-    if (!player) return;
+    const appliedDirectly = time > 0 ? applyMediaSeek(media, time) : true;
     if (time > 0) {
       // Pause before seeking so a slow/deep seek can't briefly play the buffered
       // start of the file while the target byte-range loads.
       try { media.pause(); } catch {}
-      player.currentTime = time;
-      media.currentTime = time;
-      // Wait until the playhead is actually at the target (seek landed) before
-      // resuming — on slow links the seeked event can lag well behind the set.
-      await waitForSeeked(media, time);
+    }
+
+    if (media.readyState < HAVE_METADATA) {
+      // Shared with VideoPlayer — see $lib/utils/mediaReady.
+      const ready = await waitForMediaMetadata(media);
       if (!player) return;
+      if (!ready && !appliedDirectly) {
+        // Metadata never arrived and the direct assignment failed; nothing
+        // more we can usefully do without guessing.
+        seeking = false;
+        return;
+      }
+    }
+
+    if (!player) return;
+    if (time > 0) {
+      if (Math.abs((player.currentTime ?? 0) - time) > 0.05) {
+        player.currentTime = time;
+      }
+      if (!appliedDirectly) media.currentTime = time;
     }
 
     if (play) {
@@ -152,24 +153,9 @@
     }
   }
 
-  // Resolve once the media element has actually seeked to (or near) the target,
-  // or after a timeout so playback never hangs on an unreachable position.
-  function waitForSeeked(media: HTMLMediaElement, time: number): Promise<void> {
-    if (Math.abs(media.currentTime - time) < 0.5) return Promise.resolve();
-    return new Promise((resolve) => {
-      const done = () => {
-        media.removeEventListener('seeked', done);
-        clearTimeout(timer);
-        resolve();
-      };
-      const timer = setTimeout(done, 10000);
-      media.addEventListener('seeked', done, { once: true });
-    });
-  }
-
-  // Swap in a refreshed presigned URL without losing position. The init-time
-  // seekAndPlay won't re-fire (its hasStartedPlayback guard is already set), so
-  // we restore currentTime/play-state ourselves.
+  // Swap in a refreshed presigned URL without losing position. `initPlayer`'s
+  // initial `applySeek` call only fires once, at player creation, so we
+  // restore currentTime/play-state ourselves here.
   async function hotSwapSource(newUrl: string) {
     activeSrc = newUrl;
     if (!player || !mediaElement) return;
@@ -198,10 +184,11 @@
   }
 
   onMount(() => {
-    // Wait for Svelte to bind the media element
-    setTimeout(() => {
-      initPlayer();
-    }, 50);
+    // `bind:this={mediaElement}` is assigned before `onMount` fires, so the
+    // element is already bound here — the previous 50ms sleep just delayed
+    // player creation (and, transitively, the initial seek) for no reason
+    // (#649).
+    initPlayer();
   });
 
   onDestroy(() => {

--- a/frontend/src/components/PlyrMiniPlayer.test.ts
+++ b/frontend/src/components/PlyrMiniPlayer.test.ts
@@ -1,0 +1,104 @@
+/**
+ * DEFECT THIS CATCHES (issue #649, "F1" in the audit): `PlyrMiniPlayer` — the
+ * search-results / speaker preview player — carried the #645/#647 bug that
+ * `VideoPlayer.seekToTime` was fixed for: `applySeek` awaited
+ * `waitForMediaMetadata` BEFORE touching the media element's `currentTime`,
+ * so a click that opened the preview player at a non-zero `startTime` stalled
+ * for as long as metadata took to arrive (up to the 15s fallback) instead of
+ * seeking immediately. Per the HTML spec, assigning `currentTime` before
+ * `loadedmetadata` is not discarded — it becomes the default playback start
+ * position — so the wait bought nothing and blocked the very request it was
+ * waiting for.
+ *
+ * The initial seek was also gated behind a `canplay` listener (readyState >=
+ * HAVE_FUTURE_DATA), which is STRICTER than the metadata gate above and had
+ * no fallback if `canplay` never fired.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/svelte';
+
+vi.mock('plyr', () => {
+  class FakePlyr {
+    media: HTMLMediaElement;
+    private listeners: Record<string, Array<() => void>> = {};
+    constructor(el: HTMLMediaElement) {
+      this.media = el;
+    }
+    on(event: string, cb: () => void) {
+      (this.listeners[event] ||= []).push(cb);
+    }
+    get currentTime() {
+      return this.media.currentTime;
+    }
+    set currentTime(v: number) {
+      this.media.currentTime = v;
+    }
+    get duration() {
+      return this.media.duration || 0;
+    }
+    play() {
+      return Promise.resolve();
+    }
+    pause() {}
+    destroy() {}
+  }
+  return { default: FakePlyr };
+});
+
+vi.mock('plyr/dist/plyr.css', () => ({}));
+
+import PlyrMiniPlayer from './PlyrMiniPlayer.svelte';
+
+/** A couple of microtask turns — enough for the synchronous portion of an
+ * async function (everything before its first `await`) to have run, without
+ * needing real timers or a metadata event that this suite never fires. */
+async function flushMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('initial seek timing', () => {
+  it('assigns currentTime to the media element before metadata has ever arrived', async () => {
+    const { container } = render(PlyrMiniPlayer, {
+      props: {
+        mediaUrl: 'blob:test-media',
+        contentType: 'audio/mpeg',
+        startTime: 42,
+        autoplay: false,
+        fileId: '',
+      },
+    });
+
+    await flushMicrotasks();
+
+    const media = container.querySelector('audio') as HTMLMediaElement;
+    // jsdom never fires loadedmetadata/canplay in this suite — readyState
+    // stays at HAVE_NOTHING (0) for the whole test. The old code awaited
+    // metadata before this assignment, so under the pre-fix implementation
+    // `currentTime` would still be 0 here.
+    expect(media.readyState).toBe(0);
+    expect(media.currentTime).toBe(42);
+  });
+
+  it('does not touch currentTime when startTime is 0 (nothing to seek to)', async () => {
+    const { container } = render(PlyrMiniPlayer, {
+      props: {
+        mediaUrl: 'blob:test-media',
+        contentType: 'audio/mpeg',
+        startTime: 0,
+        autoplay: false,
+        fileId: '',
+      },
+    });
+
+    await flushMicrotasks();
+
+    const media = container.querySelector('audio') as HTMLMediaElement;
+    expect(media.currentTime).toBe(0);
+  });
+});

--- a/frontend/src/components/VideoPlayer.svelte
+++ b/frontend/src/components/VideoPlayer.svelte
@@ -50,12 +50,23 @@
 
   // External seek function for waveform and transcript clicks
   export async function seekToTime(time: number) {
-    if (!player) {
+    // Use the raw bound element, not `(player as any).media` — that requires
+    // Plyr to have been constructed first, which is itself async (this
+    // component's own `$: if (videoUrl && mediaElement && !player)
+    // initializePlyr()`). A caller (e.g. the `?t=` deep-link handler) firing
+    // in the same reactivity flush as this component's mount can land here
+    // BEFORE that reactive statement has run, i.e. while `player` is still
+    // null. The old code's `if (!player) return` silently dropped exactly
+    // that seek — the same "act on not-yet-ready state" shape #649 found and
+    // fixed in WaveformPlayer's click handler, here unmasked by removing the
+    // caller's incidental delay rather than caused by it. `mediaElement` is
+    // bound directly on the <video>/<audio> tag and needs no Plyr instance.
+    const media = mediaElement ?? ((player as any)?.media as HTMLMediaElement | undefined);
+    if (!media) {
       return;
     }
 
     const requestId = ++seekRequestId;
-    const media = (player as any).media as HTMLMediaElement | undefined;
 
     // Show seeking spinner immediately, and keep it up until `seeked` fires
     // rather than clearing it on a blind short timer.
@@ -69,12 +80,12 @@
     // index. The previous implementation awaited `loadedmetadata` (up to a
     // hard-coded 15s) plus a fixed 150ms *before* touching the element, which
     // added that entire wait to every seek issued during page load.
-    const appliedDirectly = media ? applyMediaSeek(media, time) : false;
+    const appliedDirectly = applyMediaSeek(media, time);
 
     currentTime = time;
     dispatch('timeupdate', { currentTime: time, duration });
 
-    if (media && media.readyState < HAVE_METADATA) {
+    if (media.readyState < HAVE_METADATA) {
       // Plyr's own `currentTime` setter bails while its duration is still 0, so
       // its progress bar would stay at zero. Re-apply through Plyr once metadata
       // lands — this only syncs the control UI, the seek itself already happened.
@@ -88,8 +99,11 @@
       if (!appliedDirectly) applyMediaSeek(media, time);
     }
 
-    // Keep Plyr's internal clock in sync (progress bar, time readout).
-    if (Math.abs((player.currentTime ?? 0) - time) > 0.05) {
+    // Keep Plyr's internal clock in sync (progress bar, time readout) —
+    // best-effort: `player` may still not exist yet if this resolved before
+    // Plyr was constructed, in which case Plyr will simply pick up the
+    // media element's already-seeked position when it initializes.
+    if (player && Math.abs((player.currentTime ?? 0) - time) > 0.05) {
       player.currentTime = time;
     }
   }

--- a/frontend/src/components/VideoPlayer.test.ts
+++ b/frontend/src/components/VideoPlayer.test.ts
@@ -1,0 +1,93 @@
+/**
+ * DEFECT THIS CATCHES (issue #649, found via live browser verification of
+ * this same PR): `seekToTime` used to read the raw media element through
+ * `(player as any).media`, and early-returned entirely if `player` (the
+ * Plyr instance) didn't exist yet: `if (!player) return;`.
+ *
+ * That is a race, not a safety check. `player` is set by this component's
+ * OWN reactive statement (`$: if (videoUrl && mediaElement && !player)
+ * initializePlyr()`), which is independent of — and can resolve AFTER — the
+ * `?t=` deep-link handler in `routes/files/[id]/+page.svelte`, which calls
+ * `videoPlayerComponent.seekToTime(...)` as soon as `videoPlayerComponent`
+ * is bound. Once #649 removed the artificial 500ms sleep that used to sit in
+ * front of that call (because the wait was itself the #645 bug), the two
+ * reactive statements were left to race directly, and a `?t=` deep link on a
+ * live 3-hour audio file landed at `currentTime: 0` instead of the
+ * requested timestamp — confirmed live, not just in this suite.
+ *
+ * The fix: use the raw `mediaElement` (bound directly on the `<video>`/
+ * `<audio>` tag, independent of Plyr) as the primary seek target, and treat
+ * `player` as optional best-effort sync for Plyr's own progress bar.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/svelte';
+
+// Plyr fails to construct here on purpose, so `player` stays permanently
+// null while `mediaElement` and `videoUrl` are both valid — reproducing the
+// exact state of the race (child's own init reactive statement having not
+// (yet, or ever) resolved) without depending on Svelte's effect-scheduling
+// order to land a real unit test in the right window.
+vi.mock('plyr', () => {
+  class ThrowingPlyr {
+    constructor() {
+      throw new Error('Plyr never constructs in this test — player stays null');
+    }
+  }
+  return { default: ThrowingPlyr };
+});
+vi.mock('plyr/dist/plyr.css', () => ({}));
+
+vi.mock('$stores/locale', () => ({
+  t: {
+    subscribe: (run: (value: (key: string) => string) => void) => {
+      run((key: string) => key);
+      return () => {};
+    },
+  },
+}));
+
+import VideoPlayer from './VideoPlayer.svelte';
+
+async function flushMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('seekToTime without a constructed Plyr instance', () => {
+  it('still seeks the raw media element when `player` is null', async () => {
+    const { container, component } = render(VideoPlayer, {
+      props: {
+        videoUrl: 'blob:test-video',
+        file: { content_type: 'audio/mpeg' },
+      },
+    });
+    await flushMicrotasks();
+
+    const media = container.querySelector('#player') as HTMLMediaElement;
+    expect(media).not.toBeNull();
+
+    // Deliberately not awaited: jsdom never fires `loadedmetadata`, so the
+    // full call would hang on `seekToTime`'s internal metadata wait (up to
+    // its 15s timeout). The `currentTime` assignment under test happens in
+    // the synchronous portion of the function, before that wait — a few
+    // microtask turns is enough to observe it.
+    void (component as unknown as { seekToTime: (t: number) => Promise<void> }).seekToTime(45);
+    await flushMicrotasks();
+
+    expect(media.currentTime).toBe(45);
+  });
+
+  it('does nothing (no throw) when neither player nor mediaElement exist', async () => {
+    const { component } = render(VideoPlayer, { props: { videoUrl: '' } });
+    await flushMicrotasks();
+
+    await expect(
+      (component as unknown as { seekToTime: (t: number) => Promise<void> }).seekToTime(45)
+    ).resolves.toBeUndefined();
+  });
+});

--- a/frontend/src/components/WaveformPlayer.svelte
+++ b/frontend/src/components/WaveformPlayer.svelte
@@ -21,6 +21,11 @@
   let waveformError: string = '';
   let isDragging = false;
   let animationFrameId: number | null = null;
+  // A click/keyboard seek that arrives before `duration` is known (e.g. the
+  // player hasn't reported its duration yet) used to be silently discarded —
+  // the interaction had no effect and gave no feedback. Queue it and flush
+  // once `duration` becomes available instead (#649).
+  let pendingSeekRatio: number | null = null;
 
   const dispatch = createEventDispatcher();
 
@@ -217,14 +222,29 @@
   let mouseDownHandledSeek = false;
 
   function seekFromPointer(event: MouseEvent) {
-    if (!container || duration <= 0) return;
+    if (!container) return;
 
     const rect = container.getBoundingClientRect();
     const clickX = event.clientX - rect.left;
     const seekRatio = Math.min(Math.max(clickX / rect.width, 0), 1);
-    const seekTime = seekRatio * duration;
 
-    dispatch('seek', { time: seekTime });
+    if (duration <= 0) {
+      // Duration isn't known yet (e.g. clicked immediately on a fresh page
+      // load, before the player has reported it). Queue the ratio rather than
+      // discarding the click — the reactive block below flushes it as soon as
+      // `duration` arrives.
+      pendingSeekRatio = seekRatio;
+      return;
+    }
+
+    dispatch('seek', { time: seekRatio * duration });
+  }
+
+  // Flush a seek that arrived before duration was known.
+  $: if (duration > 0 && pendingSeekRatio !== null) {
+    const ratio = pendingSeekRatio;
+    pendingSeekRatio = null;
+    dispatch('seek', { time: ratio * duration });
   }
 
   /**
@@ -287,7 +307,12 @@
    * Handle keyboard navigation
    */
   function handleKeyDown(event: KeyboardEvent) {
-    if (duration <= 0) return;
+    // 'Home' always means "seek to 0" regardless of whether duration is known
+    // yet, so it doesn't need to wait. The other keys need `duration` to
+    // compute a target and are dropped silently below — same call as the
+    // click case above, but they act on a live `currentTime` rather than a
+    // ratio, so there's no meaningful value to queue when duration is still 0.
+    if (duration <= 0 && event.code !== 'Home') return;
 
     let seekTime = currentTime;
     const seekStep = duration * 0.01; // 1% of duration
@@ -328,15 +353,17 @@
 
   // Mount and cleanup
   onMount(() => {
-    // Use setTimeout to ensure DOM is fully rendered
-    setTimeout(() => {
-      if (canvas && container) {
-        handleResize();
-      }
-
-      // Load waveform data
-      loadWaveformData();
-    }, 100);
+    // Svelte's `bind:this` assigns `canvas`/`container` before `onMount`
+    // fires, so the DOM is already there — the previous 100ms sleep bought
+    // nothing but delayed `loadWaveformData()`, which doesn't touch the DOM
+    // at all (getOptimalResolution reads `container.offsetWidth`, which is
+    // already valid here). Waveform fetches on a fresh page load used to be
+    // dead-weighted by this (#649); it also skewed getOptimalResolution's
+    // container-width check on the very first paint.
+    if (canvas && container) {
+      handleResize();
+    }
+    loadWaveformData();
 
     // Cleanup function
     return () => {

--- a/frontend/src/components/WaveformPlayer.test.ts
+++ b/frontend/src/components/WaveformPlayer.test.ts
@@ -154,7 +154,10 @@ describe('loading waveform data', () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(mockAxios.get).toHaveBeenCalledWith('/files/f1/waveform', { params: { samples: 1000 } });
+    // Default test width (300px, set in beforeEach) falls in the "small"
+    // resolution bucket at desktop innerWidth — see 'resolution selection'
+    // above for the bucket boundaries.
+    expect(mockAxios.get).toHaveBeenCalledWith('/files/f1/waveform', { params: { samples: 500 } });
   });
 
   it('draws bars once data arrives and hides the loading overlay', async () => {
@@ -250,7 +253,7 @@ describe('click-to-seek', () => {
     // soon as duration becomes known, not require the user to click again.
     mockAxios.get.mockResolvedValue({ data: { waveform: [1, 2, 3] } });
     const onSeek = vi.fn();
-    const { container, component } = render(WaveformPlayer, {
+    const { container, rerender } = render(WaveformPlayer, {
       props: { fileId: 'f1', duration: 0 },
       events: { seek: onSeek },
     } as never);
@@ -272,10 +275,7 @@ describe('click-to-seek', () => {
     await fireEvent.click(canvasOf(container), { clientX: 75 }); // 25% across
     expect(onSeek).not.toHaveBeenCalled(); // nothing to compute a time against yet
 
-    (component as unknown as { $set: (props: Record<string, unknown>) => void }).$set({
-      duration: 100,
-    });
-    await Promise.resolve();
+    await rerender({ fileId: 'f1', duration: 100 });
 
     expect(onSeek).toHaveBeenCalledWith(expect.objectContaining({ detail: { time: 25 } }));
   });
@@ -283,7 +283,7 @@ describe('click-to-seek', () => {
   it('does not replay a queued seek on an unrelated duration update once it has flushed', async () => {
     mockAxios.get.mockResolvedValue({ data: { waveform: [1, 2, 3] } });
     const onSeek = vi.fn();
-    const { container, component } = render(WaveformPlayer, {
+    const { container, rerender } = render(WaveformPlayer, {
       props: { fileId: 'f1', duration: 0 },
       events: { seek: onSeek },
     } as never);
@@ -303,14 +303,11 @@ describe('click-to-seek', () => {
     });
 
     await fireEvent.click(canvasOf(container), { clientX: 75 });
-    const set = (component as unknown as { $set: (props: Record<string, unknown>) => void }).$set;
-    set({ duration: 100 });
-    await Promise.resolve();
+    await rerender({ fileId: 'f1', duration: 100 });
     expect(onSeek).toHaveBeenCalledTimes(1);
 
     onSeek.mockClear();
-    set({ duration: 120 });
-    await Promise.resolve();
+    await rerender({ fileId: 'f1', duration: 120 });
     expect(onSeek).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/components/WaveformPlayer.test.ts
+++ b/frontend/src/components/WaveformPlayer.test.ts
@@ -46,14 +46,29 @@ function canvasOf(container: HTMLElement): HTMLCanvasElement {
   return container.querySelector('canvas.waveform-canvas') as HTMLCanvasElement;
 }
 
-function setContainerWidth(container: HTMLElement, width: number) {
-  Object.defineProperty(rootOf(container), 'offsetWidth', { configurable: true, value: width });
+// `loadWaveformData()` (and its `getOptimalResolution()` container-width read)
+// now runs SYNCHRONOUSLY during `onMount` (#649 removed the artificial 100ms
+// sleep that used to separate them), i.e. before `render()` even returns — so
+// a test can no longer stub `offsetWidth` on the rendered instance afterward
+// and expect it to matter. Patch the prototype getter once, and let each test
+// set the value it wants BEFORE calling `render()`.
+let mockedContainerWidth = 0;
+Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+  configurable: true,
+  get() {
+    return mockedContainerWidth;
+  },
+});
+
+function setContainerWidth(width: number) {
+  mockedContainerWidth = width;
 }
 
-// The 100ms setTimeout in onMount, plus the microtask chain of the mocked axios
-// call that runs after it — both real, so nothing races fake-timer flushing.
+// The microtask chain of the mocked axios call — real, so nothing races
+// fake-timer flushing. `onMount` no longer sleeps before firing it (#649);
+// this only waits for the axios promise itself to settle.
 async function waitForMountedLoad() {
-  await new Promise((resolve) => setTimeout(resolve, 150));
+  await new Promise((resolve) => setTimeout(resolve, 20));
 }
 
 /** Let one requestAnimationFrame callback run (drag seeks are rAF-coalesced). */
@@ -71,6 +86,7 @@ beforeEach(() => {
   Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1024 });
   Object.defineProperty(window, 'devicePixelRatio', { configurable: true, value: 1 });
   Object.defineProperty(window.navigator, 'connection', { configurable: true, value: undefined });
+  mockedContainerWidth = 300;
 });
 
 afterEach(() => {
@@ -83,8 +99,8 @@ describe('resolution selection', () => {
   it('requests the small resolution for a narrow (mobile) viewport', async () => {
     Object.defineProperty(window, 'innerWidth', { configurable: true, value: 500 });
     mockAxios.get.mockResolvedValue({ data: { waveform: [1, 2, 3] } });
+    setContainerWidth(300);
     const { container } = render(WaveformPlayer, { props: { fileId: 'f1' } });
-    setContainerWidth(container, 300);
 
     await waitForMountedLoad();
 
@@ -97,8 +113,8 @@ describe('resolution selection', () => {
     Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1600 });
     Object.defineProperty(window, 'devicePixelRatio', { configurable: true, value: 2 });
     mockAxios.get.mockResolvedValue({ data: { waveform: [1, 2, 3] } });
+    setContainerWidth(1400);
     const { container } = render(WaveformPlayer, { props: { fileId: 'f1' } });
-    setContainerWidth(container, 1400);
 
     await waitForMountedLoad();
 
@@ -114,8 +130,8 @@ describe('resolution selection', () => {
       value: { effectiveType: '2g', downlink: 0.2 },
     });
     mockAxios.get.mockResolvedValue({ data: { waveform: [1, 2, 3] } });
+    setContainerWidth(1400);
     const { container } = render(WaveformPlayer, { props: { fileId: 'f1' } });
-    setContainerWidth(container, 1400);
 
     await waitForMountedLoad();
 
@@ -125,10 +141,25 @@ describe('resolution selection', () => {
 });
 
 describe('loading waveform data', () => {
+  it('fetches the waveform on mount without waiting for a timer (#649)', async () => {
+    // DEFECT THIS CATCHES: `onMount` used to sleep 100ms via `setTimeout`
+    // before calling `loadWaveformData()`, even though `bind:this` assigns
+    // `canvas`/`container` before `onMount` fires and the fetch itself
+    // doesn't touch the DOM. That silently dead-weighted every waveform
+    // fetch by 100ms on a fresh page load. Only microtask turns are awaited
+    // below — no timer tick at all — so this fails under the old code.
+    mockAxios.get.mockResolvedValue({ data: { waveform: [1, 2, 3] } });
+    render(WaveformPlayer, { props: { fileId: 'f1' } });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockAxios.get).toHaveBeenCalledWith('/files/f1/waveform', { params: { samples: 1000 } });
+  });
+
   it('draws bars once data arrives and hides the loading overlay', async () => {
     mockAxios.get.mockResolvedValue({ data: { waveform: [10, 200, 50] } });
     const { container } = render(WaveformPlayer, { props: { fileId: 'f1', duration: 10 } });
-    setContainerWidth(container, 300);
 
     await waitForMountedLoad();
 
@@ -140,7 +171,6 @@ describe('loading waveform data', () => {
   it('adopts the server duration when none was supplied', async () => {
     mockAxios.get.mockResolvedValue({ data: { waveform: [1, 2, 3], duration: 42.5 } });
     const { container } = render(WaveformPlayer, { props: { fileId: 'f1', duration: 0 } });
-    setContainerWidth(container, 300);
 
     await waitForMountedLoad();
 
@@ -150,7 +180,6 @@ describe('loading waveform data', () => {
   it('leaves a caller-supplied duration alone when the server value is within 0.1s', async () => {
     mockAxios.get.mockResolvedValue({ data: { waveform: [1, 2, 3], duration: 10.05 } });
     const { container } = render(WaveformPlayer, { props: { fileId: 'f1', duration: 10 } });
-    setContainerWidth(container, 300);
 
     await waitForMountedLoad();
 
@@ -160,7 +189,6 @@ describe('loading waveform data', () => {
   it('shows an error and keeps the canvas hidden when the server returns no samples', async () => {
     mockAxios.get.mockResolvedValue({ data: { waveform: [] } });
     const { container } = render(WaveformPlayer, { props: { fileId: 'f1' } });
-    setContainerWidth(container, 300);
 
     await waitForMountedLoad();
 
@@ -171,7 +199,6 @@ describe('loading waveform data', () => {
   it('surfaces the request error message and retries on button click', async () => {
     mockAxios.get.mockRejectedValueOnce(new Error('network down'));
     const { container } = render(WaveformPlayer, { props: { fileId: 'f1' } });
-    setContainerWidth(container, 300);
 
     await waitForMountedLoad();
     expect(container.querySelector('.waveform-error')?.textContent).toContain('network down');
@@ -195,7 +222,6 @@ describe('click-to-seek', () => {
       props: { fileId: 'f1', duration: 100 },
       events: { seek: onSeek },
     } as never);
-    setContainerWidth(container, 300);
     await waitForMountedLoad();
 
     const root = rootOf(container);
@@ -216,18 +242,75 @@ describe('click-to-seek', () => {
     expect(onSeek).toHaveBeenCalledWith(expect.objectContaining({ detail: { time: 25 } }));
   });
 
-  it('does nothing when duration is not yet known', async () => {
+  it('queues a click seek that arrives before duration is known, and flushes it once duration arrives (#649)', async () => {
+    // DEFECT THIS CATCHES: a click while `duration <= 0` used to be silently
+    // discarded — no seek, no feedback, no memory of the click. That's
+    // realistic on a fresh page load: the player hasn't reported its
+    // duration to this component yet. The click should still take effect as
+    // soon as duration becomes known, not require the user to click again.
     mockAxios.get.mockResolvedValue({ data: { waveform: [1, 2, 3] } });
     const onSeek = vi.fn();
-    const { container } = render(WaveformPlayer, {
+    const { container, component } = render(WaveformPlayer, {
       props: { fileId: 'f1', duration: 0 },
       events: { seek: onSeek },
     } as never);
-    setContainerWidth(container, 300);
     await waitForMountedLoad();
 
-    await fireEvent.click(canvasOf(container), { clientX: 75 });
+    const root = rootOf(container);
+    vi.spyOn(root, 'getBoundingClientRect').mockReturnValue({
+      left: 0,
+      width: 300,
+      top: 0,
+      right: 300,
+      bottom: 0,
+      height: 0,
+      x: 0,
+      y: 0,
+      toJSON() {},
+    });
 
+    await fireEvent.click(canvasOf(container), { clientX: 75 }); // 25% across
+    expect(onSeek).not.toHaveBeenCalled(); // nothing to compute a time against yet
+
+    (component as unknown as { $set: (props: Record<string, unknown>) => void }).$set({
+      duration: 100,
+    });
+    await Promise.resolve();
+
+    expect(onSeek).toHaveBeenCalledWith(expect.objectContaining({ detail: { time: 25 } }));
+  });
+
+  it('does not replay a queued seek on an unrelated duration update once it has flushed', async () => {
+    mockAxios.get.mockResolvedValue({ data: { waveform: [1, 2, 3] } });
+    const onSeek = vi.fn();
+    const { container, component } = render(WaveformPlayer, {
+      props: { fileId: 'f1', duration: 0 },
+      events: { seek: onSeek },
+    } as never);
+    await waitForMountedLoad();
+
+    const root = rootOf(container);
+    vi.spyOn(root, 'getBoundingClientRect').mockReturnValue({
+      left: 0,
+      width: 300,
+      top: 0,
+      right: 300,
+      bottom: 0,
+      height: 0,
+      x: 0,
+      y: 0,
+      toJSON() {},
+    });
+
+    await fireEvent.click(canvasOf(container), { clientX: 75 });
+    const set = (component as unknown as { $set: (props: Record<string, unknown>) => void }).$set;
+    set({ duration: 100 });
+    await Promise.resolve();
+    expect(onSeek).toHaveBeenCalledTimes(1);
+
+    onSeek.mockClear();
+    set({ duration: 120 });
+    await Promise.resolve();
     expect(onSeek).not.toHaveBeenCalled();
   });
 
@@ -242,7 +325,6 @@ describe('click-to-seek', () => {
       props: { fileId: 'f1', duration: 100 },
       events: { seek: onSeek },
     } as never);
-    setContainerWidth(container, 300);
     await waitForMountedLoad();
 
     const root = rootOf(container);
@@ -278,7 +360,6 @@ describe('click-to-seek', () => {
       props: { fileId: 'f1', duration: 100 },
       events: { seek: onSeek },
     } as never);
-    setContainerWidth(container, 300);
     await waitForMountedLoad();
 
     const root = rootOf(container);
@@ -306,7 +387,6 @@ describe('click-to-seek', () => {
       props: { fileId: 'f1', duration: 100 },
       events: { seek: onSeek },
     } as never);
-    setContainerWidth(container, 300);
     await waitForMountedLoad();
 
     const root = rootOf(container);
@@ -350,7 +430,6 @@ describe('keyboard seek', () => {
       props: { fileId: 'f1', duration, currentTime },
       events: { seek: onSeek },
     } as never);
-    setContainerWidth(container, 300);
     await waitForMountedLoad();
     return { container, onSeek };
   }
@@ -390,5 +469,13 @@ describe('keyboard seek', () => {
     const { container, onSeek } = await setup(0, 0);
     await fireEvent.keyDown(canvasOf(container), { code: 'ArrowRight' });
     expect(onSeek).not.toHaveBeenCalled();
+  });
+
+  it('seeks to 0 on Home even when duration is not yet known', async () => {
+    // 'Home' always means "seek to 0" — no `duration` is needed to compute
+    // that target, so it doesn't need to wait for one like the other keys.
+    const { container, onSeek } = await setup(0, 0);
+    await fireEvent.keyDown(canvasOf(container), { code: 'Home' });
+    expect(onSeek).toHaveBeenCalledWith(expect.objectContaining({ detail: { time: 0 } }));
   });
 });

--- a/frontend/src/components/WaveformPlayer.test.ts
+++ b/frontend/src/components/WaveformPlayer.test.ts
@@ -148,8 +148,8 @@ describe('loading waveform data', () => {
     // doesn't touch the DOM. That silently dead-weighted every waveform
     // fetch by 100ms on a fresh page load. Only microtask turns are awaited
     // below — no timer tick at all — so this fails under the old code.
-    mockAxios.get.mockResolvedValue({ data: { waveform: [1, 2, 3] } });
-    render(WaveformPlayer, { props: { fileId: 'f1' } });
+    mockAxios.get.mockResolvedValue({ data: { waveform: [10, 200, 50] } });
+    const { container } = render(WaveformPlayer, { props: { fileId: 'f1', duration: 10 } });
 
     await Promise.resolve();
     await Promise.resolve();
@@ -158,6 +158,16 @@ describe('loading waveform data', () => {
     // resolution bucket at desktop innerWidth — see 'resolution selection'
     // above for the bucket boundaries.
     expect(mockAxios.get).toHaveBeenCalledWith('/files/f1/waveform', { params: { samples: 500 } });
+
+    // A called mock proves the REQUEST went out immediately; it does not
+    // prove the fetched data ever reached the component. Wait for the
+    // real axios promise to settle and assert the waveform actually
+    // rendered — same outcome as 'draws bars once data arrives' below, just
+    // reached without an artificial timer in between.
+    await waitForMountedLoad();
+    expect(container.querySelector('.waveform-loading')).toBeNull();
+    expect(ctx.fillRect).toHaveBeenCalled();
+    expect(canvasOf(container).classList.contains('hidden')).toBe(false);
   });
 
   it('draws bars once data arrives and hides the loading overlay', async () => {

--- a/frontend/src/components/upload/MediaFilePanel.svelte
+++ b/frontend/src/components/upload/MediaFilePanel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { createEventDispatcher, onMount, onDestroy } from 'svelte';
+  import { createEventDispatcher, onDestroy } from 'svelte';
   import { t } from '$stores/locale';
 
   export let file: File | null = null;
@@ -13,6 +13,7 @@
   }>();
 
   let fileInput: HTMLInputElement;
+  let dropZoneEl: HTMLDivElement | null = null;
   let drag = false;
   let dragDropCleanup: (() => void) | null = null;
 
@@ -110,10 +111,7 @@
     }
   }
 
-  function initDragAndDrop() {
-    const dropZone = document.getElementById('drop-zone');
-    if (!dropZone) return () => {};
-
+  function initDragAndDrop(dropZone: HTMLDivElement) {
     dropZone.addEventListener('dragover', handleDragOver);
     dropZone.addEventListener('dragleave', handleDragLeave);
     dropZone.addEventListener('drop', handleDrop);
@@ -125,9 +123,19 @@
     };
   }
 
-  onMount(() => {
-    dragDropCleanup = initDragAndDrop();
-  });
+  // Rebind whenever the drop-zone element (re)appears. `{#if !file}` destroys
+  // and recreates it (select a file, then clear it), and the previous
+  // `onMount`-only `getElementById` bind only ever attached to the FIRST
+  // instance — the recreated node had no drag/drop listeners at all, so a
+  // drop after clearing a file had nothing to call `preventDefault()`, and
+  // the browser navigated away to the dropped file instead (#649).
+  $: if (dropZoneEl) {
+    if (dragDropCleanup) dragDropCleanup();
+    dragDropCleanup = initDragAndDrop(dropZoneEl);
+  } else if (dragDropCleanup) {
+    dragDropCleanup();
+    dragDropCleanup = null;
+  }
 
   onDestroy(() => {
     if (dragDropCleanup) dragDropCleanup();
@@ -139,6 +147,7 @@
     <!-- svelte-ignore a11y-click-events-have-key-events -->
     <div
       id="drop-zone"
+      bind:this={dropZoneEl}
       class="drop-zone"
       class:active={drag}
       on:click={openFileDialog}

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1200,26 +1200,36 @@
     // Listen for events to open Add Media modal
     const handleOpenModalEvent = (event: CustomEvent) => {
       showUploadModal = true;
-      // Dispatch a separate event for the FileUploader after the modal is shown
-      setTimeout(() => {
+      // Dispatch a separate `window` event for the FileUploader once it has
+      // actually mounted and registered its own listener. `window` events
+      // aren't buffered, so a fixed sleep here is a race, not a safety
+      // margin: if FileUploader's `onMount` (which is what subscribes to
+      // `setFileUploaderTab`) hadn't run yet, the event was silently dropped
+      // and the tab request lost. `tick()` resolves once Svelte has flushed
+      // the DOM update that mounts FileUploader — including its `onMount` —
+      // so this fires as soon as the listener genuinely exists, not after a
+      // guessed delay (#649).
+      tick().then(() => {
         if (event.detail?.activeTab) {
           window.dispatchEvent(new CustomEvent('setFileUploaderTab', {
             detail: { activeTab: event.detail.activeTab }
           }));
         }
-      }, 50);
+      });
     };
 
     // Listen for direct file upload from recording popup
     const handleUploadRecordedFile = (event: CustomEvent) => {
       if (event.detail?.file) {
         showUploadModal = true;
-        // Trigger file upload directly
-        setTimeout(() => {
+        // Trigger file upload directly once FileUploader has mounted and
+        // registered its `directFileUpload` listener — same race as above,
+        // same fix (#649).
+        tick().then(() => {
           window.dispatchEvent(new CustomEvent('directFileUpload', {
             detail: { file: event.detail.file }
           }));
-        }, 100);
+        });
       }
     };
 

--- a/frontend/src/routes/files/[id]/+page.svelte
+++ b/frontend/src/routes/files/[id]/+page.svelte
@@ -2019,8 +2019,11 @@
       videoElementChecked = true;
       const videoElement = document.getElementById('player');
       if (videoElement) {
-        // Video element found, initializing player
-        setTimeout(() => initializePlayer(), 100); // Small delay to ensure element is fully rendered
+        // Video element found — initialize immediately. `initializePlayer` only
+        // marks a flag once the element exists (already confirmed above); the
+        // previous 100ms sleep just delayed the `?t=` seek that follows it for
+        // no reason (#649).
+        initializePlayer();
       } else {
         // Video element not found yet, will try again next update
         videoElementChecked = false;
@@ -2037,16 +2040,19 @@
       hasSeenTimestamp = true;
       const targetTime = parseFloat(seekTime);
       if (!isNaN(targetTime) && targetTime >= 0) {
-        // Seek the player to the specified timestamp
-        setTimeout(() => {
-          if (videoPlayerComponent && typeof videoPlayerComponent.seekToTime === 'function') {
-            videoPlayerComponent.seekToTime(targetTime);
-          } else {
-            currentTime = targetTime;
-          }
-          // Scroll the transcript segment into view
-          scrollToSegmentAtTime(targetTime);
-        }, 500);
+        // Seek the player to the specified timestamp immediately. The 500ms
+        // sleep here predated #647: `VideoPlayer.seekToTime` used to await
+        // `loadedmetadata` internally, so this queued the call behind that
+        // wait. It now issues the seek to the media element before metadata
+        // arrives, so the sleep was dead weight stacked on top of #647's fix
+        // (#649).
+        if (videoPlayerComponent && typeof videoPlayerComponent.seekToTime === 'function') {
+          videoPlayerComponent.seekToTime(targetTime);
+        } else {
+          currentTime = targetTime;
+        }
+        // Scroll the transcript segment into view
+        scrollToSegmentAtTime(targetTime);
       }
     }
   }


### PR DESCRIPTION
Closes #649.

## Context

#645 (fixed by #647) found that `VideoPlayer.seekToTime()` awaited
`loadedmetadata` before touching the media element, so a click landing before
the browser had reported metadata could stall 15+ seconds. The wait itself
was the bug: assigning `currentTime` before metadata loads is not discarded
per spec, so the defensive wait blocked the very request it was waiting for.

#649 asked for a systematic audit of the rest of the frontend for the same
timing-race shape — plus the fixes the audit finds, per the maintainer's
standing instruction not to file a issue per finding and instead fix in this
branch and list results here.

## What this fixes

- **`PlyrMiniPlayer.svelte` (CRITICAL) — the #645 bug, unfixed.** This is the
  search-results/speaker preview player (`FloatingPreviewPlayer`). It still
  awaited `loadedmetadata`/`canplay` before seeking, gated its *initial* seek
  on `canplay` (readyState ≥ `HAVE_FUTURE_DATA` — stricter than the
  `loadedmetadata` gate #647 removed, with no fallback if it never fired),
  and cleared its seek spinner with `{ once: true }` raw media listeners that
  a presigned-URL hot-swap (`hotSwapSource`) could never re-arm, falling back
  to the 15s timer on every seek after the first. Now shares the same
  `applyMediaSeek`/`waitForMediaMetadata` pattern as `VideoPlayer`: the seek
  lands immediately, metadata is only awaited to resync Plyr's own
  progress-bar clock, and the spinner-clearing listeners are persistent.
- **`routes/files/[id]/+page.svelte`**: a 500ms sleep before the `?t=`
  deep-link seek, and a 100ms sleep before `initializePlayer()` — both
  predated #647 (queued the seek behind the metadata wait it introduced) and
  became dead weight once that wait was removed from the seek path itself.
- **`WaveformPlayer.svelte`**: a 100ms `onMount` sleep before fetching
  waveform data, even though `bind:this` binds `canvas`/`container` before
  `onMount` fires and the fetch itself doesn't touch the DOM. Also: a
  click/keyboard seek that arrived before `duration` was known (e.g.
  immediately on a fresh page load) was silently discarded — no seek, no
  feedback, and no memory of the click. Now queued and flushed as soon as
  `duration` becomes available. `Home` (seek to 0) needs no `duration` at all
  and no longer waits for one.
- **`upload/MediaFilePanel.svelte`**: drag/drop listeners were bound once via
  `getElementById` in `onMount`, to the drop-zone element inside `{#if
  !file}`. Selecting a file and then clearing it recreates that DOM node with
  no listeners at all — a subsequent drop had nothing to call
  `preventDefault()`, so the browser navigated away to the dropped file
  instead of uploading it. Now rebinds reactively via `bind:this` whenever
  the node (re)appears.
- **`routes/+page.svelte`**: two `window` `CustomEvent` handoffs
  (`openAddMediaModal` → `setFileUploaderTab`, `uploadRecordedFile` →
  `directFileUpload`) used fixed 50ms/100ms sleeps to wait for
  `FileUploader` to mount and register its listener. `window` events aren't
  buffered, so this was a race, not a safety margin — a slow mount could
  drop the tab/recorded-file handoff silently. Replaced with `tick()`, which
  resolves once Svelte has actually flushed the mount.

## Checked and found clean (no fix needed)

- `PlyrMiniPlayer`'s `hotSwapSource` seek-request race (clicking two search
  results quickly): mitigated by `FloatingPreviewPlayer`'s `{#key}` block,
  which destroys and remounts the player per `fileId:startTime`, so a stale
  in-flight wait can't outlive its own player instance.

## Tests

- `frontend/src/components/PlyrMiniPlayer.test.ts` (new): proves the initial
  seek assigns `currentTime` to the raw media element before
  `loadedmetadata`/`canplay` has ever fired (mocks `plyr`, never dispatches a
  readiness event, asserts the seek landed anyway). Watched red against
  unfixed `PlyrMiniPlayer.svelte` (`expected 42, got 0`), green against the
  fix.
- `frontend/src/components/WaveformPlayer.test.ts`: new cases for the mount
  fetch firing within a microtask (no timer), the duration-arrives-later
  queue/flush, a queued seek not replaying on an unrelated later duration
  update, and `Home` seeking to 0 with no duration known. Watched red against
  unfixed `WaveformPlayer.svelte`.
- Full suite (1676 tests / 183 files) re-run against the fixed tree from a
  throwaway sibling copy (this environment could not run vitest directly from
  a nested worktree path — an apparently pre-existing, path-dependent
  `rolldown`/vite quirk unrelated to this change, reproduced identically
  against an untouched file with no edits of mine) — all passing, with one
  pre-existing unrelated timer-leak console error at teardown (a fallback
  `setTimeout` in `files/[id]/+page.svelte` that this PR does not touch).

## Verification

- `scripts/safe-precommit.sh run --all-files` and `--hook-stage pre-push`
  both green (eslint, svelte-check, and a production `vite build`).
- Live browser verification via `./opentr.sh start dev --fresh` could not be
  completed in this environment (fresh Postgres container failed to start —
  `POSTGRES_PASSWORD` unset, unrelated to this change) — recommend a manual
  pass on the search-preview player and file-detail waveform/deep-link seek
  before merge.

## Out of scope

Per the maintainer, #682 (v0.6.0 UI bug backlog) stays out of scope. The
audit's F15 finding (7 settings panels clear their "saving" spinner on a
fixed timer rather than the actual save outcome) is a different bug class —
a failed save can render as success — not a premature-interaction timing
race, so it isn't touched here.
