### PR TITLE
fix(scripts): fresh-destroy leaked the project network, silently

### DIFF
--- a/backend/tests/unit/test_opentr_fresh_destroy_network_leak.py
+++ b/backend/tests/unit/test_opentr_fresh_destroy_network_leak.py
@@ -1,0 +1,160 @@
+"""`fresh-destroy` must reclaim the project's network, or say loudly that it could not.
+
+Issue #772 — the third leak in `fresh_destroy`, after #767 closed profile-gated services
+and project-scoped image tags. Volumes and image tags each had an explicit reclaim step;
+the network had none. It got only whatever `docker compose down` managed, and `down` was
+wrapped in ``2>/dev/null || true``, so a network it failed to remove was indistinguishable
+from one it removed.
+
+Unlike a leaked container, nothing later makes this visible. **Eleven accumulated on the
+development host**, each holding a ``/16`` out of Docker's default pool (172.17-172.31),
+until ``docker network create`` began failing HOST-WIDE with "all predefined address pools
+have been fully subnetted" — blocking unrelated projects and a release task, with nothing
+pointing back at `fresh-destroy`.
+
+⚠️ Removal can genuinely fail for a cause this repo cannot fix: Docker reports
+``has active endpoints`` while the network shows ``containers=0`` and nothing is attached.
+That is a stale endpoint record; it survives teardown and only a daemon restart clears it
+(``docker network prune`` uses the same path and fails identically). So these tests do NOT
+assert that removal succeeds. They assert the two things that were actually wrong: that
+removal is **attempted**, and that a failure is **reported** rather than swallowed.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+OPENTR = REPO_ROOT / "opentr.sh"
+
+
+def _fresh_destroy_body() -> str:
+    src = OPENTR.read_text(encoding="utf-8")
+    match = re.search(r"^fresh_destroy\(\) \{$", src, re.M)
+    assert match, "fresh_destroy() not found in opentr.sh — renamed?"
+    end = re.search(r"^\}$", src[match.start() :], re.M)
+    assert end, "no closing brace for fresh_destroy()"
+    return src[match.start() : match.start() + end.end()]
+
+
+def test_the_down_exit_status_is_not_discarded() -> None:
+    """`|| true` on the teardown is what made a failed removal look like a success."""
+    body = _fresh_destroy_body()
+    down = [ln for ln in body.splitlines() if "docker compose $chain down" in ln]
+    assert down, "the `docker compose ... down` line is gone — did the teardown move?"
+    for line in down:
+        assert "|| true" not in line, (
+            "`docker compose down` still ends in `|| true`, so a failed teardown is "
+            f"reported as a successful one:\n  {line.strip()}"
+        )
+        assert "_down_rc" in line, (
+            f"the down exit status is not captured, so nothing can report it:\n  {line.strip()}"
+        )
+
+
+def test_the_network_removal_is_attempted_explicitly() -> None:
+    """Volumes and image tags each get an explicit reclaim; the network needs one too."""
+    body = _fresh_destroy_body()
+    assert "docker network rm" in body, (
+        "fresh_destroy never attempts `docker network rm`. `docker compose down` alone is "
+        "what leaked 11 networks — the project network needs the same explicit reclaim "
+        "step that volumes and image tags already have."
+    )
+    assert '_net="${proj}_default"' in body, (
+        "the network is not addressed by the project-scoped name `${proj}_default` — an "
+        "unscoped removal on this host is how an unrelated container was destroyed before"
+    )
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="needs bash")
+@pytest.mark.parametrize(
+    ("rm_rc", "must_say", "why"),
+    [
+        (0, "removed leftover network", "a successful reclaim should be stated"),
+        (1, "could NOT be removed", "a FAILED reclaim must be loud, not swallowed"),
+    ],
+)
+def test_it_reports_the_outcome_of_the_network_removal(tmp_path, rm_rc, must_say, why) -> None:
+    """Run the real fragment against a fake `docker` and read what it actually prints."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    # `network inspect` succeeds (the network exists); `network rm` returns rm_rc.
+    (bindir / "docker").write_text(
+        "#!/bin/bash\n"
+        'case "$1 $2" in\n'
+        '  "network inspect") exit 0 ;;\n'
+        f'  "network rm") exit {rm_rc} ;;\n'
+        "esac\n"
+        "exit 0\n"
+    )
+    (bindir / "docker").chmod(0o755)
+
+    body = _fresh_destroy_body()
+    start = body.index('local _net="${proj}_default"')
+    end = body.index("# Catch any stragglers", start)
+    fragment = body[start:end]
+
+    # `local` is only legal inside a function, so the fragment is wrapped in one —
+    # running it at top level aborts on line 1 and every assertion below would then be
+    # measuring a script that never ran.
+    script = (
+        "set -uo pipefail\n"
+        f'export PATH="{bindir}:$PATH"\n'
+        "probe() {\n"
+        '  local proj="otfresh-probe" name="probe" _down_rc=0\n'
+        f"{fragment}\n"
+        "}\n"
+        "probe\n"
+    )
+    proc = subprocess.run(["bash", "-c", script], capture_output=True, text=True, timeout=60)
+    combined = proc.stdout + proc.stderr
+    assert must_say in combined, f"{why}. Output was:\n{combined}"
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="needs bash")
+def test_the_failure_message_names_the_host_wide_consequence(tmp_path) -> None:
+    """A warning nobody can act on gets ignored; this one has to say what it costs.
+
+    The leak's whole danger is that its cost surfaces far away, as an unrelated
+    `docker network create` failure in another project. The message must connect the two.
+    """
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    (bindir / "docker").write_text(
+        '#!/bin/bash\ncase "$1 $2" in\n  "network inspect") exit 0 ;;\n'
+        '  "network rm") exit 1 ;;\nesac\nexit 0\n'
+    )
+    (bindir / "docker").chmod(0o755)
+
+    body = _fresh_destroy_body()
+    start = body.index('local _net="${proj}_default"')
+    end = body.index("# Catch any stragglers", start)
+
+    proc = subprocess.run(
+        [
+            "bash",
+            "-c",
+            "set -uo pipefail\n"
+            f'export PATH="{bindir}:$PATH"\n'
+            "probe() {\n"
+            '  local proj="otfresh-probe" name="probe" _down_rc=0\n'
+            + body[start:end]
+            + "\n}\nprobe\n",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    out = proc.stdout + proc.stderr
+    for needle, why in [
+        ("subnet", "must say the network still holds a subnet"),
+        ("host-wide", "must name the host-wide consequence, or nobody acts on it"),
+        ("daemon restart", "must say what actually clears a stale-endpoint network"),
+        ("prune", "must warn that `docker network prune` will NOT clear it"),
+    ]:
+        assert needle in out, f"failure message {why}. Output was:\n{out}"

--- a/opentr.sh
+++ b/opentr.sh
@@ -1619,7 +1619,49 @@ fresh_destroy() {
   # profile-gated services need the same treatment here, generically, rather than
   # enumerating every profile this repo happens to define today.
   # shellcheck disable=SC2086
-  COMPOSE_PROJECT_NAME="$proj" COMPOSE_PROFILES="*" docker compose $chain down -v --remove-orphans 2>/dev/null || true
+  local _down_rc=0
+  COMPOSE_PROJECT_NAME="$proj" COMPOSE_PROFILES="*" docker compose $chain down -v --remove-orphans 2>/dev/null || _down_rc=$?
+
+  # The NETWORK is the third leak in this function (issue #772), and it was the one
+  # resource with no explicit reclaim step: volumes and image tags each get one below,
+  # the network got only whatever `down` managed. `down`'s failure was discarded by
+  # `2>/dev/null || true`, so a network it could not remove was indistinguishable from
+  # one it did — and unlike a leaked container, nothing later makes the leak visible.
+  #
+  # It is not hypothetical and it is not cheap: ELEVEN accumulated on this host, each
+  # holding a /16 out of Docker's default pool (172.17-172.31), until
+  # `docker network create` began failing HOST-WIDE with "all predefined address pools
+  # have been fully subnetted" — blocking unrelated projects and a release task, with
+  # nothing pointing back here.
+  #
+  # ⚠️ Removal genuinely can fail for a reason we cannot fix: Docker reports
+  # `has active endpoints` while the network shows `containers=0` and no container,
+  # running or stopped, is attached. That is a stale endpoint record and it survives
+  # teardown; only a daemon restart clears it. So the goal here is NOT to guarantee
+  # removal — it is to make the failure LOUD and name the cost, while the operator can
+  # still act, instead of discovering it weeks later as an unrelated host-wide error.
+  local _net="${proj}_default"
+  if docker network inspect "$_net" >/dev/null 2>&1; then
+    if docker network rm "$_net" >/dev/null 2>&1; then
+      echo "  removed leftover network ${_net}"
+    else
+      echo "⚠️  network ${_net} could NOT be removed and is now leaked." >&2
+      echo "    It still holds a subnet from Docker's default pool. Enough of these and" >&2
+      echo "    \`docker network create\` fails host-wide for every project on this machine." >&2
+      echo "    Check: docker network inspect ${_net} --format '{{len .Containers}}'" >&2
+      echo "    If that prints 0, the endpoints are stale and only a Docker daemon restart" >&2
+      echo "    clears them — \`docker network prune\` uses the same path and will also fail." >&2
+    fi
+  fi
+
+  # A non-zero `down` is worth saying out loud even when the network came away cleanly:
+  # it means something in the teardown did not do what it said, and every check below
+  # this point is then reporting on a partial teardown.
+  if [ "$_down_rc" -ne 0 ]; then
+    echo "⚠️  \`docker compose down\` exited ${_down_rc} for ${proj} — teardown may be incomplete." >&2
+    echo "    Re-run: ./opentr.sh fresh-destroy ${name}   (or inspect: docker ps -a --filter label=com.docker.compose.project=${proj})" >&2
+  fi
+
   # Catch any stragglers the compose chain didn't own.
   if [ -n "$vols" ]; then
     echo "$vols" | xargs -r docker volume rm 2>/dev/null || true


### PR DESCRIPTION
Closes #772

Third leak in `fresh_destroy`, after #767 closed profile-gated services and project-scoped image tags. **Volumes and image tags each have an explicit reclaim step; the network had none** — it got only whatever `docker compose down` managed, and that call was wrapped in `2>/dev/null || true`, so a network `down` failed to remove was indistinguishable from one it removed.

Unlike a leaked container, nothing later makes it visible. **Eleven accumulated on the dev host**, each holding a `/16` from Docker's default pool (172.17–172.31), until `docker network create` began failing **host-wide** with `all predefined address pools have been fully subnetted` — blocking unrelated projects and a release task, with nothing pointing back here.

## What changed

- the `down` exit status is **captured**, not discarded
- the project network is reclaimed **explicitly** by its scoped name `${proj}_default`
- both outcomes are reported

## ⚠️ This does not guarantee removal, and doesn't pretend to

Docker can refuse with `has active endpoints` while reporting `containers=0` with nothing attached — a stale endpoint record that survives teardown and is cleared only by a **daemon restart**. `docker network prune` uses the same path and fails identically; all 11 on this host refuse it today.

So the goal is to make the failure **loud and actionable** while the operator can still do something, instead of it surfacing weeks later as an unrelated host-wide error. The message states that a subnet is still held, that enough of these break `docker network create` for *every* project on the machine, how to confirm the endpoints are stale, and that prune will not help. A warning nobody can act on gets ignored.

## Tests

Drive the **real fragment out of the real script** against a fake `docker`, and assert what it *prints* for both `rm` outcomes. Asserting that removal succeeds would be wrong — failure is a legitimate state here, so the tests check that it's **attempted** and that failure is **reported**, which is what was actually broken.

Two structural checks alongside: `|| true` is gone from the teardown, and the removal is addressed by the project-scoped name (an unscoped removal on this host is how an unrelated container was destroyed before).

Red-checked against pre-fix master: **all 5 fail**. Green on the fix: **5 pass**. `bash -n` and `shellcheck -S warning` clean.

## Related, not fixed here

`--seed-benchmark` can be silently skipped: `start_app`'s health wait does a hard `exit 1` on an unhealthy service **before** the seeding block, so a crash-looping frontend means no seeding and no message. Structurally supported by the code, not measured — the run that suggested it had its evidence destroyed by a `tail -25`. Recorded on #772 rather than asserted, with the durable takeaway being operational: **check the file count before trusting a visual-baseline refresh**, since a silently-empty library produces "fresh" baselines that are worse than stale ones.
