### PR TITLE
docs(release): close the v0.5.0 CHANGELOG gap and six pre-cut doc/CI defects

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,12 @@
 version: 2
+# ⚠️ READ BEFORE CHASING AN ISSUE NUMBER IN THIS FILE (issue #792).
+# The `ignore:` rules below cite **#234** (5 sites) and **#256**. BOTH ARE CLOSED — #234 on
+# 2026-06-05. They are kept as historical provenance for *why* each major was deferred, NOT as
+# live tracking: no open issue owns these deferrals, so nothing will re-raise them on its own.
+# Each rule's reason is therefore written out in full beside it and stands on its own. When you
+# do a coordinated major-upgrade pass, re-evaluate every rule here from its stated reason
+# rather than from the issue link.
+#
 # Low-clutter dependency updates: weekly, but GROUPED so each ecosystem produces a
 # single batched PR (not one-per-package) — i.e. one frontend (npm) PR and one
 # backend (pip) PR per week, plus a grouped GitHub Actions PR. Known-bad versions

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -139,6 +139,23 @@ jobs:
               - 'requirements*.txt'
               - '.github/workflows/pre-commit.yml'
               - 'alembic.ini'
+              # ⚠️ The four entries below are NOT incidental (issue #793).
+              #
+              # `Backend Tests (pytest)` is a REQUIRED check, and branch protection treats a
+              # SKIPPED required check as SATISFIED. So a PR touching only these files used to
+              # merge with the backend suite never having run — confirmed live on run
+              # 34017549729 (PR #774), where both required checks report `skipped`.
+              #
+              # That is exactly backwards, because ~55 tests under `backend/tests/unit/` exist
+              # specifically to guard these files: `test_opentr_stop_container_scoping.py`,
+              # `test_shell_expansion_guards.py`, `test_opentr_fresh_aux_isolation.py`,
+              # `test_precommit_stage_ci_parity.py`, the compose-validation suites. And
+              # `opentr.sh stop` once destroyed 16 unrelated containers (#693) — it is the last
+              # file that should merge untested.
+              - 'opentr.sh'
+              - 'opentranscribe.sh'
+              - 'scripts/**'
+              - 'docker-compose*.yml'
             frontend:
               - 'frontend/**'
               - '.github/workflows/pre-commit.yml'
@@ -217,7 +234,7 @@ jobs:
         working-directory: backend
         run: python -m alembic upgrade head
 
-      - name: Run unit/API test suite (with coverage, report-only)
+      - name: "Run unit/API test suite (coverage ENFORCED via pyproject fail_under)"
         working-directory: backend
         run: |
           # pipefail is REQUIRED: GitHub's default shell is `bash -e {0}` WITHOUT
@@ -226,7 +243,7 @@ jobs:
           set -o pipefail
           pytest tests/ --cov=app --cov-report=term | tee pytest-output.txt
           {
-            echo "## Backend Test Coverage (report-only)"
+            echo "## Backend Test Coverage (enforced floor: pyproject fail_under)"
             echo '```'
             tail -40 pytest-output.txt
             echo '```'

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -110,7 +110,7 @@ jobs:
       # Report-only by design: this step's job is to produce the SARIF the next
       # step uploads. Gating here would trade the Security tab for a red X.
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.36.0  # pinned (#792): @master floats inside the job that gates releases
         with:
           image-ref: opentranscribe-backend:${{ github.sha }}
           format: 'sarif'
@@ -127,14 +127,14 @@ jobs:
       # THE GATE. Prints everything CRITICAL..MEDIUM for the human reading the
       # log, and fails only on CRITICAL with a published fix.
       - name: Run Trivy vulnerability scanner (table output)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.36.0  # pinned (#792): @master floats inside the job that gates releases
         with:
           image-ref: opentranscribe-backend:${{ github.sha }}
           format: 'table'
           severity: 'CRITICAL,HIGH,MEDIUM'
 
       - name: Fail on fixable CRITICAL CVEs (Trivy)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.36.0  # pinned (#792): @master floats inside the job that gates releases
         with:
           image-ref: opentranscribe-backend:${{ github.sha }}
           format: 'table'
@@ -200,7 +200,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.36.0  # pinned (#792): @master floats inside the job that gates releases
         with:
           image-ref: opentranscribe-frontend:${{ github.sha }}
           format: 'sarif'
@@ -215,14 +215,14 @@ jobs:
           category: 'trivy-frontend'
 
       - name: Run Trivy vulnerability scanner (table output)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.36.0  # pinned (#792): @master floats inside the job that gates releases
         with:
           image-ref: opentranscribe-frontend:${{ github.sha }}
           format: 'table'
           severity: 'CRITICAL,HIGH,MEDIUM'
 
       - name: Fail on fixable CRITICAL CVEs (Trivy)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.36.0  # pinned (#792): @master floats inside the job that gates releases
         with:
           image-ref: opentranscribe-frontend:${{ github.sha }}
           format: 'table'
@@ -270,7 +270,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Run Trivy vulnerability scanner on repository
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.36.0  # pinned (#792): @master floats inside the job that gates releases
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -279,7 +279,7 @@ jobs:
           skip-dirs: 'node_modules,venv,.venv'
 
       - name: Fail on fixable CRITICAL dependency CVEs
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.36.0  # pinned (#792): @master floats inside the job that gates releases
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -290,7 +290,7 @@ jobs:
           skip-dirs: 'node_modules,venv,.venv'
 
       - name: Run Trivy config scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.36.0  # pinned (#792): @master floats inside the job that gates releases
         with:
           scan-type: 'config'
           scan-ref: '.'
@@ -301,7 +301,7 @@ jobs:
       # `ignore-unfixed` is meaningless for misconfiguration: every finding is
       # fixable by editing the file it points at.
       - name: Fail on CRITICAL misconfiguration
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.36.0  # pinned (#792): @master floats inside the job that gates releases
         with:
           scan-type: 'config'
           scan-ref: '.'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,18 @@ per-file management and email notifications, deployments get **fresh/isolated en
 **in-app scheduled backups**, and the docs site, i18n (12 locales, four new this release), and
 release engineering (`scripts/release.sh`) all saw substantial investment.
 
+**Licensing.** OpenTranscribe ships the full **GNU AGPL-3.0** licence text, surfaces it in-app,
+and carries the **§13 network-use source offer** (issue #862) — so a user interacting with a
+hosted instance over a network can find the corresponding source. Every first-party package
+manifest and every production image now declares `AGPL-3.0-only`, and the SBOM reports it
+(#886). **If you redistribute or host this software, read [Upgrade Notes](#upgrade-notes).**
+
+**Release-blocker wave.** The final pass before this release closed 32 milestone issues in one
+merge (PR #921): raw exception text no longer reaches users on a failed upload, `/api/search`
+and the directory endpoints are rate-limited, account enumeration is closed, the summary-search
+leg gained filters/ranking/pagination, and a class of exception-echo leak invisible to the
+existing scanner was swept and gated. Detail in the sections below.
+
 **This release contains breaking changes** — see [Upgrade Notes](#upgrade-notes) before pulling.
 
 ### Added
@@ -362,6 +374,45 @@ A tag was either yours alone or published to the whole deployment, so giving one
   segments).
 
 ### Fixed
+
+- **Summary search ignored every filter, had no ranking, and broke `result_type=all`
+  pagination** (#831). The Summaries tab applied **none** of the ten filter dimensions the
+  Transcripts tab honours, so one request's two legs disagreed about which files the caller had
+  asked for. Results came back in `id` order — newest-first, with no relevance signal — and are
+  now ranked by `ts_rank` with an `id` tie-break. (`ts_rank`, not `ts_rank_cd`: cover density
+  scores how closely query terms sit together, which is meaningful in prose and meaningless
+  across a JSONB blob where adjacency is an artifact of key order.) `total_pages` reached only
+  the transcript leg, so a summaries-only search reported 0 pages however many hits it found.
+
+- **Summary search masked whole documents to return a few lines** (#822). Every matching file's
+  entire summary tree was redacted and then almost all of it discarded, so a detector outage
+  anywhere in a file withheld results the user was never going to see. Masking is now applied
+  per returned leaf.
+
+- **Chat citation snippets were capped far below the indexed chunk, and the card clipped them
+  anyway** (#913, #832). `SNIPPET_CHARS` was a flat 240 and the card clamped to two lines
+  regardless, so a wider cap would have had no reader-visible effect. The cap is now derived
+  from the indexing target (the same method already shipped for digest and overview snippets),
+  and each card gained a keyboard-accessible **Show more / Show less** toggle, rendered only
+  when the snippet exceeds what the card previously showed in full.
+
+- **The file-detail page showed nothing when processing failed** (#841). `FileHeader.svelte`
+  gated its error display on `file.error_message`, a field no schema emits.
+
+- **A cached retrieval pool could be reranked by the wrong model** (#834). `ChunkHit.language`
+  was not round-tripped through the retrieval cache, so a restored pool read as "language
+  unknown" — which the reranker's voting rule treats as a non-vote. A pool of entirely
+  non-English chunks could therefore fail the non-English check and be reordered by the English
+  cross-encoder, destroying a correct retrieval order.
+
+- **Celery queue depth undercounted, and two implementations disagreed** (#892). The metric read
+  a bare `LLEN`, which sees only the default priority sub-list, and ignored reserved
+  (prefetched, unacknowledged) work entirely — so a saturated fleet trended toward zero, the
+  inverse of the truth. Both `/metrics` and `/api/system/stats` now derive from one measurement
+  that sums all 10 priority sub-lists plus reserved work in a single pipelined round trip
+  instead of 120 sequential ones. A second defect went with it: the old reader used the *result
+  backend* client rather than the broker, so a deployment pointing `CELERY_RESULT_BACKEND`
+  elsewhere reported 0 forever.
 
 - **A fresh install could fail permanently on a race with its own database.** `run_migrations()`
   could not distinguish "Postgres is not up yet" from "the migration failed", and `main.py`'s
@@ -1903,6 +1954,46 @@ Also fixed: the E2E API session never sent a CSRF token, so every mutation retur
 
 ### Security
 
+- **Raw exception text no longer reaches users on a failed upload** (#786, #841, #843).
+  `error_categorization_service` interpolated the caught exception into `user_message` in every
+  `_handle_*` branch, and two bare-except fallbacks in `audio_processor` re-embedded `str(e)` —
+  the source of `/tmp` path disclosure on a failed preprocess. Every `user_message` and
+  suggestion is now a fixed sentence; the raw text survives only in the ERROR log and
+  `media_file.last_error_message`. Two misclassifications went with it: a video with no audio
+  track (ffmpeg fails on the *output* side with `does not contain any stream`) and a zero-byte
+  upload were both reported as "corrupted"; each now gets its own honest reason.
+  `MediaFile.error_category` was renamed `error_reason` on the wire — see
+  [Breaking Changes](#breaking-changes).
+
+- **A whole class of exception echo was invisible to the leak scanner, and is now swept and
+  gated** (#914). The AST taint scanner tracked assignments but not
+  `container.append(str(e))` returned later, so those sites could not be found by construction.
+  Six response-bound leaks were closed, disclosing — variously — MinIO/boto3 endpoints, the
+  **broker URL including its password**, host filesystem paths, the OpenSearch cluster URL, and
+  raw SQL with bound parameters. The worst was not a display leak at all: `llm_service`
+  serialized the error text into the *combiner prompt*, making the provider `base_url` an
+  egress event. Each fix keeps the facts a caller needs (which file failed, which object to
+  re-mirror, the erasure subject id) and drops only the interpolation, with a sentinel test
+  asserting that survival so a later "cleanup" cannot quietly remove the capability.
+
+- **`/api/search` and the directory endpoints are rate-limited; account enumeration is closed**
+  (#822, #904). Both routes previously had no limit at all, and any authenticated user could
+  enumerate every account in their tenant. Limits are keyed per user-or-IP.
+
+- **GDPR erasure audit records now agree on who did what to whom** (#828, #443). Four emitters
+  across `gdpr_erasure_service` and `erasure_ledger_service` disagreed about whether `user_id`
+  held the actor or the subject — the pre-#443 defect, reproduced. All four now record
+  `user_id` = ACTOR and `target_user_id` = SUBJECT, and both `/audit-logs` read paths were
+  corrected to match. A second, separate defect surfaced alongside it: `POST
+  /admin/users/{uuid}/unlock` carried its target only in `details.target_user`, a UUID string
+  invisible to `query_audit_logs`.
+
+- **Linking an external identity now converts a local account's `auth_type`** (#912). A local
+  account given an `oidc_subject`/`ldap_uid`/`pki_subject_dn` resolved through the provider-id
+  login branch while `auth_type` still told every other consumer it used a local password. The
+  conversion is guarded so an already-external account is never demoted between two external
+  methods, and the external-email remedy now symmetrically refuses a local target.
+
 - **A quarantined file's identity could still leak over a live WebSocket push** (#908). Read
   surfaces have hidden a taken-down file from non-admins since the takedown/quarantine work
   landed (`exclude_quarantined`/`is_hidden_for`), but the notification funnel had only one
@@ -2518,6 +2609,17 @@ opt-in used by `POST /api/org-admin/gdpr/erase-organization`). A bare `scope=all
 `?scope=all_users&confirm=true`** to preserve prior behaviour.
 
 ### Upgrade Notes
+
+- **⚠️ READ THIS IF YOU HOST OR REDISTRIBUTE OpenTranscribe — the AGPL-3.0 obligations are now
+  stated explicitly** (issue #862). The licence has always been the GNU Affero General Public
+  License v3.0; what changed is that the full text now ships with the software, is surfaced
+  in-app, and carries the **§13 network-use source offer**. AGPL §13 means that if you run a
+  modified version and let users interact with it **over a network**, those users must be
+  offered the corresponding source of your modified version. This is not a licence change and
+  it imposes nothing new — but if you have been running modified code as a hosted service, this
+  is the release that makes the obligation visible to your users. Every first-party manifest and
+  production image now declares `AGPL-3.0-only` (the SPDX id; the previously-used bare
+  `AGPL-3.0` is deprecated), and the generated SBOM reports it (#886).
 
 - **⚠️ ACTION REQUIRED — the backend will REFUSE TO START if your `.env` lacks production
   secrets.** Security enforcement changed from fail-open to fail-closed (issue #284 A0.3):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -399,7 +399,7 @@ this; see `scripts/CLAUDE.md` for the full flag table. This is **not** the same 
 dev/prod/lite/PKI/GPU-scale/fresh-install/upgrade, run before cutting a release, not during
 ordinary development).
 
-MinIO/OpenSearch-backed tests **auto-enable** when the dev stack is reachable (conftest TCP-probes localhost:5178/5180) and skip otherwise. Coverage is configured report-only (`pytest --cov=app`, `npm run test:coverage`).
+MinIO/OpenSearch-backed tests **auto-enable** when the dev stack is reachable (conftest TCP-probes localhost:5178/5180) and skip otherwise. Backend coverage is **ENFORCED, not report-only**: `backend/pyproject.toml`'s `fail_under = 37` is a hard pytest-cov gate — a run below the floor exits non-zero. It is a **ratchet floor** set just below the measured value, so it fails on a *regression*, not on failing to improve. Raise it when coverage rises; never lower it to make a run pass. Frontend coverage (`npm run test:coverage`) genuinely is report-only.
 
 ### Four tools that keep the suite honest (issue #431)
 

--- a/docs-site/docs/configuration/embedding-migration.md
+++ b/docs-site/docs/configuration/embedding-migration.md
@@ -61,7 +61,13 @@ POST /_aliases
 }
 ```
 
-This swap is atomic -- there is zero downtime and no window where queries could fail. If issues are discovered after finalization, the alias can be swapped back to `speakers_v3` in the same way, providing instant rollback without data loss.
+This swap is atomic -- there is zero downtime and no window where queries could fail.
+
+⚠️ The reverse swap is **mechanically** possible in the same way, but is **not exposed as an
+operation**: `swap_speaker_alias()` has one production caller (the migration task) and is only
+ever passed the v4 index. There is no endpoint, task, or UI that swaps back, so do not plan
+around "instant rollback" -- see [Rollback](#rollback-if-needed) and issue
+[#659](https://github.com/attevon-llc/OpenTranscribe/issues/659).
 
 Key functions implementing this architecture: `swap_speaker_alias()`, `get_active_versioned_index()`, and `get_write_index()` in the OpenSearch service layer.
 
@@ -280,30 +286,44 @@ Important: No data is lost during migration:
 
 ## Rollback (if needed)
 
-If you need to revert to PyAnnote v3 after migration:
+:::danger There is no supported one-click rollback today — issue #659
 
-### Reverting to v3
+Earlier versions of this page described two ways to revert to v3: an Admin UI control at
+*Settings → Embeddings → "Use PyAnnote v3"*, and a `PYANNOTE_VERSION=v3` environment variable.
+**Neither exists.** No such control is in the embedding-migration settings component, and
+`PYANNOTE_VERSION` is read by nothing — it appears in no `.env.example`, no compose file, and
+no application config. Setting it does nothing at all.
 
-1. **Via Admin UI**:
-   - Settings → Embeddings → "Use PyAnnote v3"
-   - Migration data is preserved; system switches back to v3 embeddings
-   - No data loss occurs
+Because that text was written as an *emergency fallback*, it was at its most dangerous exactly
+when it would be read: mid-incident, by an operator who needs the migration undone now. It is
+removed rather than softened.
 
-2. **Via Environment Variable** (emergency fallback):
-   ```bash
-   # In .env
-   PYANNOTE_VERSION=v3
-   # Restart backend
-   docker restart opentranscribe-backend
-   ```
+**Restoring from a backup taken before the migration is the only supported rollback.** See
+[Data Recovery](#data-recovery) below, and take that backup before you start.
 
-### What Happens During Rollback
+Tracking issue: [#659](https://github.com/attevon-llc/OpenTranscribe/issues/659) — a real
+rollback path is planned for v0.8.0.
+:::
 
-- System reverts to using v3 speaker embeddings
-- v4 data is preserved in the database
-- Speaker overlap detection becomes unavailable
-- Performance returns to v3 baseline (~3 seconds per speaker assignment)
-- Migration can be restarted later
+### Why the alias swap is not a rollback button
+
+The architecture section above notes that the `speakers` alias can point at either versioned
+index, and that swapping it is atomic. That is true of the *mechanism* — but the mechanism is
+not reachable as an operation. `swap_speaker_alias()` has exactly one production caller (the
+migration task itself) and is only ever passed the v4 index. There is no endpoint, no Celery
+task, and no UI that swaps it back.
+
+**You are not forced through a one-way door in this release**: the migration is
+superuser-opt-in (`POST /embedding-migration/start`, then `/finalize`), nothing on the beat
+schedule dispatches it, and an upgrade leaves the alias on v3. If you have not started it, you
+are not exposed to the missing rollback.
+
+### What a restore gets you back
+
+- v3 speaker embeddings, as of the backup
+- Speaker overlap detection becomes unavailable again (it is a v4 capability)
+- Performance returns to the v3 baseline (~3 seconds per speaker assignment)
+- The migration can be restarted later
 
 ### Data Recovery
 

--- a/docs-site/docs/operations/performance-tuning.md
+++ b/docs-site/docs/operations/performance-tuning.md
@@ -518,8 +518,24 @@ The native pipeline achieves 95% speaker consistency because word-level timestam
 | LLM tasks slow, vLLM GPU at 100% | LLM GPU is the bottleneck | Add dedicated LLM GPU or use cloud API | Hardware/API cost |
 | Database queries slow | PostgreSQL needs tuning | Increase `shared_buffers`, `work_mem` | Free (config change) |
 | Search queries slow | OpenSearch heap too small | Increase `OPENSEARCH_JAVA_OPTS` heap | RAM |
-| Many concurrent users, API slow | Backend needs scaling | Run multiple backend replicas behind load balancer | CPU/RAM |
+| Many concurrent users, API slow | Backend needs scaling | ⚠️ **Not yet supported — see below.** Scale Celery workers instead (`REDACTION_CONCURRENCY`, `--gpu-scale`) | CPU/RAM |
 | Download queue backing up | Network bandwidth | Increase `DOWNLOAD_CONCURRENCY`, check bandwidth | Free/network |
+
+### ⚠️ Do not run more than one `backend` replica
+
+`backend.replicas` is effectively **capped at 1** today. The backend runs five one-shot startup
+steps with **no leader election**, so every replica runs all of them — and one of those dispatches
+`search_index_maintenance`, where concurrent dispatches have corrupted a reindex. The same risk
+applies to a rolling update, where the old and new pods overlap by design.
+
+Earlier versions of this page recommended running multiple backend replicas behind a load
+balancer. **That advice was wrong and could corrupt your search index.**
+
+Scale the **workers** instead — they are designed for it (`REDACTION_CONCURRENCY`, additional
+Celery worker replicas, `./opentr.sh start dev --gpu-scale`). Leader election for the backend's
+startup steps is tracked in
+[#894](https://github.com/attevon-llc/OpenTranscribe/issues/894), and is a prerequisite for the
+Helm chart ([#864](https://github.com/attevon-llc/OpenTranscribe/issues/864)).
 
 ### When to Scale Vertically vs. Horizontally
 

--- a/docs-site/src/pages/index.tsx
+++ b/docs-site/src/pages/index.tsx
@@ -5,6 +5,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import Heading from '@theme/Heading';
+import CodeBlock from '@theme/CodeBlock';
 
 import styles from './index.module.css';
 
@@ -225,9 +226,12 @@ function Hero() {
         <div className={styles.quickInstall}>
           <div>
             <div className={styles.installLabel}>Install with one command</div>
-            <pre className={styles.installCommand}>
-              <code>curl -fsSL https://raw.githubusercontent.com/attevon-llc/OpenTranscribe/master/setup-opentranscribe.sh | bash</code>
-            </pre>
+            {/* @theme/CodeBlock, not a raw <pre>: it ships Docusaurus's own copy button.
+                This is the homepage's primary call to action and it could not be copied
+                (issue #758) -- a curl|bash line is precisely the thing nobody retypes. */}
+            <CodeBlock language="bash" className={styles.installCommand}>
+              curl -fsSL https://raw.githubusercontent.com/attevon-llc/OpenTranscribe/master/setup-opentranscribe.sh | bash
+            </CodeBlock>
           </div>
         </div>
       </div>
@@ -375,7 +379,7 @@ function Comparison() {
     {feature: 'Enterprise auth (LDAP/PKI/OIDC)',values: [C, D, D, D, D, D, D, D, D, D, D]},
     {feature: 'Multi-user / roles',             values: [C, C, D, D, D, D, D, D, C, D, D]},
     {feature: 'Multi-GPU scaling',              values: [C, D, D, D, D, D, D, D, D, D, D]},
-    {feature: 'Cloud ASR providers',            values: [C, D, D, D, D, D, D, D, D, D, D]},
+    {feature: 'Choose your own cloud ASR provider', values: [C, D, D, D, D, D, D, D, D, D, D]},
     {feature: 'URL import (YouTube etc.)',       values: [C, D, D, D, D, D, C, D, D, D, S('Pro')]},
     {feature: 'Docker Compose deploy',          values: [C, D, D, D, D, D, D, C, C, C, D]},
     {feature: 'Desktop app',                    values: [D, D, D, D, D, D, C, D, D, D, C]},
@@ -428,7 +432,7 @@ function Comparison() {
           </table>
         </div>
         <p style={{marginTop: '1.25rem', fontSize: '0.75rem', color: 'var(--ot-text-muted)', textAlign: 'center'}}>
-          Data based on publicly available documentation as of March 2026. Features may vary by plan or version.
+          Compiled from each product's publicly available documentation, last reviewed September 2026. Features change and vary by plan, region and version — check the vendor's own docs before relying on any row. Corrections welcome via a GitHub issue.
         </p>
       </div>
     </section>

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -90,9 +90,9 @@ Thank you for your interest in contributing to OpenTranscribe! This document pro
 
 ### Branch Strategy
 ```bash
-# Create feature branch from main
-git checkout main
-git pull upstream main
+# Create feature branch from master (this repo's default branch is master, not main)
+git checkout master
+git pull upstream master
 git checkout -b feature/your-feature-name
 
 # For bug fixes
@@ -344,7 +344,8 @@ Add screenshots to help explain your changes
 3. **Approval and Merge**
    - All checks pass
    - Approved by maintainer
-   - Squash and merge to main
+   - Merge to `master` with a **merge commit** (`--no-ff`) — this repo never squash-merges;
+     each commit is a documentation artifact
 
 ## 🐛 Issue Guidelines
 
@@ -406,9 +407,15 @@ Any other context, mockups, or examples
 
 ### Reporting Security Issues
 - **DO NOT** create public issues for security vulnerabilities
-- Email security concerns to: [security@opentranscribe.com]
-- Include detailed description and reproduction steps
-- Allow time for fix before public disclosure
+- Use GitHub's **private vulnerability reporting**:
+  [Report a vulnerability](https://github.com/attevon-llc/OpenTranscribe/security/advisories/new)
+- Include a detailed description and reproduction steps
+- Allow time for a fix before public disclosure
+
+`SECURITY.md` at the repository root is the authoritative policy, including the
+acknowledgement and disclosure timelines. **Do not add an email address here** — this section
+previously advertised `security@opentranscribe.com`, which nobody reads, so a real report would
+have gone nowhere.
 
 ### Security Guidelines
 - Never commit secrets or API keys
@@ -480,7 +487,7 @@ Any other context, mockups, or examples
 ## 🏆 Recognition
 
 ### Contributors
-- All contributors are listed in CONTRIBUTORS.md
+- Contributors are credited through the GitHub contributors graph and the commit history
 - Significant contributions are highlighted in release notes
 - Regular contributors may be invited as maintainers
 
@@ -493,14 +500,14 @@ Any other context, mockups, or examples
 ## 📞 Getting Help
 
 ### Community Support
-- **GitHub Discussions**: General questions and discussions
-- **Discord**: Real-time chat with the community
-- **Stack Overflow**: Use tag `opentranscribe`
+- **GitHub Issues**: bug reports and feature requests — see the guidelines above
+- **GitHub Discussions**: general questions, if enabled on the repository
 
 ### Direct Contact
-- **Maintainers**: Tag @maintainers in issues
-- **Email**: [contribute@opentranscribe.com]
-- **Office Hours**: Virtual office hours every Friday 2-4 PM UTC
+- Open an issue, or comment on the one you are interested in. There is no separate mailing
+  list, chat server, or office-hours schedule — earlier versions of this page advertised a
+  Discord, a Stack Overflow tag, an email alias and a weekly office hour, none of which
+  exist.
 
 ### Resources
 - [Development Environment Setup Guide](../backend/README.md)


### PR DESCRIPTION
Found by a fresh read-only audit of all 92 open issues plus the release state,
run after PR #921 merged. None of these is a code change; the runtime is
untouched.

CHANGELOG (the one that would have shipped wrong)
-------------------------------------------------
[Unreleased] had NO entry for whole themes of the final wave. Measured against
the section itself: `AGPL` 0 matches, `licence|license` 0, `rate limit` 0,
`exception echo` 0, `summary leg` 0.

Most serious: #862 ships the full AGPL-3.0 text, surfaces it in-app and adds the
§13 network-use source offer -- a licensing-visibility change that was about to
ship unannounced. Added an Upgrade Note spelling out what §13 means for anyone
hosting a modified version.

Also added: the exception-echo sweep and its scanner blind spot (#914, #786),
search/directory rate limiting and account-enumeration closure (#822, #904),
GDPR actor/subject attribution (#828, #443), link-identity auth_type conversion
(#912), the summary-search leg's filters/ranking/pagination (#831), leaf-level
summary masking (#822), citation snippet cap + show more/less (#913, #832),
FileHeader's dead error field (#841), the cache language round-trip (#834), and
queue-depth undercounting (#892).

The pipeline could not have caught this: release-criteria.yaml:132 asserts only
that a section EXISTS, and 20-bump.sh renames [Unreleased] -> [0.5.0]. A
47-commit hole passes every gate.

Docs that told operators to do something harmful or impossible
--------------------------------------------------------------
* embedding-migration.md (#659): the "Rollback (if needed)" section offered an
  Admin UI control that does not exist and `PYANNOTE_VERSION=v3`, a variable
  read by NOTHING -- not .env.example, not core/config.py, not any compose
  file. It was framed as an EMERGENCY FALLBACK, so it was at its most dangerous
  exactly when read: mid-incident. Removed rather than softened, with the real
  position stated (restore from backup is the only supported rollback; the
  alias swap is mechanically possible but has no endpoint/task/UI). Also
  retracted ":64"'s "instant rollback without data loss".

* performance-tuning.md (#894): a tuning table told operators to "Run multiple
  backend replicas behind load balancer". The backend runs five one-shot
  startup steps with NO leader election, one of which dispatches
  search_index_maintenance -- where concurrent dispatch has corrupted a
  reindex. We were shipping advice that can corrupt a search index. Row
  corrected and a warning section added pointing at #894/#864.

* CONTRIBUTING.md (#468): vulnerability reports were directed to
  security@opentranscribe.com, a placeholder nobody reads, contradicting
  SECURITY.md's private-advisory process -- a real report would have gone
  nowhere. Also `git checkout main` (no `main` branch exists; copy-paste
  fails), "Squash and merge to main" (this repo never squash-merges), a
  nonexistent CONTRIBUTORS.md, and a Discord/Stack Overflow tag/email
  alias/weekly office hour that do not exist.

CI and metadata
---------------
* pre-commit.yml (#793): `Backend Tests (pytest)` is a REQUIRED check, and
  branch protection counts a SKIPPED required check as SATISFIED -- so a PR
  touching only opentr.sh, scripts/ or docker-compose*.yml merged with the
  backend suite never having run. Confirmed live on run 34017549729 (PR #774):
  both required checks report `skipped`. ~55 tests under backend/tests/unit/
  exist specifically to guard those files. Added the four paths to the filter.

* security-scan.yml (#792): aquasecurity/trivy-action was `@master` at 10 call
  sites -- a floating branch inside the job that gates releases. Pinned to
  v0.36.0. (Verified the tag format against the GitHub API first: there is no
  bare `0.36.0` tag, only `v0.36.0`, so the obvious pin would have broken every
  scan job.)

* dependabot.yml (#792): 5 ignore rules cited #234 and #256 as their standing
  rationale. BOTH ARE CLOSED (#234 on 2026-06-05), so nothing re-raises those
  deferred majors. Added a header saying so, rather than filing a new issue --
  each rule's reason is already written out beside it and stands alone.

* CLAUDE.md + pre-commit.yml (#789): three places called backend coverage
  "report-only" while backend/pyproject.toml:167 sets `fail_under = 37`, a hard
  pytest-cov gate. Corrected the label only -- the floor is a deliberate ratchet
  and is NOT raised here.

* docs-site homepage (#758): the primary CTA was a raw <pre><code> with no copy
  button -- a curl|bash line is precisely what nobody retypes. Now
  @theme/CodeBlock, which ships Docusaurus's own copy button. Separately, a
  comparison row labelled "Cloud ASR providers" dashed five NAMED competitors
  who are themselves cloud ASR services; the row means "can you choose the
  provider", so it now says that. Attestation date was 6 months stale.

Verification
------------
docs-site `npm run build` exits 0 and the copy button is present in the built
output. safe-precommit commit-stage and pre-push both exit 0. No backend or
frontend application code changed.