### PR TITLE
fix(backup): include OpenSearch speaker embeddings in backup/restore

### DIFF
--- a/backend/app/core/constants.py
+++ b/backend/app/core/constants.py
@@ -589,7 +589,22 @@ DEFAULT_BACKUP_ENCRYPT = False  # gpg AES-256 symmetric; needs a passphrase file
 # Path (in-container) to a file whose contents are the gpg symmetric passphrase.
 # Empty = no passphrase configured (encryption requested but unconfigured → task errors).
 DEFAULT_BACKUP_PASSPHRASE_FILE = ""  # noqa: S105  # nosec B105 - a file PATH default (empty = unset), not a password
-DEFAULT_BACKUP_INCLUDE_OPENSEARCH = False  # OS is derived/rebuildable; pg-only this round
+# ⚠️ This used to default to False, justified by a comment calling OpenSearch derived data
+# that Postgres could rebuild. That justification was WRONG and the default was dangerous
+# (issue #658). The transcript/chunk indices are rebuildable; the SPEAKER indices are not.
+# Postgres stores no embedding vectors at all — SpeakerProfile carries only
+# embedding_count + last_embedding_update (models/media.py) — so `speakers_v3`/`speakers_v4`
+# are the sole copy of a deployment's biometric data, and re-deriving one needs the source
+# media (which may be gone) plus a GPU re-embed run. Defaulting this off shipped a
+# scheduled backup that silently excluded the only unrecoverable data in the system.
+#
+# On by default is also the non-noisy choice: the scheduled backup only runs at all when
+# `backup.destination` is a writable mount, which in practice means the --with-backup
+# overlay — and that same overlay is what allow-lists `path.repo` on the OpenSearch
+# container, so the snapshot repository the leg needs is present exactly when the leg can
+# run. Where it is not, opensearch_snapshot.perform_snapshot records an "unsupported"
+# status naming the voiceprints at risk; it never fails the pg dump.
+DEFAULT_BACKUP_INCLUDE_OPENSEARCH = True
 
 # Backup destination: "local" (mounted dir, default) or "s3" (S3-compatible bucket).
 # The s3 path lets homelab/cloud users push dumps off-host to AWS S3 / MinIO / Backblaze /

--- a/backend/app/services/opensearch_snapshot.py
+++ b/backend/app/services/opensearch_snapshot.py
@@ -97,6 +97,44 @@ def ensure_repository(client: Any) -> None:
     )
 
 
+def voiceprint_doc_count(client: Any) -> int | None:
+    """Count the speaker-embedding documents a snapshot would cover.
+
+    Issue #658: the transcript indices are rebuildable from Postgres, the speaker ones are
+    not — Postgres holds no embedding vectors, so ``speakers_v*`` is the only copy of a
+    deployment's biometric data. Recording this number turns "the snapshot ran" into "the
+    snapshot covered N voiceprints", so a run that quietly covered zero is visible on
+    ``backup.last_result`` instead of reading as a success.
+
+    Args:
+        client: A live OpenSearch client.
+
+    Returns:
+        The document count across every concrete speaker index, or None when it could not
+        be read (never 0 for an unreachable cluster — "I could not ask" and "there are
+        none" must not look the same).
+    """
+    from app.core.constants import get_speaker_index
+
+    try:
+        return int(client.count(index=f"{get_speaker_index()}*")["count"])
+    except Exception as exc:  # noqa: BLE001 - a diagnostic; unreadable is not zero
+        logger.debug("Could not count voiceprint documents: %s", exc)
+        return None
+
+
+def _at_risk_suffix(client: Any) -> str:
+    """Name the voiceprints a failed/skipped snapshot leaves with no copy anywhere."""
+    count = voiceprint_doc_count(client)
+    if not count:
+        return ""
+    return (
+        f" {count} speaker-embedding document(s) are therefore NOT backed up by this run, "
+        "and Postgres holds no copy of them (issue #658). Use './opentr.sh backup', which "
+        "writes a portable *.voiceprints.ndjson artifact beside the dump."
+    )
+
+
 def _snapshot_name(ts: str | None = None) -> str:
     """Build a timestamp-stemmed snapshot name (shared stem with the pg dump)."""
     stamp = ts or datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
@@ -177,11 +215,13 @@ def perform_snapshot(cfg: dict[str, Any], ts: str | None = None) -> dict[str, An
             "OpenSearch snapshot repository could not be registered "
             f"({exc}). Start the stack with --with-backup so the OpenSearch container "
             "gets path.repo + the snapshot bind-mount, or disable 'Include OpenSearch'."
-        )
+        ) + _at_risk_suffix(client)
         logger.warning(msg)
         return {"status": "unsupported", "error": msg}
 
     name = _snapshot_name(ts)
+    # Read BEFORE the snapshot so the number describes what was in the cluster when it ran.
+    voiceprints = voiceprint_doc_count(client)
     try:
         logger.info("Creating OpenSearch snapshot %s/%s", REPO_NAME, name)
         client.snapshot.create(
@@ -194,7 +234,11 @@ def perform_snapshot(cfg: dict[str, Any], ts: str | None = None) -> dict[str, An
         pruned = prune_snapshots(client, cfg)
         duration = round(time.monotonic() - started, 2)
         logger.info(
-            "OpenSearch snapshot complete: %s (%.2fs, pruned %d)", name, duration, len(pruned)
+            "OpenSearch snapshot complete: %s (%.2fs, pruned %d, voiceprints %s)",
+            name,
+            duration,
+            len(pruned),
+            "unknown" if voiceprints is None else voiceprints,
         )
         return {
             "status": "ok",
@@ -202,11 +246,16 @@ def perform_snapshot(cfg: dict[str, Any], ts: str | None = None) -> dict[str, An
             "repository": REPO_NAME,
             "duration_s": duration,
             "pruned": pruned,
+            "voiceprints": voiceprints,
         }
     except Exception as exc:  # noqa: BLE001 - snapshot failure is recorded, never raised
         duration = round(time.monotonic() - started, 2)
         logger.error("OpenSearch snapshot failed: %s", exc)
-        return {"status": "error", "error": str(exc), "duration_s": duration}
+        return {
+            "status": "error",
+            "error": str(exc) + _at_risk_suffix(client),
+            "duration_s": duration,
+        }
 
 
 def snapshot_status() -> dict[str, Any]:

--- a/backend/tests/api/endpoints/test_backup_settings.py
+++ b/backend/tests/api/endpoints/test_backup_settings.py
@@ -229,13 +229,22 @@ def test_status_treats_an_unparseable_stored_cron_as_not_due(
 
 
 def test_status_omits_the_opensearch_probe_when_snapshots_are_off(
-    client, super_admin_token_headers, clean_backup_settings
+    client, super_admin_token_headers, clean_backup_settings, db_session
 ):
     """The snapshot probe is a live network call, so it is only made when opted in.
 
     Catches the ``include_opensearch`` guard being dropped, which would make the
     status endpoint reach out to OpenSearch on every poll of a pg-only deployment.
+
+    The setting is written EXPLICITLY rather than leaned on as the coded default: since
+    issue #658 the default is ``True`` (the speaker indices hold voiceprints, which exist
+    nowhere else and are not "derived data"), so a test that inferred "off" from the
+    default would silently stop exercising the off path.
     """
+    from app.services import backup_service as bs
+
+    bs.update_settings(db_session, include_opensearch=False)
+
     response = client.get(f"{BASE}/status", headers=super_admin_token_headers)
     assert response.status_code == status.HTTP_200_OK
     body = response.json()

--- a/backend/tests/integration/test_voiceprint_backup_roundtrip.py
+++ b/backend/tests/integration/test_voiceprint_backup_roundtrip.py
@@ -1,0 +1,426 @@
+"""End-to-end proof that speaker voiceprints survive backup -> wipe -> restore (issue #658).
+
+Speaker voiceprints exist in exactly ONE place: the OpenSearch ``speakers_v*`` indices.
+PostgreSQL stores no embedding vectors at all — ``SpeakerProfile`` carries only
+``embedding_count`` + ``last_embedding_update`` (``app/models/media.py``) and neither
+``Speaker`` nor ``SpeakerCluster`` has a vector column — so before this fix
+``./opentr.sh backup`` (a bare ``pg_dump``) left a deployment with **no recoverable copy of
+its biometric data**.
+
+This drives the REAL ``scripts/common.sh`` primitives the shipped CLI uses
+(``os_export_speaker_indices`` / ``os_import_speaker_indices`` /
+``os_verify_speaker_restore``), which in turn pipe the real ``scripts/voiceprint-backup.py``
+into the OpenSearch container's own ``python3`` — the exact code path
+``backup_database``/``restore_database`` execute, not a re-implementation.
+
+**The central assertion is on CONTENT, not on file existence**: after the index is deleted
+outright and restored from the artifact, every embedding vector must come back
+component-for-component identical. An artifact that exists and restores nothing is the same
+data loss with extra steps, so a control assertion between the wipe and the restore proves
+the vectors really were gone.
+
+Safety posture, matching the sibling ``test_opentr_restore_roundtrip.py``:
+
+- A dedicated bridge network with **no published ports**, so the throwaway OpenSearch is
+  unreachable from the host and cannot be mistaken for the dev stack's cluster on 5180.
+- ``uuid4``-suffixed container/network names.
+- The image tag is **parsed from ``docker-compose.yml``**, never hardcoded, so this tracks
+  the pinned OpenSearch version.
+- Container and network are removed in ``finally`` blocks.
+
+Run directly: ``cd backend && PYTHONPATH=. pytest -m integration
+tests/integration/test_voiceprint_backup_roundtrip.py -v``
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import time
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(shutil.which("docker") is None, reason="docker CLI not available"),
+]
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_COMMON_SH = _REPO_ROOT / "scripts" / "common.sh"
+_COMPOSE_FILE = _REPO_ROOT / "docker-compose.yml"
+
+_INDEX_BASE = "speakers"
+_V4_INDEX = "speakers_v4"
+_DIMENSION = 256
+_BOOT_TIMEOUT_S = 180.0
+
+# Deterministic, mutually distinguishable vectors — named separately from the documents so
+# the tampering test below can take one by name (and so its element type survives, rather
+# than being erased to `object` by the heterogeneous document literal).
+_ALPHA_VECTOR: list[float] = [round(0.001 * i, 6) for i in range(_DIMENSION)]
+_BETA_VECTOR: list[float] = [round(-0.002 * i, 6) for i in range(_DIMENSION)]
+_SPEAKER_VECTOR: list[float] = [round(0.5 - 0.003 * i, 6) for i in range(_DIMENSION)]
+
+# Two profile documents and one per-file speaker document. Deterministic so a digest
+# mismatch means the data changed, not that the fixture re-rolled.
+_SEED_DOCS: dict[str, dict[str, Any]] = {
+    "profile_alpha": {
+        "document_type": "profile",
+        "profile_uuid": "0192f000-0000-7000-8000-00000000a1fa",
+        "profile_name": "Alpha",
+        "user_id": 1,
+        "embedding_count": 4,
+        "embedding": _ALPHA_VECTOR,
+    },
+    "profile_beta": {
+        "document_type": "profile",
+        "profile_uuid": "0192f000-0000-7000-8000-00000000be7a",
+        "profile_name": "Beta",
+        "user_id": 1,
+        "embedding_count": 2,
+        "embedding": _BETA_VECTOR,
+    },
+    "speaker_7": {
+        "document_type": "speaker",
+        "speaker_uuid": "0192f000-0000-7000-8000-0000000005ea",
+        "speaker_id": 7,
+        "user_id": 1,
+        "media_file_id": 42,
+        "embedding": _SPEAKER_VECTOR,
+    },
+}
+
+
+def _run(cmd: list[str], *, stdin_text: str | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603 - fixed argv, no shell
+        cmd, capture_output=True, text=True, input=stdin_text
+    )
+
+
+def _opensearch_image_tag() -> str:
+    """Parse the pinned OpenSearch image out of docker-compose.yml — never hardcoded."""
+    compose = _COMPOSE_FILE.read_text(encoding="utf-8")
+    match = re.search(r"image:\s*(opensearchproject/opensearch:\S+)", compose)
+    assert match, "could not find an `image: opensearchproject/opensearch:<tag>` line"
+    return match.group(1)
+
+
+def _call_common_fn(name: str, *args: str) -> subprocess.CompletedProcess[str]:
+    """Invoke a real ``scripts/common.sh`` function — the exact code the CLI ships."""
+    return _run(["bash", "-c", f'source "{_COMMON_SH}"; {name} "$@"', "--", *args])
+
+
+def _os_request(container: str, method: str, path: str, body: Any = None) -> dict:
+    """Talk to the throwaway cluster through ``docker exec`` (it publishes no ports)."""
+    cmd = [
+        "docker",
+        "exec",
+        "-i",
+        container,
+        "curl",
+        "-sS",
+        "-X",
+        method,
+        f"http://127.0.0.1:9200{path}",
+    ]
+    stdin_text = None
+    if body is not None:
+        cmd += ["-H", "Content-Type: application/json", "--data-binary", "@-"]
+        stdin_text = json.dumps(body)
+    result = _run(cmd, stdin_text=stdin_text)
+    assert result.returncode == 0, f"{method} {path} failed: {result.stderr}"
+    return json.loads(result.stdout) if result.stdout.strip() else {}
+
+
+def _wait_ready(container: str) -> None:
+    """Poll the cluster health endpoint — never a bare sleep."""
+    deadline = time.monotonic() + _BOOT_TIMEOUT_S
+    last = ""
+    while time.monotonic() < deadline:
+        result = _run(
+            [
+                "docker",
+                "exec",
+                container,
+                "curl",
+                "-fsS",
+                "http://127.0.0.1:9200/_cluster/health?wait_for_status=yellow&timeout=2s",
+            ]
+        )
+        if result.returncode == 0:
+            return
+        last = result.stderr or result.stdout
+        time.sleep(1.0)
+    raise RuntimeError(f"OpenSearch in {container} never became ready: {last}")
+
+
+@pytest.fixture
+def os_container() -> Iterator[str]:
+    """A throwaway OpenSearch on a private bridge network with no published ports."""
+    suffix = uuid.uuid4().hex[:12]
+    net_name = f"ot-vp658-net-{suffix}"
+    name = f"ot-vp658-os-{suffix}"
+    image = _opensearch_image_tag()
+
+    created_net = _run(["docker", "network", "create", net_name])
+    assert created_net.returncode == 0, f"failed to create test network: {created_net.stderr}"
+    try:
+        started = _run(
+            [
+                "docker",
+                "run",
+                "-d",
+                "--network",
+                net_name,
+                "--name",
+                name,
+                "-e",
+                "discovery.type=single-node",
+                "-e",
+                "DISABLE_SECURITY_PLUGIN=true",
+                "-e",
+                "bootstrap.memory_lock=false",
+                "-e",
+                "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m",
+                image,
+            ]
+        )
+        assert started.returncode == 0, f"failed to start throwaway opensearch: {started.stderr}"
+        try:
+            _wait_ready(name)
+            yield name
+        finally:
+            _run(["docker", "rm", "-f", name])
+    finally:
+        _run(["docker", "network", "rm", net_name])
+
+
+def _create_speaker_index(container: str) -> None:
+    _os_request(
+        container,
+        "PUT",
+        f"/{_V4_INDEX}",
+        {
+            "settings": {"index": {"number_of_shards": 1, "number_of_replicas": 0, "knn": True}},
+            "mappings": {
+                "properties": {
+                    "document_type": {"type": "keyword"},
+                    "profile_uuid": {"type": "keyword"},
+                    "profile_name": {"type": "keyword"},
+                    "speaker_uuid": {"type": "keyword"},
+                    "speaker_id": {"type": "integer"},
+                    "profile_id": {"type": "integer"},
+                    "user_id": {"type": "integer"},
+                    "media_file_id": {"type": "integer"},
+                    "embedding_count": {"type": "integer"},
+                    "embedding": {
+                        "type": "knn_vector",
+                        "dimension": _DIMENSION,
+                        "method": {
+                            "name": "hnsw",
+                            "space_type": "cosinesimil",
+                            "engine": "lucene",
+                            "parameters": {"ef_construction": 128, "m": 24},
+                        },
+                    },
+                }
+            },
+        },
+    )
+    _os_request(container, "PUT", f"/{_V4_INDEX}/_alias/{_INDEX_BASE}")
+
+
+def _seed(container: str) -> None:
+    _create_speaker_index(container)
+    for doc_id, source in _SEED_DOCS.items():
+        _os_request(container, "PUT", f"/{_V4_INDEX}/_doc/{doc_id}?refresh=true", source)
+
+
+def _read_embeddings(container: str, index: str = _V4_INDEX) -> dict:
+    """Read every document's embedding back out of the live cluster, keyed by doc id."""
+    response = _os_request(
+        container, "POST", f"/{index}/_search", {"size": 100, "query": {"match_all": {}}}
+    )
+    return {hit["_id"]: hit["_source"]["embedding"] for hit in response["hits"]["hits"]}
+
+
+def _exec_prefix(container: str) -> str:
+    return f"docker exec -i {container}"
+
+
+# ---------------------------------------------------------------------------------------------
+# The central round-trip.
+# ---------------------------------------------------------------------------------------------
+
+
+def test_voiceprints_survive_backup_wipe_and_restore(os_container: str, tmp_path: Path) -> None:
+    """Seed -> export -> DELETE the index -> import -> the vectors are back, byte-for-byte."""
+    container = os_container
+    _seed(container)
+
+    seeded = _read_embeddings(container)
+    assert set(seeded) == set(_SEED_DOCS), (
+        f"the fixture did not seed what this test asserts on: {sorted(seeded)}"
+    )
+
+    artifact = tmp_path / "backup.sql.voiceprints.ndjson"
+    export = _call_common_fn(
+        "os_export_speaker_indices", _exec_prefix(container), str(artifact), _INDEX_BASE
+    )
+    assert export.returncode == 0, f"os_export_speaker_indices failed: {export.stderr}"
+    assert artifact.is_file(), "the export produced no artifact"
+
+    manifest = json.loads(artifact.read_text(encoding="utf-8").splitlines()[0])
+    assert manifest["total_docs"] == len(_SEED_DOCS), (
+        f"the artifact claims {manifest['total_docs']} documents, seeded {len(_SEED_DOCS)}"
+    )
+
+    # --- destroy the ONLY copy -----------------------------------------------------------
+    _os_request(container, "DELETE", f"/{_V4_INDEX}")
+
+    # Control: without this, a restore that did nothing would still pass the assertion below.
+    gone = _run(["docker", "exec", container, "curl", "-fsS", f"http://127.0.0.1:9200/{_V4_INDEX}"])
+    assert gone.returncode != 0, "the wipe did not actually delete the speaker index"
+
+    restore = _call_common_fn(
+        "os_import_speaker_indices", _exec_prefix(container), str(artifact), _INDEX_BASE
+    )
+    assert restore.returncode == 0, f"os_import_speaker_indices failed: {restore.stderr}"
+
+    verify = _call_common_fn(
+        "os_verify_speaker_restore", _exec_prefix(container), str(artifact), _INDEX_BASE
+    )
+    assert verify.returncode == 0, f"os_verify_speaker_restore reported a mismatch: {verify.stderr}"
+
+    restored = _read_embeddings(container)
+    assert restored == seeded, (
+        "the restored embeddings are not identical to the ones backed up — a voiceprint that "
+        "comes back changed is a profile that silently stops matching"
+    )
+
+    alias = _os_request(container, "GET", f"/_alias/{_INDEX_BASE}")
+    assert _V4_INDEX in alias, (
+        f"the read alias {_INDEX_BASE} was not restored onto {_V4_INDEX}: {sorted(alias)}"
+    )
+
+
+# ---------------------------------------------------------------------------------------------
+# The must-fire case for the verifier itself (issue #431's lesson).
+# ---------------------------------------------------------------------------------------------
+
+
+def test_verify_fails_when_a_restored_embedding_differs(os_container: str, tmp_path: Path) -> None:
+    """A verifier that cannot fail reports a clean restore forever — including an empty one."""
+    container = os_container
+    _seed(container)
+
+    artifact = tmp_path / "backup.sql.voiceprints.ndjson"
+    export = _call_common_fn(
+        "os_export_speaker_indices", _exec_prefix(container), str(artifact), _INDEX_BASE
+    )
+    assert export.returncode == 0, f"os_export_speaker_indices failed: {export.stderr}"
+
+    baseline = _call_common_fn(
+        "os_verify_speaker_restore", _exec_prefix(container), str(artifact), _INDEX_BASE
+    )
+    assert baseline.returncode == 0, (
+        f"the control arm must pass against the cluster it was exported from: {baseline.stderr}"
+    )
+
+    # Change ONE component of ONE vector — the smallest corruption that matters.
+    tampered = list(_ALPHA_VECTOR)
+    tampered[0] = tampered[0] + 0.5
+    mutated = dict(_SEED_DOCS["profile_alpha"], embedding=tampered)
+    _os_request(container, "PUT", f"/{_V4_INDEX}/_doc/profile_alpha?refresh=true", mutated)
+
+    tampered_verify = _call_common_fn(
+        "os_verify_speaker_restore", _exec_prefix(container), str(artifact), _INDEX_BASE
+    )
+    assert tampered_verify.returncode != 0, (
+        "os_verify_speaker_restore must FAIL when a live embedding differs from the backup"
+    )
+    assert "digest mismatch" in tampered_verify.stderr, (
+        f"expected the mismatch to be named, got: {tampered_verify.stderr!r}"
+    )
+
+
+def test_verify_fails_when_the_index_came_back_empty(os_container: str, tmp_path: Path) -> None:
+    """The exact silent-failure shape: a restore that reports success with zero voiceprints."""
+    container = os_container
+    _seed(container)
+
+    artifact = tmp_path / "backup.sql.voiceprints.ndjson"
+    export = _call_common_fn(
+        "os_export_speaker_indices", _exec_prefix(container), str(artifact), _INDEX_BASE
+    )
+    assert export.returncode == 0, f"os_export_speaker_indices failed: {export.stderr}"
+
+    _os_request(
+        container,
+        "POST",
+        f"/{_V4_INDEX}/_delete_by_query?refresh=true",
+        {"query": {"match_all": {}}},
+    )
+    assert _read_embeddings(container) == {}, "the emptying step did not empty the index"
+
+    verify = _call_common_fn(
+        "os_verify_speaker_restore", _exec_prefix(container), str(artifact), _INDEX_BASE
+    )
+    assert verify.returncode != 0, (
+        "a present-but-empty speaker index must fail verification, not pass it"
+    )
+
+
+# ---------------------------------------------------------------------------------------------
+# A fresh install has no speaker indices at all — that must not look like a failure.
+# ---------------------------------------------------------------------------------------------
+
+
+def test_export_of_a_cluster_with_no_speaker_indices_is_a_valid_empty_artifact(
+    os_container: str, tmp_path: Path
+) -> None:
+    container = os_container
+
+    artifact = tmp_path / "empty.sql.voiceprints.ndjson"
+    export = _call_common_fn(
+        "os_export_speaker_indices", _exec_prefix(container), str(artifact), _INDEX_BASE
+    )
+    assert export.returncode == 0, f"os_export_speaker_indices failed: {export.stderr}"
+
+    manifest = json.loads(artifact.read_text(encoding="utf-8").splitlines()[0])
+    assert manifest["total_docs"] == 0
+    assert manifest["indices"] == []
+
+    for mode in ("os_import_speaker_indices", "os_verify_speaker_restore"):
+        result = _call_common_fn(mode, _exec_prefix(container), str(artifact), _INDEX_BASE)
+        assert result.returncode == 0, (
+            f"{mode} rejected a legitimately empty artifact: {result.stderr}"
+        )
+
+
+def test_a_truncated_artifact_is_refused_rather_than_read_as_no_voiceprints(
+    os_container: str, tmp_path: Path
+) -> None:
+    """An unreadable artifact and "this deployment has none" must never be the same outcome."""
+    container = os_container
+    _seed(container)
+
+    artifact = tmp_path / "backup.sql.voiceprints.ndjson"
+    export = _call_common_fn(
+        "os_export_speaker_indices", _exec_prefix(container), str(artifact), _INDEX_BASE
+    )
+    assert export.returncode == 0, f"os_export_speaker_indices failed: {export.stderr}"
+
+    truncated = tmp_path / "truncated.ndjson"
+    truncated.write_bytes(b"")
+
+    result = _call_common_fn(
+        "os_import_speaker_indices", _exec_prefix(container), str(truncated), _INDEX_BASE
+    )
+    assert result.returncode != 0, "an empty artifact must be refused, not silently accepted"

--- a/backend/tests/unit/test_voiceprint_backup_coverage.py
+++ b/backend/tests/unit/test_voiceprint_backup_coverage.py
@@ -1,0 +1,267 @@
+"""Static + hermetic guards for the voiceprint backup coverage fix (issue #658).
+
+The round-trip proof lives in ``tests/integration/test_voiceprint_backup_roundtrip.py``
+(real OpenSearch, real embeddings, real ``scripts/common.sh`` functions). This file is the
+fast half: it pins the things that can silently regress without any container — the CLI
+wiring, the corrected coded default, the shipped-file list, and the digest/manifest logic
+inside ``scripts/voiceprint-backup.py`` itself.
+
+Why the wiring needs a static guard at all: ``backup_database`` writing a ``pg_dump`` and
+nothing else is *exactly* the shipped behaviour issue #658 reports, and it fails no test —
+the dump is valid, the exit code is 0, and the missing half (speaker embeddings, which
+PostgreSQL does not store) is invisible until a restore. A detector that fails when the
+export call disappears is the only thing that makes deleting it loud.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from tests.unit.test_opentr_restore_safety import extract_function
+from tests.unit.test_opentr_restore_safety import first_line_index
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_COMMON_SH = _REPO_ROOT / "scripts" / "common.sh"
+_HELPER = _REPO_ROOT / "scripts" / "voiceprint-backup.py"
+_MANIFEST = _REPO_ROOT / "release-manifest.txt"
+
+
+def _common_source() -> str:
+    return _COMMON_SH.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def helper() -> ModuleType:
+    """Import ``scripts/voiceprint-backup.py`` (hyphenated, so not a normal import)."""
+    spec = importlib.util.spec_from_file_location("voiceprint_backup_helper", _HELPER)
+    assert spec and spec.loader, f"could not load {_HELPER}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------------------------
+# CLI wiring: the export/import/verify calls must exist, and in the right order.
+# ---------------------------------------------------------------------------------------------
+
+
+def test_backup_database_exports_the_speaker_indices() -> None:
+    body = extract_function(_common_source(), "backup_database")
+    assert body, "backup_database not found in scripts/common.sh"
+    assert "os_export_speaker_indices" in body, (
+        "backup_database must export the OpenSearch speaker indices — PostgreSQL stores no "
+        "embedding vectors, so a pg_dump alone leaves the deployment's voiceprints with no "
+        "recoverable copy anywhere (issue #658)"
+    )
+
+
+def test_restore_database_imports_and_then_verifies_the_speaker_indices() -> None:
+    body = extract_function(_common_source(), "restore_database")
+    assert body, "restore_database not found in scripts/common.sh"
+
+    import_idx = first_line_index(body, "os_import_speaker_indices")
+    verify_idx = first_line_index(body, "os_verify_speaker_restore")
+    assert import_idx != -1, "restore_database must import the voiceprint artifact"
+    assert verify_idx != -1, (
+        "restore_database must VERIFY the voiceprint restore — a restore that silently comes "
+        "back with zero voiceprints is the same data loss with extra steps"
+    )
+    assert import_idx < verify_idx, "the verification must run after the import, not before it"
+
+
+def test_the_voiceprint_restore_runs_after_the_database_has_been_verified() -> None:
+    """Ordering is load-bearing: a failed database replay must not replace live voiceprints."""
+    body = extract_function(_common_source(), "restore_database")
+    assert body, "restore_database not found in scripts/common.sh"
+
+    pg_verify_idx = first_line_index(body, "pg_verify_custom_restore")
+    import_idx = first_line_index(body, "os_import_speaker_indices")
+    assert pg_verify_idx != -1, "expected the database verification call in restore_database"
+    assert import_idx != -1, "expected the voiceprint import call in restore_database"
+    assert pg_verify_idx < import_idx, (
+        "the voiceprint import must come after the database replay has been verified"
+    )
+
+
+def test_the_voiceprint_restore_runs_before_the_services_are_restarted() -> None:
+    """The app must never come back up over a half-restored speaker plane."""
+    body = extract_function(_common_source(), "restore_database")
+    assert body, "restore_database not found in scripts/common.sh"
+
+    verify_idx = first_line_index(body, "os_verify_speaker_restore")
+    decision_idx = first_line_index(body, "pg_restore_restart_decision")
+    assert verify_idx != -1, "expected the voiceprint verification call in restore_database"
+    assert decision_idx != -1, "expected the restart decision in restore_database"
+    assert verify_idx < decision_idx, (
+        "voiceprints must be restored and verified before the restart decision is taken"
+    )
+
+
+def test_restore_database_reports_postgres_opensearch_voiceprint_consistency() -> None:
+    """``embedding_count`` is a Postgres number about data that lives only in OpenSearch."""
+    body = extract_function(_common_source(), "restore_database")
+    assert body, "restore_database not found in scripts/common.sh"
+    assert "report_voiceprint_consistency" in body, (
+        "restore_database must report whether speaker_profile.embedding_count agrees with what "
+        "OpenSearch actually holds — otherwise rows silently claim embeddings that do not exist"
+    )
+
+
+# ---------------------------------------------------------------------------------------------
+# The corrected coded default, and the comment that justified the wrong one.
+# ---------------------------------------------------------------------------------------------
+
+
+def test_scheduled_backups_include_opensearch_by_default() -> None:
+    from app.core import constants
+
+    assert constants.DEFAULT_BACKUP_INCLUDE_OPENSEARCH is True, (
+        "the in-app scheduled backup must cover OpenSearch by default: the speaker indices "
+        "hold voiceprints, which are NOT derived from anything in PostgreSQL (issue #658)"
+    )
+
+
+def test_the_derived_rebuildable_justification_is_gone_from_the_constant() -> None:
+    """The old comment ('OS is derived/rebuildable') is what made the wrong default look safe.
+
+    Scoped to the whole file on purpose. The first draft of this test looked only at the
+    characters *preceding* the constant — and the old justification is a TRAILING comment on
+    the assignment line, so it passed against the unfixed tree. A guard whose window excludes
+    the thing it guards is the #431 failure mode in miniature.
+    """
+    source = (_REPO_ROOT / "backend" / "app" / "core" / "constants.py").read_text(encoding="utf-8")
+    assert "OS is derived/rebuildable" not in source, (
+        "the justification for excluding OpenSearch must not survive the default being fixed — "
+        "the speaker indices are the sole copy of the deployment's biometric data"
+    )
+
+
+def test_the_helper_is_shipped_to_self_hosted_installs() -> None:
+    manifest = _MANIFEST.read_text(encoding="utf-8")
+    paths = [
+        line.split("\t")[0].strip()
+        for line in manifest.splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+    assert "scripts/voiceprint-backup.py" in paths, (
+        "a production `curl | bash` install downloads only what release-manifest.txt lists; "
+        "without this entry backup_database would refuse on every self-hosted deployment"
+    )
+
+
+# ---------------------------------------------------------------------------------------------
+# The helper's own logic — stdlib only, so it runs in the fast suite with nothing running.
+# ---------------------------------------------------------------------------------------------
+
+
+def test_the_digest_is_order_independent_but_content_sensitive(helper: ModuleType) -> None:
+    documents = [
+        ("b", {"embedding": [0.1, 0.2], "profile_name": "Beta"}),
+        ("a", {"embedding": [0.3, 0.4], "profile_name": "Alpha"}),
+    ]
+    reversed_documents = list(reversed(documents))
+    assert helper.digest_documents(documents) == helper.digest_documents(reversed_documents), (
+        "scroll order is not a property of the data — a digest that depends on it would fail "
+        "every restore"
+    )
+
+    tampered = [("b", {"embedding": [0.1, 0.2000001], "profile_name": "Beta"}), documents[1]]
+    assert helper.digest_documents(tampered) != helper.digest_documents(documents), (
+        "a single changed vector component must change the digest, or verification proves nothing"
+    )
+
+
+def test_a_missing_document_changes_the_digest(helper: ModuleType) -> None:
+    documents = [("a", {"embedding": [1.0]}), ("b", {"embedding": [2.0]})]
+    assert helper.digest_documents(documents) != helper.digest_documents(documents[:1])
+
+
+def test_read_manifest_refuses_an_empty_or_foreign_artifact(helper: ModuleType) -> None:
+    import io
+
+    with pytest.raises(helper.VoiceprintBackupError):
+        helper.read_manifest(io.StringIO(""))
+
+    with pytest.raises(helper.VoiceprintBackupError):
+        helper.read_manifest(io.StringIO('{"format": "something-else"}\n'))
+
+    with pytest.raises(helper.VoiceprintBackupError):
+        helper.read_manifest(
+            io.StringIO(json.dumps({"format": helper.FORMAT_NAME, "version": 99}) + "\n")
+        )
+
+
+def test_read_manifest_returns_the_bulk_lines_untouched(helper: ModuleType) -> None:
+    import io
+
+    manifest = {"format": helper.FORMAT_NAME, "version": helper.FORMAT_VERSION, "indices": []}
+    action = json.dumps({"index": {"_index": "speakers_v4", "_id": "profile_1"}})
+    source = json.dumps({"embedding": [0.5]})
+    parsed, lines = helper.read_manifest(
+        io.StringIO(f"{json.dumps(manifest)}\n{action}\n{source}\n")
+    )
+    assert parsed["format"] == helper.FORMAT_NAME
+    assert lines == [action, source]
+
+
+def test_restorable_settings_drops_the_read_only_index_metadata(helper: ModuleType) -> None:
+    """``PUT /<index>`` rejects uuid/creation_date/provided_name — an unfiltered round-trip fails."""
+    live = {
+        "index": {
+            "number_of_shards": "1",
+            "number_of_replicas": "0",
+            "knn": "true",
+            "uuid": "abc123",
+            "creation_date": "1700000000000",
+            "provided_name": "speakers_v4",
+            "version": {"created": "136387827"},
+        }
+    }
+    kept = helper._restorable_settings(live)["index"]
+    assert set(kept) == {"number_of_shards", "number_of_replicas", "knn"}
+
+
+# ---------------------------------------------------------------------------------------------
+# Hermetic bash behaviour (no Docker): a failed export must not leave a partial artifact.
+# ---------------------------------------------------------------------------------------------
+
+
+def _call_common_fn(name: str, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603 - fixed argv, no shell
+        ["bash", "-c", f'source "{_COMMON_SH}"; {name} "$@"', "--", *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_voiceprint_artifact_path_shares_one_stem_with_encrypted_and_plain_dumps() -> None:
+    plain = _call_common_fn("voiceprint_artifact_path", "./backups/ot_2026.sql")
+    encrypted = _call_common_fn("voiceprint_artifact_path", "./backups/ot_2026.sql.gpg")
+    assert plain.returncode == 0, plain.stderr
+    assert encrypted.returncode == 0, encrypted.stderr
+    assert plain.stdout.strip() == "./backups/ot_2026.sql.voiceprints.ndjson"
+    assert encrypted.stdout.strip() == plain.stdout.strip(), (
+        "restore is handed the .gpg name, backup writes the .sql name — they must resolve to "
+        "the same artifact stem or a restore silently finds nothing"
+    )
+
+
+def test_a_failed_export_removes_the_partial_artifact(tmp_path: Path) -> None:
+    """A half-written artifact must never be mistaken for a complete backup."""
+    out_file = tmp_path / "partial.voiceprints.ndjson"
+    # `false` as the exec prefix: it swallows the argv and exits 1, i.e. the export fails
+    # after the redirect has already created the output file.
+    result = _call_common_fn("os_export_speaker_indices", "false", str(out_file), "speakers")
+    assert result.returncode != 0, "a failing exec prefix must fail the export"
+    assert not out_file.exists(), (
+        "the empty artifact left by the redirect must be removed — an empty file parses as "
+        "'this deployment has no voiceprints', which is the failure mode being fixed"
+    )

--- a/docs-site/docs/operations/backup-audit.md
+++ b/docs-site/docs/operations/backup-audit.md
@@ -28,7 +28,8 @@ below.
 |---|---|---|---|---|
 | **PostgreSQL** (users, transcripts, segments, speakers, settings) | In-app scheduled `pg_dump -Fc` (GFS retention, optional gpg) to a local mount **or** S3-compatible bucket; manual `./opentranscribe.sh backup [--encrypt]`; `restore` covers both plain-SQL and `-Fc`/S3 artifacts, with a real integration-test round-trip (#600) | Restore is not automatically *verified on a schedule* (no periodic restore drill / checksum) | **Low** | Run the quarterly restore drill in [Backup & Restore](./backup-restore.md#testing-backups). Good as shipped. |
 | **MinIO media** (~484 GB, irreplaceable originals) | **Addressed (#242):** in-app scheduled **Media Mirror** — incremental, never-deleting copy of the media bucket to a mounted folder or S3-compatible bucket, with metrics + failure alerting | Default-OFF (must be enabled + given a destination); mirror is single-copy (pair with offsite for 3-2-1) | **Low** (was High) | Enable the mirror and point it off-host; optionally add bucket versioning as a deployment-level extra. See [MinIO media](#2-minio-media--the-484-gb-gap). |
-| **OpenSearch** (search + vector indices) | Optional in-app `fs` snapshot alongside each dump (`backup.include_opensearch`); fully **rebuildable** from Postgres via reindex | None that matters — derived data | **Low** | Leave snapshots off unless you want to skip reindex time on restore. Confirmed adequate. |
+| **OpenSearch — transcript/chunk indices** | Optional in-app `fs` snapshot alongside each dump (`backup.include_opensearch`, on by default since #658); **rebuildable** from Postgres via reindex | None that matters — derived data | **Low** | Snapshots only skip reindex time on restore. Confirmed adequate. |
+| **OpenSearch — speaker/voiceprint indices** (`speakers_v3` / `speakers_v4`) | **Addressed (#658):** `backup` writes a portable `*.voiceprints.ndjson` artifact beside every dump, and `restore` re-imports it and **verifies** it against a content digest before reporting success. The in-app scheduled snapshot now defaults ON and records how many voiceprints it covered | Not rebuildable at all if both copies are lost — re-deriving needs the source media plus a GPU re-embed run | **Low** (was **Critical**) | Keep the `*.voiceprints.ndjson` file with its dump. It is the only copy of the deployment's biometric data. See [§3](#3-opensearch--split-verdict). |
 | **Configuration & Secrets** (`.env`: `ENCRYPTION_KEY`, `JWT_SECRET_KEY`, DB/MinIO creds; gpg passphrase) | **Addressed (#243):** encrypted runs write `opentranscribe-recovery.env.gpg` (the essential keys, same passphrase) beside the dumps; unencrypted runs write a no-secrets `RECOVERY-README.txt` + a one-time admin warning | With encryption off, keys must still be preserved separately (by design — no plaintext keys beside a plaintext dump) | **Low** (was Critical) | Keep the gpg passphrase in a password manager and verify keys in every restore drill. See [§4](#secrets-gap). |
 | **Redis** (Celery broker/cache) | Nothing — by design | None | **None** | Ephemeral. Tasks re-queue (acks-late). No backup needed. Confirmed. |
 | **Model cache** (~2.5 GB AI weights) | Nothing — by design | None | **None** | Re-downloaded on first use. Back up only for air-gapped installs. |
@@ -111,12 +112,38 @@ deployment-level extra, not a requirement. Setup + restore-from-mirror:
 Residual note: the mirror is one additional copy — for full 3-2-1, point it (or a
 second replica) offsite.
 
-## 3. OpenSearch — adequate (derived data)
+## 3. OpenSearch — split verdict {/* #3-opensearch--split-verdict */}
 
-Every search and vector index is **rebuildable from PostgreSQL** via the reindex tasks, so
-OpenSearch is not a data-safety concern. The in-app scheduler can *optionally* take an `fs`
-snapshot beside each dump (`backup.include_opensearch`) purely to **skip reindex time** on
-restore. Leave it off and nothing is lost. **Confirmed adequate. Severity: Low.**
+This section used to read "adequate (derived data)" and say that *every* index is
+rebuildable from PostgreSQL. **That was wrong for one of them, and it was the one that
+mattered** (issue #658).
+
+**Transcript and chunk indices — genuinely derived.** Rebuildable from PostgreSQL via the
+reindex tasks. A snapshot only saves reindex time.
+
+**Speaker indices (`speakers_v3` / `speakers_v4`) — the sole copy of the deployment's
+biometric data.** PostgreSQL stores **no embedding vectors at all**: `SpeakerProfile`
+carries only `embedding_count` and `last_embedding_update`, and neither `Speaker` nor
+`SpeakerCluster` has a vector column (`backend/app/models/media.py`). Re-deriving a
+voiceprint needs the **source media** (which may have been deleted) plus a **GPU re-embed
+run** — it is not a reindex. Until #658, `backup` was a bare `pg_dump` and the in-app
+snapshot defaulted OFF, so a stock deployment had no recoverable copy.
+
+What ships now:
+
+- `./opentranscribe.sh backup` writes `<dump>.voiceprints.ndjson` (gpg-encrypted alongside
+  an encrypted dump) containing every speaker document, its index mapping, and a content
+  digest. A failed export **fails the backup** rather than reporting success.
+- `./opentranscribe.sh restore` finds that artifact by name, re-imports it, and then
+  **verifies** the live indices against the digest. A restore that silently comes back with
+  zero voiceprints is treated as a failed restore, services left stopped.
+- The restore also reports whether `speaker_profile.embedding_count` agrees with what
+  OpenSearch actually holds, so rows claiming embeddings that no longer exist are named
+  rather than discovered months later as "speaker matching stopped working".
+- `backup.include_opensearch` now defaults **on**; a snapshot that could not run records
+  how many voiceprints it therefore left uncovered.
+
+**Severity: Low (was Critical).** Keep the `*.voiceprints.ndjson` file with its dump.
 
 ## 4. Configuration & Secrets — the sneaky-critical gap {/* #secrets-gap */}
 

--- a/docs-site/docs/operations/backup-restore.md
+++ b/docs-site/docs/operations/backup-restore.md
@@ -16,7 +16,8 @@ OpenTranscribe stores data across several services. Understanding each component
 |-----------|--------------------------|----------|----------|
 | **PostgreSQL** | `postgres_data` | Users, transcripts, segments, speakers, settings | Critical |
 | **MinIO** | `minio_data` | Uploaded media files (audio/video) | Critical |
-| **OpenSearch** | `opensearch_data` | Full-text and vector search indices | Medium (rebuildable) |
+| **OpenSearch — search indices** | `opensearch_data` | Full-text and vector transcript/chunk indices | Medium (rebuildable) |
+| **OpenSearch — speaker indices** | `opensearch_data` (`speakers_v3` / `speakers_v4`) | **Speaker voiceprints** — the embeddings that make cross-file speaker identification work | **Critical** (NOT rebuildable) |
 | **Redis** | `redis_data` | Task queue state, cache | Low (ephemeral) |
 | **Model Cache** | `${MODEL_CACHE_DIR:-./models}/` | AI model weights (~2.5GB) | Low (re-downloadable) |
 | **Configuration** | `.env`, `docker-compose.*.yml` | Environment and deployment config | Critical |
@@ -25,12 +26,25 @@ OpenTranscribe stores data across several services. Understanding each component
 **Critical** components contain irreplaceable data. **Medium** components can be rebuilt from critical data (e.g., reindexing). **Low** components are automatically regenerated or re-downloaded.
 :::
 
+:::danger[Speaker voiceprints are not "derived data"]
+PostgreSQL stores **no embedding vectors**. `SpeakerProfile` carries only `embedding_count`
+and `last_embedding_update` — the vectors themselves live *only* in the OpenSearch
+`speakers_v*` indices. Re-deriving one needs the original media (which may be gone) plus a
+GPU re-embed run; a reindex cannot produce it.
+
+`backup` therefore writes a second artifact beside every dump:
+`opentranscribe_backup_YYYYMMDD_HHMMSS.sql.voiceprints.ndjson`. **Keep the two files
+together** — `restore` finds the voiceprint artifact by name and, if it is missing, tells
+you plainly that whatever OpenSearch currently holds is what you now have.
+:::
+
 ```mermaid
 graph TB
     subgraph Critical["Critical - Back Up Always"]
         PG[(PostgreSQL<br/>Users, transcripts,<br/>speakers, settings)]
         MINIO[(MinIO<br/>Media files)]
         ENV[".env Config"]
+        VP[(OpenSearch speakers_v*<br/>Voiceprint embeddings)]
     end
     subgraph Rebuildable["Medium - Rebuildable from Critical Data"]
         OS[(OpenSearch<br/>Search indices)]
@@ -42,6 +56,7 @@ graph TB
 
     PG -->|reindex| OS
     MINIO -->|reprocess| OS
+    MINIO -.->|GPU re-embed only,<br/>impossible if media deleted| VP
 ```
 
 ## Database Backup
@@ -54,7 +69,21 @@ The built-in backup command creates a timestamped SQL dump:
 ./opentranscribe.sh backup
 ```
 
-This creates a file at `./backups/opentranscribe_backup_YYYYMMDD_HHMMSS.sql`.
+This creates **two** files:
+
+| File | Contents |
+|---|---|
+| `./backups/opentranscribe_backup_YYYYMMDD_HHMMSS.sql` | the PostgreSQL dump |
+| `./backups/opentranscribe_backup_YYYYMMDD_HHMMSS.sql.voiceprints.ndjson` | every speaker/voiceprint document from OpenSearch, its index mapping, and a content digest |
+
+The second file is not optional and not a convenience: PostgreSQL holds no embedding
+vectors, so the dump on its own contains none of the deployment's biometric data. If the
+export fails (OpenSearch down, for example) the whole `backup` command fails rather than
+reporting success on a half-backup. `restore` locates the artifact from the dump's name, so
+**move and store the pair together**.
+
+With `--encrypt`, the artifact is encrypted too (`…​.voiceprints.ndjson.gpg`) and gpg
+prompts twice — once per file. Use the same passphrase for both.
 
 :::note[`opentranscribe.sh`, not `opentr.sh`]
 `opentranscribe.sh` is the management script the installer places next to your

--- a/release-manifest.txt
+++ b/release-manifest.txt
@@ -94,6 +94,11 @@ scripts/generate-ssl-cert.sh	exec
 scripts/fix-model-permissions.sh	exec
 scripts/download-models.sh	exec
 scripts/download-models.py
+# Speaker-voiceprint export/import, driven by common.sh's backup_database /
+# restore_database (issue #658). `optional` because releases before it shipped have no
+# such path — but on a release that DOES have it, a missing copy means `backup` refuses
+# rather than quietly writing a dump with none of the deployment's biometric data in it.
+scripts/voiceprint-backup.py	optional,exec
 
 # --- The management script itself ----------------------------------------------
 opentranscribe.sh	exec

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -950,6 +950,181 @@ pg_restore_restart_decision() {
 }
 
 #######################
+# VOICEPRINT (SPEAKER-EMBEDDING) BACKUP PRIMITIVES (issue #658)
+#######################
+#
+# Speaker voiceprints exist in exactly ONE place: the OpenSearch `speakers_v*` indices.
+# PostgreSQL stores no embedding vectors at all — `SpeakerProfile` carries only
+# `embedding_count` + `last_embedding_update`, and `Speaker`/`SpeakerCluster` have no
+# vector column (backend/app/models/media.py) — so a bare `pg_dump` leaves a deployment
+# with NO recoverable copy of its biometric data. Voiceprints are not derived data:
+# re-deriving one needs the source media (which may be gone) plus a GPU re-embed run.
+#
+# These are the same shape as the pg primitives above — first argument is an *exec
+# prefix* — so production passes "docker compose exec -T opensearch" and the integration
+# test passes "docker exec -i <throwaway-opensearch>", and the tests drive the exact code
+# the CLI ships rather than a re-implementation.
+#
+# The work itself is done by scripts/voiceprint-backup.py, piped into the OpenSearch
+# container's own python3 (`python3 -c "$(cat …)"`). Running it THERE rather than on the
+# host is deliberate: it needs no host tooling, so a `curl | bash` production install is
+# covered identically to a git checkout, and it talks to 127.0.0.1:9200 inside the
+# container, so it still works while every application container is stopped — which is
+# exactly the state restore_database leaves them in between the replay and the restart
+# decision.
+
+# Sidecar artifact suffix, appended to the dump's name with any `.gpg` stripped first, so
+# `opentranscribe_backup_X.sql` and `opentranscribe_backup_X.sql.gpg` both resolve to the
+# same stem and a restore can find the artifact from either form.
+VOICEPRINT_SUFFIX=".voiceprints.ndjson"
+
+# Echo the sidecar artifact path for a dump path (encrypted or not).
+# $1 dump_path
+voiceprint_artifact_path() {
+  local dump_path="${1:-}"
+  echo "${dump_path%.gpg}${VOICEPRINT_SUFFIX}"
+}
+
+# Echo the path to the helper, resolved relative to THIS file so it works from a git
+# checkout, a production install, and a test's temp cwd alike.
+voiceprint_helper_path() {
+  local here
+  here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  echo "$here/voiceprint-backup.py"
+}
+
+# Shared runner for the three modes below. Fails loudly (never silently degrades) when the
+# helper is missing: an absent helper and "this deployment has no voiceprints" must not
+# look the same, which is the whole failure mode #658 is about.
+#
+# $1 exec_prefix
+# $2 mode          export | import | verify
+# $3 index_base    (optional; defaults to OPENSEARCH_SPEAKER_INDEX, else "speakers")
+_voiceprint_run() {
+  local exec_prefix="$1"
+  local mode="$2"
+  local index_base="${3:-${OPENSEARCH_SPEAKER_INDEX:-speakers}}"
+
+  local helper
+  helper="$(voiceprint_helper_path)"
+  if [ ! -f "$helper" ]; then
+    echo "❌ voiceprint $mode: helper not found at $helper"
+    echo "   Re-download it (release-manifest.txt lists scripts/voiceprint-backup.py) —"
+    echo "   without it, speaker voiceprints are NOT covered by this backup."
+    return 1
+  fi
+
+  local program
+  program="$(cat "$helper")"
+  # shellcheck disable=SC2086
+  $exec_prefix python3 -c "$program" "$mode" --index-base "$index_base"
+}
+
+# Export every speaker index to a single self-describing artifact (manifest line + _bulk
+# pairs). Removes a partial artifact on failure so a half-written file can never be
+# mistaken for a complete one.
+#
+# $1 exec_prefix
+# $2 out_file
+# $3 index_base (optional)
+os_export_speaker_indices() {
+  local exec_prefix="$1"
+  local out_file="$2"
+  local index_base="${3:-}"
+
+  if ! _voiceprint_run "$exec_prefix" export "$index_base" > "$out_file"; then
+    rm -f "$out_file"
+    return 1
+  fi
+}
+
+# Recreate any missing speaker index from the artifact's saved mappings, bulk-load its
+# documents, and restore the read alias.
+#
+# $1 exec_prefix
+# $2 in_file
+# $3 index_base (optional)
+os_import_speaker_indices() {
+  local exec_prefix="$1"
+  local in_file="$2"
+  local index_base="${3:-}"
+
+  _voiceprint_run "$exec_prefix" import "$index_base" < "$in_file"
+}
+
+# Prove the restore actually happened: re-read the live cluster and compare document
+# counts AND a content digest of every embedding against the artifact's manifest.
+# Returns 1 on any mismatch, so a silent zero-voiceprint restore fails loudly instead of
+# reporting success.
+#
+# $1 exec_prefix
+# $2 in_file
+# $3 index_base (optional)
+os_verify_speaker_restore() {
+  local exec_prefix="$1"
+  local in_file="$2"
+  local index_base="${3:-}"
+
+  _voiceprint_run "$exec_prefix" verify "$index_base" < "$in_file"
+}
+
+# Echo how many speaker-PROFILE documents OpenSearch currently holds, or "unknown" when
+# the cluster/alias cannot be read. Used for the Postgres<->OpenSearch consistency report
+# below — `speaker_profile.embedding_count` is a Postgres number describing data that
+# lives only in OpenSearch, so a restore of one without the other leaves rows claiming
+# embeddings that do not exist.
+#
+# $1 exec_prefix
+# $2 index_base (optional)
+os_speaker_profile_doc_count() {
+  local exec_prefix="$1"
+  local index_base="${2:-${OPENSEARCH_SPEAKER_INDEX:-speakers}}"
+
+  local body='{"query":{"term":{"document_type":"profile"}}}'
+  local raw
+  # shellcheck disable=SC2086
+  raw="$($exec_prefix curl -sf -X POST "http://127.0.0.1:9200/${index_base}/_count" \
+         -H 'Content-Type: application/json' -d "$body" 2>/dev/null)" || {
+    echo "unknown"
+    return 0
+  }
+  local count
+  count="$(echo "$raw" | grep -o '"count":[0-9]*' | head -1 | cut -d: -f2)"
+  echo "${count:-unknown}"
+}
+
+# Report whether Postgres and OpenSearch agree about voiceprints, and say plainly when
+# they do not. Never fails the caller — it is a diagnostic, and the authoritative gate is
+# os_verify_speaker_restore above.
+#
+# $1 pg_exec_prefix
+# $2 db_user
+# $3 db_name
+# $4 os_exec_prefix
+report_voiceprint_consistency() {
+  local pg_exec_prefix="$1"
+  local db_user="$2"
+  local db_name="$3"
+  local os_exec_prefix="$4"
+
+  local claiming
+  # shellcheck disable=SC2086
+  claiming="$($pg_exec_prefix psql -tA -U "$db_user" "$db_name" -c \
+    "SELECT count(*) FROM speaker_profile WHERE COALESCE(embedding_count, 0) > 0;" 2>/dev/null | tr -d '[:space:]')"
+  claiming="${claiming:-unknown}"
+
+  local present
+  present="$(os_speaker_profile_doc_count "$os_exec_prefix")"
+
+  echo "🗣️  Voiceprint consistency: $claiming speaker_profile row(s) claim embeddings; OpenSearch holds $present profile document(s)."
+  if [ "$claiming" != "unknown" ] && [ "$present" != "unknown" ] && [ "$claiming" != "$present" ]; then
+    echo "   ⚠️  These disagree. Rows claiming an embedding that OpenSearch does not hold will never"
+    echo "       match a speaker — the profile looks trained in the UI and behaves as if it is not."
+    echo "       Restore the matching *${VOICEPRINT_SUFFIX} artifact, or re-run speaker identification."
+  fi
+}
+
+#######################
 # BACKUP / RESTORE (issue #613)
 #######################
 #
@@ -1018,6 +1193,8 @@ backup_database() {
 
   if [[ "$ENCRYPT_BACKUP" == true ]]; then
     echo "📦 Creating encrypted database backup: ${BACKUP_FILE}.gpg..."
+    echo "ℹ️  gpg will prompt for a passphrase TWICE — once for the database dump, once for the"
+    echo "   speaker-voiceprint artifact beside it. Use the same passphrase for both."
     # Subshell with pipefail so a pg_dump failure isn't masked by gpg succeeding
     # shellcheck disable=SC2086
     if (set -o pipefail; docker compose $compose_files exec -T postgres pg_dump -U "$db_user" "$db_name" \
@@ -1040,6 +1217,42 @@ backup_database() {
       exit 1
     fi
   fi
+
+  # Speaker voiceprints (issue #658). NOT optional and NOT "nice to have": PostgreSQL
+  # holds no embedding vectors, so the dump written above contains none of this
+  # deployment's biometric data. A failure here fails the whole backup — a partial
+  # artifact that reports success is precisely the bug being fixed.
+  local dump_display="./backups/${BACKUP_FILE}"
+  if [[ "$ENCRYPT_BACKUP" == true ]]; then
+    dump_display="${dump_display}.gpg"
+  fi
+  local voiceprint_file
+  voiceprint_file="$(voiceprint_artifact_path "./backups/${BACKUP_FILE}")"
+  echo "🗣️  Exporting speaker voiceprints from OpenSearch..."
+  # The prefix is built as ONE quoted string here and word-split inside _voiceprint_run,
+  # the same exec-prefix contract the pg primitives use.
+  if ! os_export_speaker_indices "docker compose $compose_files exec -T opensearch" "$voiceprint_file"; then
+    echo "❌ Voiceprint export failed — this backup is INCOMPLETE."
+    echo "   The database dump itself succeeded and is at ${dump_display},"
+    echo "   but speaker voiceprints live ONLY in OpenSearch and are not in it. Bring OpenSearch"
+    echo "   up and re-run '$frontend_cmd backup' before relying on this as a restore point."
+    exit 1
+  fi
+
+  if [[ "$ENCRYPT_BACKUP" == true ]]; then
+    if ! gpg --symmetric --cipher-algo AES256 --output "${voiceprint_file}.gpg" "$voiceprint_file"; then
+      rm -f "${voiceprint_file}.gpg"
+      echo "❌ Could not encrypt the voiceprint artifact — leaving it unencrypted would write"
+      echo "   biometric data beside an encrypted dump. Removing it; this backup is INCOMPLETE."
+      rm -f "$voiceprint_file"
+      exit 1
+    fi
+    rm -f "$voiceprint_file"
+    voiceprint_file="${voiceprint_file}.gpg"
+  fi
+  echo "✅ Voiceprints exported: $voiceprint_file"
+  echo "   Keep it BESIDE the dump — 'restore' finds it by name and refuses to report success"
+  echo "   if the voiceprints it holds do not come back."
 }
 
 # Function to restore database from backup (issue #599)
@@ -1283,9 +1496,11 @@ restore_database() {
       echo "   ⚠️  --no-safety-dump: no safety dump will be taken. The current database is NOT recoverable after this."
     fi
     echo ""
-    echo "   ⚠️  MinIO (media files) and OpenSearch (search indices) are NOT rolled back with the"
+    echo "   ⚠️  MinIO (media files) and the OpenSearch SEARCH indices are NOT rolled back with the"
     echo "   database — restoring only PostgreSQL creates a time skew (media with no row, rows with"
     echo "   no media, stale search hits). Reindex from Admin → Search afterwards."
+    echo "   The OpenSearch SPEAKER indices ARE rolled back when a *${VOICEPRINT_SUFFIX} artifact"
+    echo "   sits beside this dump (issue #658) — those hold voiceprints, which exist nowhere else."
     echo ""
     printf '   Type the database name ("%s") to confirm, anything else cancels: ' "$db_name"
     local confirm_name
@@ -1426,6 +1641,66 @@ restore_database() {
 
   [ -n "$temp_sql" ] && rm -f "$temp_sql"
 
+  # ---- Speaker voiceprints (issue #658) ------------------------------------------------
+  # Runs AFTER the database replay has been verified (so a failed replay never replaces the
+  # live voiceprints with an older set) and BEFORE the restart decision (so the app never
+  # comes back up over a half-restored speaker plane). OpenSearch is deliberately NOT in the
+  # stop list above, so this works with every application container still stopped.
+  local os_exec_prefix="docker compose $compose_files exec -T opensearch"
+  local voiceprint_file=""
+  local voiceprint_temp=""
+  local voiceprint_plain
+  voiceprint_plain="$(voiceprint_artifact_path "$backup_file")"
+  if [ -f "$voiceprint_plain" ]; then
+    voiceprint_file="$voiceprint_plain"
+  elif [ -f "${voiceprint_plain}.gpg" ]; then
+    if ! command -v gpg &> /dev/null; then
+      echo "❌ Found ${voiceprint_plain}.gpg but gpg is not installed — cannot restore voiceprints."
+      echo "   Install gnupg (e.g. 'apt install gnupg') and re-run the restore."
+      echo "⏸️  Services left stopped."
+      exit 1
+    fi
+    echo "🔓 Decrypting the voiceprint artifact..."
+    voiceprint_temp=$(mktemp ./backups/.voiceprints_XXXXXX)
+    if ! gpg --yes --output "$voiceprint_temp" --decrypt "${voiceprint_plain}.gpg"; then
+      rm -f "$voiceprint_temp"
+      echo "❌ Could not decrypt ${voiceprint_plain}.gpg — voiceprints were NOT restored."
+      echo "⏸️  Services left stopped."
+      exit 1
+    fi
+    voiceprint_file="$voiceprint_temp"
+  fi
+
+  if [ -n "$voiceprint_file" ]; then
+    echo "🗣️  Restoring speaker voiceprints into OpenSearch..."
+    if ! os_import_speaker_indices "$os_exec_prefix" "$voiceprint_file"; then
+      [ -n "$voiceprint_temp" ] && rm -f "$voiceprint_temp"
+      echo "❌ Voiceprint restore failed. The database was restored and verified, but the speaker"
+      echo "   embeddings are NOT in place — every profile would silently stop matching."
+      echo "   Fix OpenSearch and re-run: $frontend_cmd restore --yes $backup_file"
+      echo "⏸️  Services left stopped — bringing the app up now would run against a half-restored"
+      echo "   speaker plane and start writing new embeddings into it."
+      exit 1
+    fi
+    echo "🔍 Verifying voiceprint restore..."
+    if ! os_verify_speaker_restore "$os_exec_prefix" "$voiceprint_file"; then
+      [ -n "$voiceprint_temp" ] && rm -f "$voiceprint_temp"
+      echo "❌ Voiceprint verification failed — the live indices do not match the backup (see the"
+      echo "   mismatch(es) above). A restore that silently comes back with zero voiceprints is"
+      echo "   the same data loss with extra steps, so this is treated as a failed restore."
+      echo "⏸️  Services left stopped."
+      exit 1
+    fi
+    [ -n "$voiceprint_temp" ] && rm -f "$voiceprint_temp"
+    echo "✅ Voiceprints restored and verified against the backup's content digest."
+  else
+    echo "⚠️  No voiceprint artifact found beside this backup (looked for ${voiceprint_plain}"
+    echo "   and ${voiceprint_plain}.gpg). Backups taken before issue #658 do not have one:"
+    echo "   speaker embeddings live ONLY in OpenSearch and are NOT in the SQL dump, so whatever"
+    echo "   OpenSearch currently holds is what this deployment now has."
+  fi
+  report_voiceprint_consistency "$exec_prefix" "$db_user" "$db_name" "$os_exec_prefix"
+
   # Decide whether it is safe to bring the app back up automatically (issue #610). The
   # decision is made by the shared, independently-tested pg_restore_restart_decision
   # (scripts/common.sh) — never reimplemented here — so both front ends and their test
@@ -1460,8 +1735,9 @@ restore_database() {
     "${restart_services[@]}"
     echo "✅ Database restored successfully."
   fi
-  echo "ℹ️  MinIO and OpenSearch were NOT rolled back — reindex from Admin → Search if the"
-  echo "   restored database's file list differs from what MinIO/OpenSearch currently have."
+  echo "ℹ️  MinIO and the OpenSearch SEARCH indices were NOT rolled back — reindex from"
+  echo "   Admin → Search if the restored database's file list differs from what they hold."
+  echo "   (The speaker/voiceprint indices were handled above — see the line starting 🗣️.)"
   if [ -n "$safety_dump_file" ]; then
     echo "   Pre-restore safety dump of the database this replaced: $safety_dump_file"
   fi

--- a/scripts/voiceprint-backup.py
+++ b/scripts/voiceprint-backup.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+"""Export / import / verify the OpenSearch speaker-embedding (voiceprint) indices.
+
+Issue #658: speaker voiceprints exist in exactly ONE place. PostgreSQL stores no
+embedding vectors at all — ``SpeakerProfile`` carries only ``embedding_count`` and
+``last_embedding_update`` (``backend/app/models/media.py``), and ``Speaker`` /
+``SpeakerCluster`` have no vector column — so the ``speakers_v*`` indices are the
+sole copy of the deployment's biometric data. ``./opentr.sh backup`` was a bare
+``pg_dump``, which means a stock deployment had **no recoverable copy of it**.
+Voiceprints are not "derived data": re-deriving one needs the source media (which
+may be gone) plus a GPU re-embed run.
+
+This module is the artifact half of the fix. ``scripts/common.sh`` drives it —
+``os_export_speaker_indices`` / ``os_import_speaker_indices`` /
+``os_verify_speaker_restore`` — and both front ends (``opentr.sh`` and
+``opentranscribe.sh``) reach it through those.
+
+**It runs INSIDE the OpenSearch container**, piped in as
+``docker compose exec -T opensearch python3 -c "$(cat this-file)" <mode>``. That
+placement is deliberate and load-bearing:
+
+* it needs no host tooling (the OpenSearch image ships ``python3``), so a
+  production ``curl | bash`` install is covered identically to a git checkout;
+* it talks to ``127.0.0.1:9200`` inside the container, so it works while every
+  application container is **stopped** — which is exactly the state
+  ``restore_database`` leaves them in between the replay and the restart decision.
+
+⚠️ It authenticates with nothing. The shipped OpenSearch runs with
+``DISABLE_SECURITY_PLUGIN=true`` in both dev and prod (``docker-compose.yml``,
+``docker-compose.prod.yml``'s ``OPENSEARCH_DISABLE_SECURITY`` default), the same
+assumption ``scripts/speaker-profiles-backup.sh`` already makes. On a deployment
+that turned the security plugin on, a 401/403 is reported as a hard failure naming
+the cause — it never degrades to an empty artifact, because an empty artifact is
+indistinguishable from "this deployment has no voiceprints".
+
+Artifact format — one self-describing file, ``<dump-stem>.voiceprints.ndjson``:
+
+* **line 1** a manifest object: format/version, the alias target, and per index the
+  mappings, the settings worth restoring, the document count and a content digest.
+* **lines 2..n** ``_bulk``-ready pairs: an action line, then the ``_source`` line.
+
+Keeping the manifest in the same file matters: a count/digest stored separately is
+a count/digest that gets moved, encrypted or copied without its data, and the
+verification step that makes a restore trustworthy would then silently have
+nothing to compare against.
+
+The digest is a content hash over ``id + canonical JSON source``, never a
+similarity comparison, so nothing here reads or writes an OpenSearch
+``cosinesimil`` score and ``app/utils/cosine_space.py`` does not apply.
+
+Modes::
+
+    export           # -> artifact on stdout
+    import           # <- artifact on stdin; creates missing indices, bulk-loads
+    verify           # <- artifact on stdin; exit 1 if the live cluster differs
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import hashlib
+import http.client
+import json
+import sys
+import time
+from typing import Any
+
+FORMAT_NAME = 'opentranscribe-voiceprints'
+FORMAT_VERSION = 1
+
+# Index settings worth carrying across a restore. Everything else OpenSearch
+# reports under `settings.index` is read-only metadata (`uuid`, `creation_date`,
+# `provided_name`, `version.*`) that a `PUT /<index>` rejects outright, so an
+# unfiltered round-trip fails on every index it tries to recreate.
+_RESTORABLE_SETTINGS = ('number_of_shards', 'number_of_replicas', 'knn')
+
+_SCROLL_KEEPALIVE = '2m'
+_SCROLL_PAGE = 500
+_BULK_DOCS_PER_REQUEST = 500
+
+
+class VoiceprintBackupError(RuntimeError):
+    """Any failure that must abort the backup/restore rather than degrade."""
+
+
+class _Client:
+    """Minimal OpenSearch HTTP client (stdlib only — the container has no urllib3)."""
+
+    def __init__(self, host: str, port: int, timeout: float = 120.0) -> None:
+        self._host = host
+        self._port = port
+        self._timeout = timeout
+
+    def request(self, method: str, path: str, body: Any = None) -> dict:
+        """Issue one request and return the decoded JSON body.
+
+        Args:
+            method: HTTP verb.
+            path: Path beginning with ``/``.
+            body: A JSON-serialisable object, a pre-encoded NDJSON ``str``, or None.
+
+        Returns:
+            The decoded response body.
+
+        Raises:
+            VoiceprintBackupError: On a transport failure or a non-2xx status.
+        """
+        if isinstance(body, str):
+            payload = body.encode('utf-8')
+            content_type = 'application/x-ndjson'
+        elif body is None:
+            payload = None
+            content_type = 'application/json'
+        else:
+            payload = json.dumps(body).encode('utf-8')
+            content_type = 'application/json'
+
+        conn = http.client.HTTPConnection(self._host, self._port, timeout=self._timeout)
+        try:
+            headers = {'Content-Type': content_type} if payload is not None else {}
+            conn.request(method, path, body=payload, headers=headers)
+            response = conn.getresponse()
+            raw = response.read()
+            status = response.status
+        except OSError as exc:
+            raise VoiceprintBackupError(
+                f'OpenSearch is unreachable at {self._host}:{self._port} ({exc})'
+            ) from exc
+        finally:
+            conn.close()
+
+        if status in (401, 403):
+            raise VoiceprintBackupError(
+                f'OpenSearch refused the request with HTTP {status}. This helper '
+                'authenticates with nothing, which is correct for the shipped '
+                'DISABLE_SECURITY_PLUGIN=true configuration. This deployment has the '
+                'security plugin enabled, so voiceprints cannot be exported this way — '
+                'use the in-app scheduled backup (Settings -> Backups), which holds the '
+                'OpenSearch credentials.'
+            )
+        if status >= 400:
+            detail = raw.decode('utf-8', 'replace')[:500]
+            raise VoiceprintBackupError(f'{method} {path} failed with HTTP {status}: {detail}')
+        if not raw:
+            return {}
+        return json.loads(raw.decode('utf-8'))
+
+    def exists(self, path: str) -> bool:
+        """Return True when a HEAD on ``path`` answers 2xx, False on 404."""
+        conn = http.client.HTTPConnection(self._host, self._port, timeout=self._timeout)
+        try:
+            conn.request('HEAD', path)
+            status = conn.getresponse().status
+        except OSError as exc:
+            raise VoiceprintBackupError(
+                f'OpenSearch is unreachable at {self._host}:{self._port} ({exc})'
+            ) from exc
+        finally:
+            conn.close()
+        return status < 400
+
+
+def _canonical(doc_id: str, source: dict) -> str:
+    """Render one document as the stable line the content digest is computed over."""
+    return doc_id + '\t' + json.dumps(source, sort_keys=True, separators=(',', ':'))
+
+
+def digest_documents(documents: list) -> str:
+    """Content digest over ``(doc_id, source)`` pairs, order-independent.
+
+    Args:
+        documents: ``(doc_id, source)`` tuples.
+
+    Returns:
+        ``sha256:<hex>`` over the id-sorted canonical rendering of every document.
+        This is an exact-content hash, NOT a similarity measure — a single changed
+        vector component changes it.
+    """
+    hasher = hashlib.sha256()
+    for doc_id, source in sorted(documents, key=lambda pair: pair[0]):
+        hasher.update(_canonical(doc_id, source).encode('utf-8'))
+        hasher.update(b'\n')
+    return 'sha256:' + hasher.hexdigest()
+
+
+def speaker_index_names(client: _Client, index_base: str) -> list:
+    """Return every concrete speaker index, newest-name-last, alias entries excluded.
+
+    ``_cat/indices`` resolves the ``speakers`` alias onto its concrete target, so a
+    pattern scan finds ``speakers_v3`` / ``speakers_v4`` / ``speakers_v3_backup``
+    and any future sibling without this file having to keep its own list of the
+    names ``app/core/constants.py`` derives.
+    """
+    rows = client.request('GET', f'/_cat/indices/{index_base}*?format=json&h=index')
+    if not isinstance(rows, list):
+        return []
+    names = {row['index'] for row in rows if isinstance(row, dict) and row.get('index')}
+    return sorted(names)
+
+
+def scroll_documents(client: _Client, index: str) -> list:
+    """Read every document in ``index`` as ``(doc_id, source)`` pairs via the scroll API."""
+    documents = []
+    body = {'size': _SCROLL_PAGE, 'query': {'match_all': {}}, 'sort': ['_doc']}
+    response = client.request('POST', f'/{index}/_search?scroll={_SCROLL_KEEPALIVE}', body)
+    scroll_id = response.get('_scroll_id')
+    try:
+        while True:
+            hits = response.get('hits', {}).get('hits', [])
+            if not hits:
+                break
+            for hit in hits:
+                documents.append((hit['_id'], hit.get('_source') or {}))
+            if not scroll_id:
+                break
+            response = client.request(
+                'POST', '/_search/scroll', {'scroll': _SCROLL_KEEPALIVE, 'scroll_id': scroll_id}
+            )
+            scroll_id = response.get('_scroll_id', scroll_id)
+    finally:
+        if scroll_id:
+            # A leaked scroll context expires on its own — never fail the export over it.
+            with contextlib.suppress(VoiceprintBackupError):
+                client.request('DELETE', '/_search/scroll', {'scroll_id': [scroll_id]})
+    return documents
+
+
+def _restorable_settings(raw: dict) -> dict:
+    """Filter a live index's settings down to the keys a ``PUT /<index>`` accepts."""
+    index_settings = (raw or {}).get('index', {})
+    kept = {key: index_settings[key] for key in _RESTORABLE_SETTINGS if key in index_settings}
+    return {'index': kept} if kept else {}
+
+
+def _alias_target(client: _Client, index_base: str) -> dict:
+    """Describe which concrete index the read alias points at, if it is an alias at all."""
+    if not client.exists(f'/_alias/{index_base}'):
+        return {}
+    mapping = client.request('GET', f'/_alias/{index_base}')
+    targets = sorted(mapping) if isinstance(mapping, dict) else []
+    if not targets:
+        return {}
+    return {'name': index_base, 'target': targets[0]}
+
+
+def do_export(client: _Client, index_base: str, out) -> int:
+    """Write the manifest line plus ``_bulk``-ready pairs for every speaker index.
+
+    Returns:
+        The total number of documents written.
+    """
+    indices = []
+    bulk_lines = []
+    total = 0
+    for name in speaker_index_names(client, index_base):
+        definition = client.request('GET', f'/{name}')
+        meta = definition.get(name, {})
+        documents = scroll_documents(client, name)
+        total += len(documents)
+        indices.append(
+            {
+                'name': name,
+                'doc_count': len(documents),
+                'digest': digest_documents(documents),
+                'mappings': meta.get('mappings', {}),
+                'settings': _restorable_settings(meta.get('settings', {})),
+            }
+        )
+        for doc_id, source in sorted(documents, key=lambda pair: pair[0]):
+            bulk_lines.append(json.dumps({'index': {'_index': name, '_id': doc_id}}))
+            bulk_lines.append(json.dumps(source))
+
+    manifest = {
+        'format': FORMAT_NAME,
+        'version': FORMAT_VERSION,
+        # time.gmtime, not datetime.now(UTC): this file executes on the OpenSearch
+        # container's python3, which is 3.9 — `datetime.UTC` landed in 3.11.
+        'created_at': time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime()),
+        'index_base': index_base,
+        'alias': _alias_target(client, index_base),
+        'indices': indices,
+        'total_docs': total,
+    }
+    out.write(json.dumps(manifest) + '\n')
+    for line in bulk_lines:
+        out.write(line + '\n')
+    return total
+
+
+def read_manifest(stream) -> tuple:
+    """Split an artifact into ``(manifest, bulk_lines)``, validating the format header."""
+    first = stream.readline()
+    if not first.strip():
+        raise VoiceprintBackupError(
+            'voiceprint artifact is empty — refusing to treat it as "no voiceprints"'
+        )
+    try:
+        manifest = json.loads(first)
+    except ValueError as exc:
+        raise VoiceprintBackupError(
+            f'voiceprint artifact has no manifest on line 1: {exc}'
+        ) from exc
+    if manifest.get('format') != FORMAT_NAME:
+        raise VoiceprintBackupError(
+            f'not a voiceprint artifact (format={manifest.get("format")!r})'
+        )
+    if manifest.get('version') != FORMAT_VERSION:
+        raise VoiceprintBackupError(
+            f'unsupported voiceprint artifact version {manifest.get("version")!r} '
+            f'(this build reads version {FORMAT_VERSION})'
+        )
+    return manifest, [line for line in (raw.rstrip('\n') for raw in stream) if line]
+
+
+def _bulk_load(client: _Client, lines: list) -> None:
+    """Replay the artifact's action/source pairs through ``_bulk`` in bounded batches."""
+    per_request = _BULK_DOCS_PER_REQUEST * 2
+    for start in range(0, len(lines), per_request):
+        batch = lines[start : start + per_request]
+        response = client.request('POST', '/_bulk', '\n'.join(batch) + '\n')
+        if response.get('errors'):
+            failures = [
+                item['index']['error']
+                for item in response.get('items', [])
+                if item.get('index', {}).get('error')
+            ]
+            raise VoiceprintBackupError(
+                f'bulk restore reported {len(failures)} failure(s): {failures[:3]}'
+            )
+
+
+def do_import(client: _Client, stream) -> dict:
+    """Recreate any missing speaker index, bulk-load the artifact, restore the alias.
+
+    Returns:
+        The artifact's manifest, so the caller can report what was expected.
+    """
+    manifest, lines = read_manifest(stream)
+    for entry in manifest.get('indices', []):
+        name = entry['name']
+        if client.exists(f'/{name}'):
+            continue
+        body = {'mappings': entry.get('mappings', {})}
+        settings = entry.get('settings') or {}
+        if settings:
+            body['settings'] = settings
+        client.request('PUT', f'/{name}', body)
+        print(f'   created index {name} from the backup mapping', file=sys.stderr)
+
+    _bulk_load(client, lines)
+
+    names = [entry['name'] for entry in manifest.get('indices', [])]
+    if names:
+        client.request('POST', '/' + ','.join(names) + '/_refresh')
+
+    alias = manifest.get('alias') or {}
+    if alias.get('name') and alias.get('target') and not client.exists('/_alias/' + alias['name']):
+        client.request('PUT', f'/{alias["target"]}/_alias/{alias["name"]}')
+        print(f'   restored alias {alias["name"]} -> {alias["target"]}', file=sys.stderr)
+    return manifest
+
+
+def do_verify(client: _Client, stream) -> list:
+    """Re-read the live cluster and compare it to the artifact.
+
+    Returns:
+        A list of human-readable mismatches; empty means the restore is proven.
+    """
+    manifest, _ = read_manifest(stream)
+    problems = []
+    for entry in manifest.get('indices', []):
+        name = entry['name']
+        if not client.exists(f'/{name}'):
+            problems.append(f'index {name} is missing after the restore')
+            continue
+        live = scroll_documents(client, name)
+        if len(live) != entry['doc_count']:
+            problems.append(
+                f'index {name}: {len(live)} document(s) present, backup holds {entry["doc_count"]}'
+            )
+            continue
+        live_digest = digest_documents(live)
+        if live_digest != entry['digest']:
+            problems.append(
+                f'index {name}: content digest mismatch — live {live_digest}, backup {entry["digest"]}'
+            )
+    alias = manifest.get('alias') or {}
+    if alias.get('name') and not client.exists('/_alias/' + alias['name']):
+        problems.append(f'read alias {alias["name"]} is missing after the restore')
+    return problems
+
+
+def _parse_args(argv: list) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('mode', choices=('export', 'import', 'verify'))
+    parser.add_argument('--index-base', default='speakers')
+    parser.add_argument('--host', default='127.0.0.1')
+    parser.add_argument('--port', type=int, default=9200)
+    return parser.parse_args(argv)
+
+
+def main(argv: list) -> int:
+    """Entry point. Returns a process exit code; never raises for an expected failure."""
+    args = _parse_args(argv)
+    client = _Client(args.host, args.port)
+    try:
+        if args.mode == 'export':
+            total = do_export(client, args.index_base, sys.stdout)
+            print(f'   exported {total} voiceprint document(s)', file=sys.stderr)
+            return 0
+        if args.mode == 'import':
+            manifest = do_import(client, sys.stdin)
+            print(
+                f'   imported {manifest.get("total_docs", 0)} voiceprint document(s)',
+                file=sys.stderr,
+            )
+            return 0
+        problems = do_verify(client, sys.stdin)
+        if problems:
+            for problem in problems:
+                print(f'   MISMATCH: {problem}', file=sys.stderr)
+            return 1
+        return 0
+    except VoiceprintBackupError as exc:
+        print(f'   ERROR: {exc}', file=sys.stderr)
+        return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Problem

Speaker voiceprints existed in **exactly one place** — the OpenSearch `speakers_v*`
indices — and nothing backed them up.

Verified against `master` before writing any code:

| Claim (issue #658) | Verdict |
|---|---|
| PostgreSQL stores no embedding vectors | **True.** `backend/app/models/media.py:505` says so in a comment; `SpeakerProfile` (`:485`) carries only `embedding_count` + `last_embedding_update`, and `Speaker` (`:553`) / `SpeakerCluster` (`:973`) have no vector column. |
| `./opentr.sh backup` is a bare `pg_dump`, no OpenSearch | **True.** `backup_database` in `scripts/common.sh` (moved there by #613) — `pg_dump` piped optionally through gpg, no OpenSearch interaction. |
| `DEFAULT_BACKUP_INCLUDE_OPENSEARCH = False` | **True**, `backend/app/core/constants.py:592`, with the comment *"OS is derived/rebuildable; pg-only this round"*. |
| That comment is wrong | **True for the speaker indices, correct for the rest.** Transcript/chunk indices really are rebuildable from Postgres; a voiceprint is not — re-deriving one needs the source media (which may be gone) plus a GPU re-embed run. |

The same wrong claim was repeated in `docs-site/docs/operations/backup-audit.md`
("None that matters — derived data", Severity Low) and in `backup-restore.md`'s
priority table. Both are corrected here.

## Approach: cover the backup, not a second source of truth

The vectors are read by kNN queries only OpenSearch can serve. A Postgres vector
column would be a *second* copy to keep in sync, not a fix — and a much larger
architecture change.

The CLI export is **document-level** (a portable NDJSON artifact) rather than the
OpenSearch snapshot API, for a concrete reason: a snapshot needs `path.repo`
allow-listed on the OpenSearch container, which only the `--with-backup` overlay
provides. A stock `./opentr.sh backup` would produce `unsupported` and no data. The
NDJSON artifact works on any stack, is inspectable, and — the point of the issue —
is **content-verifiable**.

## What changed

**CLI (`backup` / `restore`, shared by `opentr.sh` and `opentranscribe.sh`)**

- `backup` writes `<dump>.voiceprints.ndjson` beside the dump: line 1 is a manifest
  (per-index mappings, restorable settings, doc count, `sha256` content digest of
  every document), lines 2..n are `_bulk`-ready pairs. gpg-encrypted alongside an
  encrypted dump. **A failed export fails the whole backup.**
- `restore` locates the artifact from the dump's name (the `.gpg` suffix is stripped
  so both forms resolve to one stem), imports it **after** the database replay has
  been verified and **before** the restart decision, then **verifies** the live
  indices against the manifest. A zero-voiceprint restore is a failed restore, with
  services left stopped — the existing `#610` failure shape.
- Restore also reports whether `speaker_profile.embedding_count` agrees with the
  profile documents OpenSearch actually holds, so rows claiming embeddings that no
  longer exist are named at restore time instead of surfacing months later as
  "speaker matching stopped working".

**In-app scheduled backup** (separate path, and it did **not** cover this)

- `DEFAULT_BACKUP_INCLUDE_OPENSEARCH` is now `True`, with the wrong justification
  replaced. This is also the non-noisy choice: the scheduled backup only runs when
  `backup.destination` is a writable mount, which in practice means the
  `--with-backup` overlay — the same overlay that allow-lists `path.repo`.
- `opensearch_snapshot.perform_snapshot` now records how many voiceprints the
  snapshot covered, and an `unsupported`/`error` status names the voiceprints left
  with no copy anywhere.

**Where the work runs.** `scripts/voiceprint-backup.py` is piped into the OpenSearch
container's own `python3` (`python3 -c "$(cat …)"`). That needs no host tooling — so a
`curl | bash` install is covered identically to a git checkout — and it talks to
`127.0.0.1:9200` *inside* the container, so it still works while every application
container is stopped, which is exactly the state `restore_database` leaves them in.
It is written to run on **Python 3.9** (what the pinned OpenSearch image ships).

Nothing here reads or writes an OpenSearch `cosinesimil` score, so
`app/utils/cosine_space.py` does not apply — the digest is an exact content hash, never
a similarity comparison.

## Proof the tests would have caught the bug

Red baseline against a `git archive HEAD` tree with only the new test files copied in:

```
$ cd /tmp/redcheck658/backend && pytest tests/unit/test_voiceprint_backup_coverage.py
9 failed, 1 passed, 5 errors

FAILED test_backup_database_exports_the_speaker_indices
  AssertionError: backup_database must export the OpenSearch speaker indices — PostgreSQL
  stores no embedding vectors, so a pg_dump alone leaves the deployment's voiceprints with
  no recoverable copy anywhere (issue #658)
FAILED test_restore_database_imports_and_then_verifies_the_speaker_indices
FAILED test_the_voiceprint_restore_runs_after_the_database_has_been_verified
FAILED test_the_voiceprint_restore_runs_before_the_services_are_restarted
FAILED test_restore_database_reports_postgres_opensearch_voiceprint_consistency
FAILED test_scheduled_backups_include_opensearch_by_default
FAILED test_the_derived_rebuildable_justification_is_gone_from_the_constant
FAILED test_the_helper_is_shipped_to_self_hosted_installs
FAILED test_voiceprint_artifact_path_shares_one_stem_with_encrypted_and_plain_dumps
ERROR  (x5)  FileNotFoundError: '/tmp/redcheck658/scripts/voiceprint-backup.py'

$ pytest tests/integration/test_voiceprint_backup_roundtrip.py -k "survive or differs"
2 failed
  AssertionError: os_export_speaker_indices failed:
  --: line 1: os_export_speaker_indices: command not found
```

The first draft of `test_the_derived_rebuildable_justification_is_gone_from_the_constant`
**passed** against the unfixed tree — its window excluded the trailing comment it was
guarding. That is recorded in the test's docstring; it is why the red check is run.

Green on this branch: **20 passed** (5 integration against a real throwaway OpenSearch,
15 unit), plus **12,774 passed / 0 failed** across the whole `backend/tests` fast suite
against a throwaway migrated Postgres.

## How the restore is proven

`os_verify_speaker_restore` re-reads the live cluster and compares, per index, the
document count **and** a `sha256` over the id-sorted canonical JSON of every document
(embedding vectors included) against the manifest. The integration test asserts:

- 3 seeded documents round-trip with `restored == seeded` (256-dim vectors,
  component-for-component), after the index has been `DELETE`d outright — with a control
  assertion between the wipe and the restore proving the vectors really were gone;
- the read alias is restored onto the concrete index;
- **must-fire cases**: one changed vector component fails verification (`digest
  mismatch`), a present-but-empty index fails, and an empty/truncated artifact is refused
  rather than read as "this deployment has no voiceprints".

## Gates

| Gate | Result |
|---|---|
| `scripts/safe-precommit.sh run --all-files` | exit **0** |
| `scripts/safe-precommit.sh run --all-files --hook-stage pre-push` | exit **0** |
| `python3 scripts/audit-tests.py tests` | exit **0**, no un-allowlisted findings |
| `shellcheck -S warning scripts/common.sh` | exit **0** |

mypy caught one real defect in the new test (a heterogeneous dict literal erasing the
vector element type to `object`); fixed by naming the vectors, not by widening.

## Known gaps

- **The helper authenticates with nothing.** Correct for the shipped
  `DISABLE_SECURITY_PLUGIN=true` configuration (dev and prod both default to it), and the
  same assumption `scripts/speaker-profiles-backup.sh` already makes. On a deployment that
  enabled the security plugin, a 401/403 is reported as a hard failure naming the cause
  and pointing at the in-app scheduled backup — it never degrades to an empty artifact.
- **`--encrypt` prompts for the gpg passphrase twice** (dump, then artifact). Announced in
  the CLI output. Encrypting the artifact is not optional: it is biometric data.
- Issue #658's third fix item — making a verified backup a *precondition* of starting the
  v4 embedding migration (`POST /api/embedding-migration/start`) — is **not** in this PR.
  It is a separate API-surface change and belongs with the #572 migration work.
- The end-to-end `backup_database` / `restore_database` paths are covered by static
  wiring/ordering assertions plus the primitives' real round-trip; running the full CLI
  needs a live compose stack and was not exercised here.

Closes #658
