### PR TITLE
docs(release): regenerate the roadmap and record the v0.5.0 blocker fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -363,6 +363,49 @@ A tag was either yours alone or published to the whole deployment, so giving one
 
 ### Fixed
 
+- **GPU workers were SIGKILLed 10 seconds into a stop, with no shutdown handler** (#782).
+  `opentr.sh stop` gave a CUDA-holding worker Docker's default 10-second grace period and no
+  chance to release the device, so a stop during transcription could leave the GPU wedged. A
+  `worker_shutting_down` handler now releases GPU resources before the drain, and every
+  CUDA-holding service carries `stop_grace_period: ${OT_STOP_GRACE_GPU:-30}s`. The 30 seconds
+  is measured, not guessed — worst clean stop across three runs on an idle A6000 was 4.44 s.
+  It is deliberately not larger: a SIGTERM arriving during **boot** is never handled, so the
+  container burns the whole window and is SIGKILLed anyway (31.09 s at T+2s versus 4.55 s once
+  ready), and a longer value only lengthens that hang.
+  ⚠️ **This covers an idle or between-stages worker, not one mid-decode** (#809). With
+  `--pool=threads`, `executor.shutdown(wait=True)` blocks the shutdown signal until the running
+  task returns, so no handler can preempt an in-flight transcription; it still runs to the
+  ceiling and is SIGKILLed. Releasing earlier instead would free VRAM under a live CUDA kernel,
+  which is worse. Stopping a worker mid-transcription therefore remains unsafe.
+- **The docs image shipped on end-of-life Node 20** (#780). Dependabot's Docker ecosystem
+  rewrites `FROM` lines and nothing else, so a bump moved the frontend to `node:26-alpine` and
+  left `.nvmrc`, three workflow literals, and `docs-site/` behind — and `/docs-site` was never
+  a bump candidate at all. Every Node build stage is now pinned from one source and gated
+  against future drift, including an EOL-date check so three files agreeing on an obsolete
+  major cannot pass. Running the frontend suite on the version the image actually ships also
+  surfaced a real incompatibility: Node ≥26 predefines a `localStorage` global that shadows
+  jsdom's, which vitest then declines to install, so every test touching storage saw
+  `undefined`.
+- **Release assets had no checksums, and the SBOM was attached by glob** (#781). `finish`
+  attached artifacts with a bare existence glob, which was vacuous in both directions: three
+  stale `*-sbom.json` files are git-tracked, so presence proved only that `git checkout` had
+  run, while the offline package was globbed from `dist/*.tar.gz` when the builder writes
+  `offline-package-build/linux/*.tar.xz` — wrong directory and wrong extension, so it had
+  never been attached to any release. The asset set is now derived per published leg and
+  checksummed.
+- **`FROM_VERSIONS` was documented but never implemented** (#783), so the upgrade rehearsal
+  silently ignored it and always tested the derived single hop. It now overrides the
+  derivation, and the skip-version upgrade policy is stated rather than implied.
+- **No patch/hotfix path existed** (#784), despite four of the last five minor releases needing
+  one within 24 hours. Hotfixes now branch from `release/<major>.<minor>`, and release
+  validation runs on those branches so a hotfix PR gets the same metadata CI as one onto
+  `master`.
+- **Chat retention tests depended on the contents of the developer's database.** The sweep
+  selects by age across the whole table, so asserting on the returned delete count also counted
+  whatever real conversations happened to be older than the window — failing locally, on a
+  machine whose dev data had simply aged, for a reason unrelated to the code. CI never saw it,
+  because each job gets a fresh Postgres. The test population is now normalised inside the test
+  transaction rather than the assertions being loosened.
 - **Pre-release UI defect wave** (#739–#746, #649). Eight defects found by a UX/UI review of
   the release candidate, plus an audit of every path sharing their root cause. The upload
   wizard had a dead Skip button and resized between steps; its fixed-height body now fills so

--- a/docs-site/src/data/roadmap.json
+++ b/docs-site/src/data/roadmap.json
@@ -6,11 +6,11 @@
       "version": "v0.5.0",
       "headline": "Ship what is already built",
       "summary": "Native diarization, corpus-scale chat, redaction and the identity overhaul, published without adding one more feature.",
-      "stage": "now",
+      "stage": "complete",
       "released": false,
       "scheduled": true,
       "total": 275,
-      "closed": 270,
+      "closed": 275,
       "areas": [
         {
           "key": "asr-engines",
@@ -48,7 +48,7 @@
           "scope": "Docs site, release pipeline, repo tooling",
           "known": true,
           "total": 6,
-          "closed": 2,
+          "closed": 6,
           "issues": [
             {
               "number": 772,
@@ -58,22 +58,22 @@
             {
               "number": 780,
               "title": "build(docs): docs image ships on EOL Node 20 while the frontend is on 26",
-              "done": false
+              "done": true
             },
             {
               "number": 781,
               "title": "fix(release): release assets have no checksums, and the SBOM is attached by glob rather than gated",
-              "done": false
+              "done": true
             },
             {
               "number": 783,
               "title": "fix(release): FROM_VERSIONS is documented but never implemented, and no skip-version upgrade policy is stated",
-              "done": false
+              "done": true
             },
             {
               "number": 784,
               "title": "task(release): no patch/hotfix path exists — 4 of the last 5 minors needed one within 24 hours",
-              "done": false
+              "done": true
             },
             {
               "number": 800,
@@ -403,7 +403,7 @@
           "scope": "Build, deploy, workers, GPU tuning, governance",
           "known": true,
           "total": 101,
-          "closed": 100,
+          "closed": 101,
           "issues": [
             {
               "number": 21,
@@ -908,7 +908,7 @@
             {
               "number": 782,
               "title": "fix(gpu): opentr.sh stop SIGKILLs GPU workers after 10s — no grace period, no shutdown handler",
-              "done": false
+              "done": true
             }
           ]
         },
@@ -1513,7 +1513,7 @@
       "version": "v0.6.0",
       "headline": "Interface polish, and chat measured",
       "summary": "A full UI pass over what v0.5.0 shipped, plus real metrics for search and chat answer quality instead of assumptions.",
-      "stage": "next",
+      "stage": "now",
       "released": false,
       "scheduled": true,
       "total": 29,
@@ -1740,7 +1740,7 @@
       "version": "v0.7.0",
       "headline": "Run it in public",
       "summary": "Publish the inert public demo, and put in place the spend limits, alerting and dependency hygiene you only miss once strangers are using it.",
-      "stage": "later",
+      "stage": "next",
       "released": false,
       "scheduled": true,
       "total": 9,


### PR DESCRIPTION
Release prep for v0.5.0. Both halves were stale in a way that would have shipped wrong.

## Roadmap

Closing #780–#784 put `docs-site/src/data/roadmap.json` out of date — `generate-roadmap.py --check` confirms it. **v0.5.0 now reads 275/275.**

⚠️ Do not assume the `roadmap.yml` automation handles this. Its `chore/roadmap-data` branch exists but has **never opened a PR**, so the regeneration has been landing nowhere. Worth a follow-up on its own.

## CHANGELOG

Entries for the five blockers (#780–#784) plus the chat retention test fix, all under `## [Unreleased]` so `20-bump.sh` stamps the real tag date.

## The #782 entry states a limitation, deliberately

Closing #782 on "the files are present on master" was my error. Two of its four acceptance criteria are **not** met — AC#1 (an in-progress transcription survives a stop) and AC#4 (requeue). With `--pool=threads`, `executor.shutdown(wait=True)` blocks the shutdown signal until the running task returns, so no handler can preempt an in-flight transcription: it still runs to the grace ceiling and is SIGKILLed. Releasing earlier instead would free VRAM under a live CUDA kernel, which is worse. Tracked as #809 on v0.6.0.

So the entry says what shipped — an idle or between-stages worker shuts down cleanly — and carries an explicit warning that stopping a worker mid-transcription remains unsafe. A changelog reading "GPU workers now shut down cleanly" would land, for an operator, as permission to do exactly the thing that has wedged this machine twice and required a full restart.

## Verified rather than asserted

```
generate-roadmap.py --check              -> up to date
check-version-consistency.py --mode ci   -> 7 passed, 0 failed, 1 warning
```

The warning is the expected absent `## [0.5.0] - YYYY-MM-DD` heading, which the `bump` stage stamps. Not a finding.

Docs and data only — no code, no tests, no production behaviour.