### PR TITLE
fix(e2e): one frontend warm-up detector — the second copy still had the rejected bug

### DIFF
--- a/backend/tests/e2e/conftest.py
+++ b/backend/tests/e2e/conftest.py
@@ -68,6 +68,7 @@ if _backend_dir not in sys.path:
 # same env vars this dev stack exposes) — imported here for its **module-level side effects
 # only** (setting `os.environ` before any `app.*` import happens), not registered as a plugin,
 # so its own fixtures / its own `pytest_plugins` entries don't leak into this rootdir.
+from frontend_warm import find_entry_modules
 from timeouts import APP_SHELL_READY_MS
 from timeouts import LOGIN_FORM_READY_MS
 
@@ -341,16 +342,16 @@ def _warm_frontend_module_graph(base_url: str) -> None:
             if shell.status_code != 200:
                 last = f"shell HTTP {shell.status_code}"
             else:
-                mods = re.findall(
-                    r'["\'](/(?:@fs|@vite|src|node_modules)/[^"\']+\.js)["\']', shell.text
-                )
+                # Detection lives in frontend_warm.py because `run-dev-tests.sh`'s
+                # quiesce step needs the identical rule — it used to carry its own
+                # copy, with the `<script src type=module>` bug this docstring warns
+                # about, and reported NOT WARM on every run as a result.
+                # It already returns widest-graph-first.
+                mods = find_entry_modules(shell.text)
                 if not mods:
                     # Not the Vite dev server (prod/nginx overlay serves hashed bundles that
                     # need no warming). Nothing to do, and not a problem.
                     return
-                # The generated client app imports the real route modules, so it pulls the
-                # widest graph of anything referenced by the shell.
-                mods.sort(key=lambda u: (0 if "generated/client/app.js" in u else 1, len(u)))
                 probe_started = time.monotonic()
                 mod = requests.get(base_url.rstrip("/") + mods[0], timeout=90)
                 took = time.monotonic() - probe_started

--- a/backend/tests/e2e/frontend_warm.py
+++ b/backend/tests/e2e/frontend_warm.py
@@ -1,0 +1,58 @@
+"""Find the entry modules a Vite/SvelteKit dev shell references.
+
+THE SINGLE SOURCE OF TRUTH for that detection. It lives here because two callers
+need it and, for a while, each carried its own copy — one correct, one not:
+
+  * ``backend/tests/e2e/conftest.py``'s ``_warm_frontend_module_graph`` (session
+    preflight), and
+  * ``scripts/run-dev-tests.sh``'s quiesce step (before the browser suite).
+
+⚠️ **Why the obvious pattern is wrong.** SvelteKit references its client entry from
+an **inline** script, not from ``<script src="..." type="module">``. A probe matching
+the latter finds nothing on a perfectly healthy dev server and reports NOT WARM on
+*every single run*. That draft was written, rejected and documented in
+``conftest.py`` — and then shipped anyway in ``run-dev-tests.sh``, where it burned
+170 s of a 180 s quiesce budget, declared the frontend cold, and let the e2e suite
+start against an uncompiled module graph. Vite's on-demand transform then landed on
+whichever test ran first, surfacing as ``gallery_page`` timing out on
+``.gallery-action-buttons`` — a fixture timeout that reads like a broken test rather
+than a cold server. Measured 2026-09-12: 3 failed + 3 errors, all
+``wait_for_selector`` timeouts, all passing in isolation seconds later.
+
+So: match the module URLs the shell actually contains, wherever they appear.
+
+An empty result is **not** an error — the prod/nginx overlay serves hashed bundles
+that need no warming at all. Callers must treat "no modules" as "nothing to do".
+"""
+
+from __future__ import annotations
+
+import re
+
+#: Module URLs a Vite dev shell references, inline or otherwise. Deliberately not
+#: anchored to a ``<script>`` tag: see this module's docstring for what that cost.
+_ENTRY_MODULE_RE = re.compile(r'["\'](/(?:@fs|@vite|src|node_modules)/[^"\']+\.js)["\']')
+
+#: The generated client app imports the real route modules, so warming it pulls the
+#: widest graph of anything the shell references. Prefer it, then shortest URL.
+_GENERATED_CLIENT_APP = "generated/client/app.js"
+
+
+def find_entry_modules(shell_html: str) -> list[str]:
+    """Return referenced module paths, widest-graph-first.
+
+    Args:
+        shell_html: The HTML body served at the SPA root.
+
+    Returns:
+        Absolute module paths (leading ``/``), best warm-up candidate first. Empty
+        when the shell is not a Vite dev shell — a served-but-not-a-SPA answer such
+        as an nginx error page, or the prod overlay's hashed bundles. Empty means
+        "nothing to warm", never "something is broken".
+    """
+    mods = _ENTRY_MODULE_RE.findall(shell_html)
+    # dict.fromkeys: de-duplicate while keeping first-seen order stable, so the sort
+    # below is deterministic for shells that reference a module more than once.
+    mods = list(dict.fromkeys(mods))
+    mods.sort(key=lambda u: (0 if _GENERATED_CLIENT_APP in u else 1, len(u)))
+    return mods

--- a/backend/tests/unit/test_frontend_warm_probe.py
+++ b/backend/tests/unit/test_frontend_warm_probe.py
@@ -1,0 +1,129 @@
+"""The frontend warm-up detector, and the drift guard that would have caught its bug.
+
+Why this file exists, concretely. Two places needed "which module should I fetch to
+make Vite compile the SPA?": ``backend/tests/e2e/conftest.py``'s session preflight and
+``scripts/run-dev-tests.sh``'s quiesce step. Each carried its own copy. One was
+correct. The other matched ``<script src="..." type="module">`` — a shape SvelteKit
+never emits, because it references the client entry from an **inline** script.
+
+The consequence was not a loud failure. The broken probe matched nothing on a
+perfectly healthy dev server, spent 170 s of a 180 s budget concluding so, printed
+``frontend: NOT WARM``, and let the browser suite start against an uncompiled module
+graph. Vite's on-demand transform then landed on whichever test ran first. Measured
+2026-09-12: **3 failed + 3 errors**, every one a ``wait_for_selector`` timeout on
+``.gallery-action-buttons``, every one passing in isolation seconds later — a
+signature that reads like flaky tests and is actually a cold server.
+
+The detector now lives in one module. These tests pin the behaviour AND assert the
+shell script cannot quietly grow a second copy again.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from tests.e2e.frontend_warm import find_entry_modules
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+RUN_DEV_TESTS = REPO_ROOT / "scripts" / "run-dev-tests.sh"
+
+#: The real shape, reduced: SvelteKit puts the entry in an INLINE script, so there is
+#: no `<script src=... type=module>` anywhere. Captured from the running dev server.
+SVELTEKIT_DEV_SHELL = """<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <script src="/theme.js?v=c7b68d42"></script>
+    <script>
+      {
+        __sveltekit_1abcde = { base: "" };
+        const element = document.currentScript.parentElement;
+        Promise.all([
+          import("/node_modules/@sveltejs/kit/src/runtime/client/entry.js"),
+          import("/@fs/app/.svelte-kit/generated/client/app.js"),
+        ]).then(([kit, app]) => { kit.start(app, element); });
+      }
+    </script>
+  </head>
+  <body><div>%sveltekit.body%</div></body>
+</html>
+"""
+
+#: A served-but-not-a-SPA answer. Must yield nothing, and that is NOT an error —
+#: the prod/nginx overlay serves hashed bundles that need no warming at all.
+NGINX_ERROR_SHELL = """<html>
+<head><title>502 Bad Gateway</title></head>
+<body><center><h1>502 Bad Gateway</h1></center><hr><center>nginx</center></body>
+</html>
+"""
+
+
+def test_it_finds_the_entry_modules_a_real_sveltekit_dev_shell_references():
+    """MUST FIRE. This is the case the broken copy got wrong."""
+    mods = find_entry_modules(SVELTEKIT_DEV_SHELL)
+
+    assert mods, (
+        "found no modules in a real SvelteKit dev shell — this is exactly the bug that "
+        "made run-dev-tests.sh report NOT WARM on every run and hand a cold module "
+        "graph to the e2e suite"
+    )
+    assert "/@fs/app/.svelte-kit/generated/client/app.js" in mods
+    assert "/node_modules/@sveltejs/kit/src/runtime/client/entry.js" in mods
+
+
+def test_the_generated_client_app_is_probed_first_because_it_pulls_the_widest_graph():
+    """Order is load-bearing: the caller warms mods[0] and nothing else."""
+    mods = find_entry_modules(SVELTEKIT_DEV_SHELL)
+
+    assert mods[0] == "/@fs/app/.svelte-kit/generated/client/app.js", (
+        "the generated client app imports the real route modules, so warming it compiles "
+        f"the widest graph; probing {mods[0]} first would warm less than intended"
+    )
+
+
+def test_the_old_script_src_type_module_pattern_finds_nothing_here():
+    """CONTROL, and the whole point of the file.
+
+    Documents *why* the rejected pattern is rejected, against the same fixture. If
+    this ever starts matching, SvelteKit changed how it emits the entry and the
+    detector deserves a fresh look rather than a silent pass.
+    """
+    old_pattern = re.search(
+        r'<script[^>]+src="([^"]+)"[^>]*type="module"', SVELTEKIT_DEV_SHELL
+    ) or re.search(r'<script[^>]+type="module"[^>]*src="([^"]+)"', SVELTEKIT_DEV_SHELL)
+
+    assert old_pattern is None, (
+        "the `<script src type=module>` pattern matched — if SvelteKit now emits that, "
+        "re-derive the detector deliberately instead of assuming either shape"
+    )
+
+
+def test_a_non_vite_shell_yields_nothing_rather_than_a_false_entry():
+    """MUST STAY CLEAN. Empty means 'nothing to warm', never 'something is broken'."""
+    assert find_entry_modules(NGINX_ERROR_SHELL) == []
+
+
+def test_run_dev_tests_does_not_reimplement_the_detector():
+    """DRIFT GUARD — the test that would have caught the original defect.
+
+    The bug was never that one regex was wrong; it was that the fix landed in one of
+    two copies. Assert the shell script imports the shared detector and does not
+    carry its own `<script ... type="module">` matcher.
+    """
+    source = RUN_DEV_TESTS.read_text(encoding="utf-8")
+
+    assert "from frontend_warm import find_entry_modules" in source, (
+        f"{RUN_DEV_TESTS.name} no longer imports the shared detector — if the quiesce "
+        "step grew its own copy again, that is the exact regression this guards"
+    )
+
+    reimplemented = re.search(r"<script\[\^>\]\+(src|type)=", source)
+    assert reimplemented is None, (
+        f"{RUN_DEV_TESTS.name} contains a `<script ... type=module>` matcher again. "
+        "SvelteKit references its entry from an INLINE script, so that pattern matches "
+        "nothing and silently reports the frontend cold. Use find_entry_modules()."
+    )

--- a/scripts/run-dev-tests.sh
+++ b/scripts/run-dev-tests.sh
@@ -607,6 +607,15 @@ else:
 # 30 s fixture. Requiring two consecutive FAST responses distinguishes "compiled and cached"
 # from "answered once, slowly, while still compiling".
 frontend = "http://localhost:" + os.environ.get("FRONTEND_PORT", "5173")
+# Shared with conftest.py's session preflight -- ONE detector, deliberately. `sys.path`
+# already carries backend/tests/e2e from the `_await_stable_backend` load above; import it
+# defensively anyway, because that load is in a try/except and may not have run. A failure
+# here degrades this one probe instead of aborting the whole quiesce.
+try:
+    from frontend_warm import find_entry_modules
+except Exception as exc:  # noqa: BLE001
+    find_entry_modules = None
+    _warm_import_error = f"{type(exc).__name__}: {exc}"
 t0 = time.monotonic()
 last = "no probe completed"
 warm = False
@@ -618,16 +627,30 @@ while first or time.monotonic() < deadline:
         shell = requests.get(frontend, timeout=30)
         # The entry is whatever the shell declares; never hardcode /src/main.ts, which is a
         # SvelteKit layout detail that has moved before.
-        entry = re.search(r'<script[^>]+src="([^"]+)"[^>]*type="module"', shell.text) or \
-                re.search(r'<script[^>]+type="module"[^>]*src="([^"]+)"', shell.text)
+        #
+        # ⚠️ Detection is IMPORTED, not re-implemented here. This block used to carry its own
+        # regex matching `<script src="..." type="module">`, which SvelteKit never emits (it
+        # references the client entry from an INLINE script). That draft had already been
+        # written, rejected and documented over in conftest.py -- and then shipped here
+        # anyway. It matched nothing on a perfectly healthy dev server, so this step burned
+        # 170s of its 180s budget, printed "frontend: NOT WARM", and let the browser suite
+        # start against an uncompiled module graph. Vite's on-demand transform then landed on
+        # whichever test ran first: 3 failed + 3 errors on 2026-09-12, every one a
+        # wait_for_selector timeout on `.gallery-action-buttons`, every one passing in
+        # isolation seconds later.
+        if find_entry_modules is None:
+            last = f"detector unavailable ({_warm_import_error})"
+            break
+        entries = find_entry_modules(shell.text)
         if shell.status_code != 200:
             last = f"shell HTTP {shell.status_code}"
-        elif entry is None:
-            # A shell with no module script is a served-but-not-a-SPA answer (an nginx error
-            # page, or the prod overlay). Report it rather than calling it warm.
-            last = "shell has no <script type=module> — not the Vite dev server?"
+        elif not entries:
+            # No module refs is a served-but-not-a-SPA answer (an nginx error page) OR the
+            # prod overlay, whose hashed bundles need no warming at all. Report it rather
+            # than calling it warm; it is not necessarily a fault.
+            last = "shell references no Vite modules — prod overlay, or not the dev server?"
         else:
-            url = entry.group(1)
+            url = entries[0]
             if url.startswith("/"):
                 url = frontend + url
             probe_started = time.monotonic()


### PR DESCRIPTION
## What

`run-dev-tests.sh --full` reported **3 failed + 3 errors** in the e2e phase. Every one was a `wait_for_selector` timeout on `.gallery-action-buttons`. Every one **passed in isolation seconds later** (`7 passed in 31.72s`).

That shape reads as flaky tests. It was a **cold server**, and the thing that was supposed to prevent it was broken.

## The cause: two copies, one fixed

Two places need the same answer — *"which module do I fetch to make Vite compile the SPA?"* — and each carried its own:

| | Pattern | Verdict |
|---|---|---|
| `backend/tests/e2e/conftest.py` | matches the module URLs the shell actually contains | ✅ correct |
| `scripts/run-dev-tests.sh:621` | matches `<script src="..." type="module">` | ❌ **matches nothing** |

SvelteKit never emits that second shape — it references the client entry from an **inline** script.

**And this was not a new mistake.** `conftest.py`'s own docstring records that exact pattern as a first draft that *"found nothing, and would have reported NOT WARM on every single run"* — written, rejected, documented… and then shipped anyway in the other file.

**The regex is just where it showed. The defect is that the fix landed in one of two copies.**

## Why it was expensive rather than loud

A probe that matches nothing doesn't crash. It:

1. burned **170 s of a 180 s** quiesce budget concluding the frontend was cold,
2. printed `frontend: NOT WARM — shell has no <script type=module>`,
3. let the browser suite start anyway.

Vite serves the shell instantly and transforms the module graph **on demand**, so the first navigation pays for the whole SPA — landing on whichever test ran first, inside a 30 s fixture.

The harness even printed **"treat e2e failures in this run as suspect"**. The suspicion was correct, and it was pointing at itself.

Measured against the live dev server *before* changing anything:

```
old pattern  -> NO MATCH
new detector -> /node_modules/@sveltejs/kit/src/runtime/client/entry.js
                /@fs/app/.svelte-kit/generated/client/app.js
```

## The fix

Detection moves to `backend/tests/e2e/frontend_warm.py`; **both callers import it.** Not "fix the regex in both places" — one implementation, because the repo's rule is that replacing an implementation means deleting the old one, and this PR is what leaving two costs.

Two behaviours preserved **deliberately**:

- **An empty result stays non-fatal.** The prod/nginx overlay serves hashed bundles needing no warming, so "no modules" means *nothing to do*, never *something is broken*.
- **`APP_SHELL_READY_MS` is NOT raised.** Widening it hides the cost rather than paying it once, and every test would then wait longer for a *real* failure too. That trade-off is already argued in `conftest.py` and this PR does not reopen it.

## The guard — the test that would have caught it

`test_frontend_warm_probe.py`:

- pins the detector against a real SvelteKit dev shell (must-fire)
- keeps an nginx-error shell as must-stay-clean
- keeps a **control** asserting the rejected pattern still matches nothing — so if SvelteKit ever changes how it emits the entry, that gets re-derived deliberately instead of silently passing
- **asserts `run-dev-tests.sh` imports the shared detector and carries no `<script … type=module>` matcher of its own**

**Red-checked** against `git archive HEAD` with only the new files copied in: the drift guard **FAILED** there while the four detector tests passed — it fails on the real defect, and for the right reason (assertion, not a missing import). 5/5 green on this branch; `audit-tests` clean.

## Scope

**No product code changes.** Gate reliability only — `frontend_warm.py` (new), `conftest.py` (import + call), `run-dev-tests.sh` (import + call), and the new test.

## Test plan

- `pytest tests/unit/test_frontend_warm_probe.py` → 5 passed
- `python3 scripts/audit-tests.py tests` → no un-allowlisted findings
- pre-commit commit stage → 0
- e2e re-run validating the quiesce now reports the frontend **warm** (posted as a comment once complete)
