### PR TITLE
fix(scripts): keep stack bring-up diagnostics instead of discarding them

### DIFF
--- a/scripts/lib/dev-test-overlays.sh
+++ b/scripts/lib/dev-test-overlays.sh
@@ -368,9 +368,28 @@ setup_overlays() {
         local with_flags=() f
         for f in "${OVERLAYS_NEEDED[@]}"; do with_flags+=("--with-$f"); done
         echo -e "${YELLOW}==>${NC} bringing up overlays in one batched call: ${with_flags[*]}"
-        if ! "$REPO_ROOT/opentr.sh" start dev "${with_flags[@]}" >/dev/null 2>&1; then
-            echo -e "${RED}error:${NC} failed to bring up overlays (${with_flags[*]}) — run" \
-                 "'./opentr.sh start dev ${with_flags[*]}' manually to see why" >&2
+        # Capture rather than discard. `>/dev/null 2>&1` here threw away the ONLY
+        # evidence of why a bring-up failed, and `opentr.sh start` prints `compose ps`
+        # plus 50 lines of logs on failure precisely so someone can read them. The
+        # error then told the operator to re-run the whole thing by hand — a rebuild
+        # across a 10-file overlay chain — to see output that had already been
+        # produced and dropped. Worse, a re-run does not reproduce a transient: the
+        # one real occurrence was a Keycloak start that wedged under concurrent
+        # `--build` I/O and came up in 28s once the machine was quiet, so the manual
+        # re-run would have shown a healthy stack and no cause.
+        # REPORT_DIR is run-dev-tests.sh's per-run mktemp dir, so the bring-up log lands
+        # beside the phase logs. Falls back to $TMPDIR for any other caller of this lib.
+        local overlay_log="${REPORT_DIR:-${TMPDIR:-/tmp}}/overlay-bringup.log"
+        if ! "$REPO_ROOT/opentr.sh" start dev "${with_flags[@]}" >"$overlay_log" 2>&1; then
+            echo -e "${RED}error:${NC} failed to bring up overlays (${with_flags[*]})" >&2
+            echo "--- last 40 lines of $overlay_log ---" >&2
+            tail -40 "$overlay_log" >&2
+            echo "--- full output: $overlay_log ---" >&2
+            # Which container is unhealthy is the first question every time, and it is
+            # not always in compose's own output.
+            echo "--- containers not running/healthy ---" >&2
+            docker ps -a --format '{{.Names}}\t{{.Status}}' \
+                | grep -Ev 'Up .*healthy|Up [0-9]' >&2 || true
             exit "$EXIT_PRECONDITION"
         fi
         for f in "${OVERLAYS_TO_START[@]}"; do

--- a/scripts/lib/dev-test-overlays.sh
+++ b/scripts/lib/dev-test-overlays.sh
@@ -8,6 +8,46 @@
 # YELLOW/NC, EXIT_PRECONDITION, and the mode booleans (RUN_BACKEND/RUN_E2E/ALL_OVERLAYS/
 # NO_OVERLAYS/WITH_GPU_SCALE).
 
+# ── Bringing a stack up, with its diagnostics KEPT ───────────────────────────────
+#
+# Every caller here ran `opentr.sh start dev ... >/dev/null 2>&1` and, on failure, told
+# the operator to re-run it by hand "to see why". That discarded the only evidence:
+# `opentr.sh start` prints `compose ps` plus 50 lines of service logs on exactly that
+# path, specifically so somebody can read them. Observed: a --full gate exited 3 after
+# ~20 minutes having never reached a test, and its entire log was six lines with no
+# cause in it.
+#
+# Re-running by hand is not a substitute, which is why this is a shared helper rather
+# than three copies of a fix. The one real occurrence was a Keycloak start that wedged
+# under the concurrent `--build` I/O of a 10-file overlay chain and then came up in
+# 28.6s once the machine was quiet — a manual re-run would have shown a healthy stack
+# and no cause at all. The advice in the old error message destroys the evidence it asks
+# for.
+#
+# Args: $1 = human description used in the error line
+#       $2 = log basename (no extension)
+#       $@ = flags passed through to `opentr.sh start dev`
+start_stack_or_die() {
+    local what="$1" logname="$2"
+    shift 2
+    # REPORT_DIR is run-dev-tests.sh's per-run mktemp dir, so this lands beside the phase
+    # logs. Falls back to $TMPDIR for any other caller of this library.
+    local log="${REPORT_DIR:-${TMPDIR:-/tmp}}/${logname}.log"
+    if "$REPO_ROOT/opentr.sh" start dev "$@" >"$log" 2>&1; then
+        return 0
+    fi
+    echo -e "${RED}error:${NC} failed to bring up ${what}" >&2
+    echo "--- last 40 lines of $log ---" >&2
+    tail -40 "$log" >&2
+    echo "--- full output: $log ---" >&2
+    # Which container is unhealthy is the first question every time, and compose's own
+    # output does not always name it.
+    echo "--- containers not running/healthy ---" >&2
+    docker ps -a --format '{{.Names}}\t{{.Status}}' | grep -Ev 'Up .*healthy|Up [0-9]' >&2 || true
+    exit "$EXIT_PRECONDITION"
+}
+
+
 # ---------------------------------------------------------------- overlay table (issue #630)
 #
 # Model: opentr.sh's own leg-table convention (scripts/test-matrix.sh's LEGS array) — one
@@ -368,30 +408,7 @@ setup_overlays() {
         local with_flags=() f
         for f in "${OVERLAYS_NEEDED[@]}"; do with_flags+=("--with-$f"); done
         echo -e "${YELLOW}==>${NC} bringing up overlays in one batched call: ${with_flags[*]}"
-        # Capture rather than discard. `>/dev/null 2>&1` here threw away the ONLY
-        # evidence of why a bring-up failed, and `opentr.sh start` prints `compose ps`
-        # plus 50 lines of logs on failure precisely so someone can read them. The
-        # error then told the operator to re-run the whole thing by hand — a rebuild
-        # across a 10-file overlay chain — to see output that had already been
-        # produced and dropped. Worse, a re-run does not reproduce a transient: the
-        # one real occurrence was a Keycloak start that wedged under concurrent
-        # `--build` I/O and came up in 28s once the machine was quiet, so the manual
-        # re-run would have shown a healthy stack and no cause.
-        # REPORT_DIR is run-dev-tests.sh's per-run mktemp dir, so the bring-up log lands
-        # beside the phase logs. Falls back to $TMPDIR for any other caller of this lib.
-        local overlay_log="${REPORT_DIR:-${TMPDIR:-/tmp}}/overlay-bringup.log"
-        if ! "$REPO_ROOT/opentr.sh" start dev "${with_flags[@]}" >"$overlay_log" 2>&1; then
-            echo -e "${RED}error:${NC} failed to bring up overlays (${with_flags[*]})" >&2
-            echo "--- last 40 lines of $overlay_log ---" >&2
-            tail -40 "$overlay_log" >&2
-            echo "--- full output: $overlay_log ---" >&2
-            # Which container is unhealthy is the first question every time, and it is
-            # not always in compose's own output.
-            echo "--- containers not running/healthy ---" >&2
-            docker ps -a --format '{{.Names}}\t{{.Status}}' \
-                | grep -Ev 'Up .*healthy|Up [0-9]' >&2 || true
-            exit "$EXIT_PRECONDITION"
-        fi
+        start_stack_or_die "overlays (${with_flags[*]})" "overlay-bringup" "${with_flags[@]}"
         for f in "${OVERLAYS_TO_START[@]}"; do
             OVERLAYS_STARTED_BY_US+=("$f")
             local svc="${OVERLAY_SERVICE[$f]}"


### PR DESCRIPTION
**Test-infrastructure fix, wanted on master now** — it makes the next gate failure debuggable. Split out of my release-docs branch so it isn't queued behind a blog post.

## The bug

All three stack bring-ups in the dev-test path ran:

```bash
"$REPO_ROOT/opentr.sh" start dev "${flags[@]}" >/dev/null 2>&1
```

and, on failure, printed only *"run './opentr.sh start dev …' manually to see why"*.

`opentr.sh start` prints `compose ps` plus 50 lines of service logs on **exactly that path**, specifically so someone can read them. All of it went to `/dev/null`.

**Observed today:** a `run-dev-tests.sh --full` exited 3 after ~20 minutes having never reached a test, and the entire log was six lines with no cause in it.

## Re-running by hand is not a substitute

This is the part that makes it worth a fix rather than a shrug. The real failure was a Keycloak start that wedged under the concurrent `--build` I/O of a 10-file overlay chain, then came up in 28.6s once the machine was quiet. **A manual re-run would have shown a healthy stack and no cause at all** — the error message's own advice destroys the evidence it asks for. It was only diagnosed because someone inspected the live container before anything changed.

## The fix

One `start_stack_or_die` helper, used by all three call sites (overlays, `--with-gpu-scale`, `--with-llm-test`) rather than the same block copied three times. It:

- tees to `$REPORT_DIR/<name>.log` — `run-dev-tests.sh`'s per-run mktemp dir, beside the phase logs;
- prints the last 40 lines plus the full path;
- lists containers that are **not** running/healthy — the first question asked every time, and not always in compose's own output.

## Verified

`bash -n`, `shellcheck --severity=warning`, and the failure block driven with a stub producer to confirm it actually prints the error, the path, and the captured output.

One file. No behaviour change on the success path.