### PR TITLE
test(chat): make the retention sweep tests independent of database contents

### DIFF
--- a/backend/tests/test_chat_retention.py
+++ b/backend/tests/test_chat_retention.py
@@ -94,6 +94,38 @@ def _exists(db, conversation_id: int) -> bool:
     )
 
 
+@pytest.fixture(autouse=True)
+def _only_this_tests_rows_are_sweepable(db_session):
+    """Age every pre-existing conversation forward, so the sweep can only see ours.
+
+    The sweep selects by AGE across the WHOLE table — no user filter, no test
+    scoping — so on a shared database every assertion on ``result["deleted"]``
+    silently counts whatever real conversations happen to be older than the
+    window too. Against a dev stack that is not a hypothetical: this file failed
+    three tests with ``assert 9 == 1`` and ``assert 8 == 0`` purely because the
+    database held 8 aged conversations of its own, and the cap test's second
+    sweep found more rows waiting than the 2 it created. CI never noticed because
+    it gets a fresh Postgres; the failures land only on a developer's machine,
+    for a reason that has nothing to do with the code under test.
+
+    A baseline-delta assertion would fix the first two but not the cap test,
+    whose whole subject is how a bounded run splits a KNOWN population across
+    ticks. Normalising the population is what makes all three independent of what
+    the database happens to contain.
+
+    Safe, and it does not touch real data: ``db_session`` runs each test inside a
+    savepoint that is rolled back at teardown, and ``_run_sweep`` points the sweep
+    at that same session — so these writes live and die inside the test, exactly
+    like the deletions the sweep itself performs.
+    """
+    now = datetime.now(UTC)
+    db_session.query(ChatConversation).update(
+        {ChatConversation.created_at: now, ChatConversation.last_message_at: now},
+        synchronize_session=False,
+    )
+    db_session.commit()
+
+
 # --- the safety property -----------------------------------------------------
 
 


### PR DESCRIPTION
Three tests in `tests/test_chat_retention.py` fail on any database that already holds conversations older than the retention window — for a reason that has nothing to do with the code under test. Found while running the full backend suite locally against the dev stack.

```
assert result["deleted"] == 1   ->  assert 9 == 1
assert result["deleted"] == 0   ->  assert 8 == 0
test_a_run_is_capped_and_reports_truncation
```

## Cause

The sweep selects by **age across the whole `chat_conversation` table** — no user filter, no test scoping (`app/tasks/chat_retention.py:53-70`). So an assertion on `result["deleted"]` counts every real row that qualifies, not just the fixtures the test created. This dev database holds 15 such rows today.

CI never sees it, because each job gets a fresh Postgres. The failures land **only on a developer's machine**, and only on one whose dev data has aged past the window — which is the worst place for them, since the natural reading is "my branch broke something."

Reproduced at `-n0`, single worker: `3 failed, 6 passed`. That rules out cross-worker contamination; an earlier reading of the `[gw0]`/`[gw3]` tags in an `-n 4` run had it as workers eating each other's fixtures, and a single-worker repro kills that.

## No data is at risk, and none was lost establishing this

`_run_sweep` points the sweep at the test's own `db_session`, which runs inside a savepoint rolled back at teardown, so the deletions live and die inside the test. The fixture's own comment says so. Verified against the live dev stack rather than assumed: 36 conversations before and after, and all 32 rows in `backups/opentranscribe_backup_20260822_175255.sql` still present (diffed by uuid, 0 missing).

## The fix

Normalise the population instead of loosening an assertion. An autouse fixture ages every pre-existing conversation forward **inside the test transaction**, so the sweep can only ever see rows the test created.

A baseline-delta assertion would have fixed the first two tests but not the cap test, whose subject is precisely how a bounded run splits a **known** population across ticks. And relaxing `== 1` to `>= 1` would delete the property each test exists to prove.

## Still falsifiable — verified by mutation, not by reading

Each mutation applied to a `git archive` tree, so the shared checkout was never mutated:

| mutation | test that fails |
|---|---|
| `.limit(MAX_DELETIONS_PER_RUN)` -> `.limit(10_000)` | `test_a_run_is_capped_and_reports_truncation` |
| window widened by a day (`<` -> `<=`, `retention_days + 1`) | `test_the_boundary_is_not_off_by_a_day` |

Each is caught by exactly the test that owns that property, and by no other — so the fixture normalises the population without blunting anything.

Before: `3 failed, 6 passed`. After: `9 passed`.

## Scope

One file, tests only. No production code touched. Deliberately **not** folded into #802 / #806 / #807 — all three are green and awaiting a merge decision, and re-opening their CI for an unrelated test fix would be a poor trade.