### PR TITLE
test(quality): pin the printf exemption ceiling below one stdio buffer

### DIFF
--- a/backend/tests/unit/test_opentr_docker_probe_sigpipe.py
+++ b/backend/tests/unit/test_opentr_docker_probe_sigpipe.py
@@ -1013,8 +1013,13 @@ def test_the_scanner_fires_on_every_shape_the_two_bug_fixes_could_have_blinded_i
 
 
 #: Payload size the ``printf`` exemption above is asserted safe at. Deliberately tiny --
-#: see the ceiling this pins.
-_PRINTF_SAFE_BYTES = 4 * 1024
+#: see the ceiling this pins. It has to stay below one stdio buffer: the exemption's
+#: premise is that the payload leaves in ONE ``write(2)``, and bash's ``printf`` builtin
+#: flushes through stdio, whose buffer for a pipe is ``st_blksize`` -- 4096 B on Linux.
+#: ``4 * 1024`` plus the ``FIRST\n`` header and the trailing newline is 4103 B, i.e. two
+#: writes, and under xdist load ``head`` can leave between them, which is exactly the
+#: SIGPIPE this test says a builtin cannot get (#918). 1 KiB is one write on every host.
+_PRINTF_SAFE_BYTES = 1024
 #: ...and a size at which the same construct provably breaks. Measured on this host
 #: 2026-09-07, `printf 'FIRST\n<payload>\n' | head -1` under `set -euo pipefail`:
 #: 1 KiB 0/100 aborts, 7 KiB 0/100, **16 KiB 4/100**, 32 KiB 31/100, 60 KiB 100/100,


### PR DESCRIPTION
Fixes #918

## What was racing

`test_the_printf_exemption_has_a_measured_ceiling` asserts two things: that `printf "FIRST\n<4 KiB>\n" | head -1` completes under `set -euo pipefail` (the exemption is safe), and that 256 KiB does not (the ceiling exists). The "safe" half rests on the premise stated in the docstring: the payload reaches the pipe in one `write(2)`, so the reader cannot leave first.

That premise does not hold at 4 KiB. bash's `printf` builtin writes through stdio, and glibc sizes a pipe's stdio buffer from `st_blksize`, which is 4096 B on Linux. `FIRST\n` + 4096 bytes + `\n` is 4103 B, so the builtin flushes it as two writes (4096 B when the buffer fills, 7 B at the end). `head -1` has its line after the first write; under xdist load it can exit before the second one lands, and the builtin then takes the SIGPIPE that `pipefail` surfaces, which is the intermittent failure in the report (fails in the full suite, passes alone with `-n0`).

## Change

`_PRINTF_SAFE_BYTES` goes from `4 * 1024` to `1024` with a comment that names the bound it has to stay under (one stdio buffer) and why. The payload then leaves in a single write on every host, so the safe half is a property of the construct again rather than of scheduling. `_PRINTF_BROKEN_BYTES` (256 KiB) is unchanged; the ceiling assertion still holds.

This is in line with `backend/tests/CLAUDE.md`: the fixed size was calibrated on an idle machine and the assumption behind it stopped holding under load.

## Verification

- The test module executed directly against the change on macOS: both halves pass (`safe bytes: 1024`, `broken bytes: 262144`).
- Reading the pipe with a delayed reader shows 1 KiB + header arriving as a single 1031-byte chunk. On macOS a pipe's `st_blksize` is 64 KiB, so even the old 4103 B arrived in one chunk there, which matches the report that the failure only shows on the Linux CI hosts; I could not run a Linux container here to watch the 4096/7 split directly, so that part of the explanation is from glibc's buffering behaviour rather than a trace.
