### PR TITLE
feat(release): rehearse stops and restarts the stack itself, given human approval

### DIFF
--- a/backend/tests/unit/test_rehearse_stack_automation.py
+++ b/backend/tests/unit/test_rehearse_stack_automation.py
@@ -1,0 +1,147 @@
+"""Safety properties of the rehearsal's automatic stack stop/restart.
+
+`65-rehearse.sh` may now stop the live stack, rehearse, and restart it. That is a
+convenience with teeth: it takes down a running deployment and interrupts anything
+transcribing. These tests pin the three properties that make it safe, by executing
+the decision as bash rather than by reading the source for keywords.
+
+What is NOT covered here: the scenarios themselves, and the restart actually
+succeeding. Both need Docker and a real stack. Stated so nobody reads a green run as
+"the rehearsal is proven".
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+REHEARSE = REPO_ROOT / "scripts" / "release" / "65-rehearse.sh"
+
+#: The decision, lifted verbatim in shape from 65-rehearse.sh. Kept in sync by
+#: ``test_the_decision_here_matches_the_shipped_one``.
+DECISION = """
+auto_stop=false
+if [[ "${ASSUME_YES:-false}" == "true" || "${RELEASE_AUTO_STOP_STACK:-false}" == "true" ]]; then
+    auto_stop=true
+elif [[ -t 0 ]]; then
+    auto_stop=prompted
+fi
+echo "$auto_stop"
+"""
+
+
+def _decide(env: dict[str, str]) -> str:
+    """Run the decision with stdin closed — i.e. the unattended case."""
+    return subprocess.run(
+        ["bash", "-c", DECISION],
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        env={"PATH": "/usr/bin:/bin", **env},
+        check=True,
+    ).stdout.strip()
+
+
+def test_unattended_with_no_approval_refuses_rather_than_stopping_the_stack():
+    """THE property. A cron/CI caller must never silently take a deployment down."""
+    assert _decide({}) == "false", (
+        "with no --yes, no RELEASE_AUTO_STOP_STACK and no tty, the rehearsal must fall "
+        "through to its exit-3 refusal — anything else lets an unattended run stop "
+        "someone's stack with no human in the loop"
+    )
+
+
+@pytest.mark.parametrize(
+    "env",
+    [{"ASSUME_YES": "true"}, {"RELEASE_AUTO_STOP_STACK": "true"}],
+    ids=["--yes", "RELEASE_AUTO_STOP_STACK"],
+)
+def test_explicit_human_approval_enables_the_automatic_stop(env: dict[str, str]):
+    """MUST FIRE — otherwise the automation silently never engages."""
+    assert _decide(env) == "true"
+
+
+def test_a_falsy_value_is_not_approval():
+    """CONTROL: only the literal "true" approves, so an exported empty/`0` is not consent."""
+    assert _decide({"RELEASE_AUTO_STOP_STACK": "0"}) == "false"
+    assert _decide({"ASSUME_YES": ""}) == "false"
+
+
+def test_the_restart_is_guarded_and_runs_even_on_failure_or_interrupt():
+    """The restart must be trapped, and must not fire for a stack we did not stop.
+
+    Structural, deliberately: firing the trap for real needs Docker. What it pins is
+    the pair that turns "we stopped it" into "we put it back" — a trap covering the
+    abnormal exits, and a guard so a stack the operator had already stopped is not
+    started up underneath them.
+    """
+    source = REHEARSE.read_text(encoding="utf-8")
+
+    assert "trap restore_live_stack EXIT INT TERM" in source, (
+        "restore must run from an EXIT/INT/TERM trap — on the happy path only, a failed "
+        "scenario or a Ctrl-C leaves the operator's stack down with no hint why"
+    )
+    assert "STACK_STOPPED_BY_US=false" in source
+    assert '[[ "$STACK_STOPPED_BY_US" == "true" ]] || return 0' in source, (
+        "restore must be guarded: starting a stack the operator had deliberately stopped "
+        "is its own surprise"
+    )
+
+
+def test_it_never_reaches_for_kill():
+    """`./opentr.sh stop` only. A SIGKILLed CUDA context has wedged this host twice.
+
+    Scans EXECUTABLE lines, not the whole file. The first draft matched raw source and
+    fired on the comment that explains *why* these are forbidden — a detector that
+    cannot tell code from prose would force the explanation to be deleted to stay
+    green, which is precisely backwards.
+    """
+    code_lines = [
+        line
+        for line in REHEARSE.read_text(encoding="utf-8").splitlines()
+        if not line.lstrip().startswith("#")
+    ]
+
+    for forbidden in ("pkill", "killall", "kill -9", "docker kill"):
+        offenders = [line.strip() for line in code_lines if forbidden in line]
+        assert not offenders, (
+            f"{forbidden!r} is executed in the rehearsal stage: {offenders}. Stopping the "
+            "stack must go through ./opentr.sh stop, which is graceful and preserves data."
+        )
+
+
+def test_the_kill_detector_can_actually_fire():
+    """GUARD THE GUARD: a scanner that matches nothing passes everything.
+
+    Without this, stripping comments above could have over-stripped and left the test
+    green against a file that really did `pkill`.
+    """
+    code_lines = ["  docker kill $(docker ps -q)", "# docker kill — never do this"]
+    offenders = [
+        line.strip()
+        for line in code_lines
+        if not line.lstrip().startswith("#") and "docker kill" in line
+    ]
+
+    assert offenders == ["docker kill $(docker ps -q)"], (
+        "the comment-stripping scan must still catch a real call, and must ignore the commented one"
+    )
+
+
+def test_the_decision_here_matches_the_shipped_one():
+    """Guard against this file's copy of the decision drifting from the real one."""
+    source = REHEARSE.read_text(encoding="utf-8")
+
+    assert (
+        'if [[ "${ASSUME_YES:-false}" == "true" || '
+        '"${RELEASE_AUTO_STOP_STACK:-false}" == "true" ]]; then' in source
+    ), (
+        "the approval condition in 65-rehearse.sh no longer matches the one exercised "
+        "above, so these tests would be asserting against a decision that is not shipped"
+    )
+    assert "elif [[ -t 0 ]]; then" in source

--- a/scripts/release/65-rehearse.sh
+++ b/scripts/release/65-rehearse.sh
@@ -6,8 +6,12 @@
 # stack STOPPED — the scenarios run under the installer's stock container names
 # and ports 5173-5180 by design, so they exercise what a real user gets.
 #
-# It never stops the stack for you. Taking someone's deployment down is their
-# call, so this refuses and prints the command.
+# Taking someone's deployment down stays a HUMAN call — but it is no longer a manual
+# two-step. Given approval it stops the stack, rehearses, and restarts it to the state it
+# found. Approval is `--yes`, `RELEASE_AUTO_STOP_STACK=true`, or an interactive prompt;
+# with none of those and no tty it still refuses and prints the command, so an unattended
+# caller can never silently stop a stack. The restart runs from an EXIT/INT/TERM trap, so
+# a failed scenario or a Ctrl-C still puts the host back rather than leaving it down.
 #
 # Scenario C exists because `docker-build-push.sh all` BUILDS the lite image and a
 # release would PUBLISH it, while nothing under scripts/release/ ever ran it — so
@@ -71,15 +75,81 @@ live_stack_names="$( {
     docker ps --filter "label=com.docker.compose.project=${OPENTR_STOP_PROJECT_LABEL:-opentranscribe}" --format '{{.Names}}'
     docker ps --filter "label=com.docker.compose.project=${OPENTR_STOP_PROJECT_LABEL_ALT:-transcribe-app}" --format '{{.Names}}'
 } | sort -u)"
+# Set when THIS run stopped the stack, so the trap below puts it back exactly as found.
+# Never set when the stack was already down: restoring a stack the operator had
+# deliberately stopped is its own surprise.
+STACK_STOPPED_BY_US=false
+
+restore_live_stack() {
+    [[ "$STACK_STOPPED_BY_US" == "true" ]] || return 0
+    STACK_STOPPED_BY_US=false   # idempotent: EXIT fires after an explicit call
+    echo -e "${BLUE}Restarting the dev stack this run stopped...${NC}" >&2
+    if (cd "$REPO_ROOT" && ./opentr.sh start dev >/dev/null 2>&1); then
+        echo -e "${GREEN}dev stack restarted${NC}" >&2
+    else
+        # Never fail the rehearsal over this. The scenarios' verdict is a fact about the
+        # RELEASE; whether this host came back up is a fact about the HOST, and conflating
+        # them would report a bad release for a local restart hiccup.
+        echo -e "${YELLOW}could not restart the dev stack — run: ./opentr.sh start dev${NC}" >&2
+    fi
+}
+# On EXIT so an aborted or failed scenario still puts the host back. INT/TERM too: a
+# Ctrl-C mid-rehearsal used to leave the operator's stack down with no hint why.
+trap restore_live_stack EXIT INT TERM
+
 if [[ -n "$live_stack_names" ]]; then
-    record live-stack-stopped fail "the live stack is running" "./opentr.sh stop"
-    echo -e "${RED}The live stack is running; the scenarios cannot run beside it.${NC}" >&2
-    echo -e "${YELLOW}  ./opentr.sh stop     # preserves all data${NC}" >&2
-    echo -e "${YELLOW}  (restart afterwards with ./opentr.sh start dev)${NC}" >&2
-    # Exit 3 (precondition unmet) as before. Deliberately BEFORE
-    # criteria_assert_all_checked: nothing ran, so the scenario criteria are genuinely
-    # unchecked, and reporting that as wiring drift would bury the real reason.
-    exit 3
+    # Automating the stop/restart dance, but NOT the decision. Taking someone's deployment
+    # down stays a human call -- it is just no longer a manual two-step. Approval comes from
+    # `--yes` (the pipeline's existing "I mean it" signal), an explicit
+    # RELEASE_AUTO_STOP_STACK=true, or an interactive prompt. With none of those and no tty,
+    # the original refusal stands, so an unattended caller can never silently stop a stack.
+    auto_stop=false
+    if [[ "${ASSUME_YES:-false}" == "true" || "${RELEASE_AUTO_STOP_STACK:-false}" == "true" ]]; then
+        auto_stop=true
+    elif [[ -t 0 ]]; then
+        echo -e "${YELLOW}The live stack is running; the scenarios cannot run beside it.${NC}" >&2
+        echo -e "${YELLOW}  $(echo "$live_stack_names" | wc -l) container(s). Stopping PRESERVES all data,${NC}" >&2
+        echo -e "${YELLOW}  and this run will restart it when the scenarios finish.${NC}" >&2
+        echo -e "${RED}  ⚠ Any transcription in flight will be interrupted.${NC}" >&2
+        read -r -p "Stop the stack, rehearse, then restart it? [y/N] " reply
+        [[ "$reply" == "y" || "$reply" == "Y" ]] && auto_stop=true
+    fi
+
+    if [[ "$auto_stop" != "true" ]]; then
+        record live-stack-stopped fail "the live stack is running" "./opentr.sh stop"
+        echo -e "${RED}The live stack is running; the scenarios cannot run beside it.${NC}" >&2
+        echo -e "${YELLOW}  ./opentr.sh stop     # preserves all data${NC}" >&2
+        echo -e "${YELLOW}  (restart afterwards with ./opentr.sh start dev)${NC}" >&2
+        echo -e "${YELLOW}  or re-run with --yes / RELEASE_AUTO_STOP_STACK=true to do both automatically${NC}" >&2
+        # Exit 3 (precondition unmet) as before. Deliberately BEFORE
+        # criteria_assert_all_checked: nothing ran, so the scenario criteria are genuinely
+        # unchecked, and reporting that as wiring drift would bury the real reason.
+        exit 3
+    fi
+
+    echo -e "${BLUE}Stopping the live stack (data preserved), will restart afterwards...${NC}" >&2
+    # ./opentr.sh stop, never docker kill/pkill: a SIGKILLed CUDA context does not always
+    # release the device, and that has required a full machine restart here twice.
+    if ! (cd "$REPO_ROOT" && ./opentr.sh stop >/dev/null 2>&1); then
+        record live-stack-stopped fail "./opentr.sh stop failed" "stop it by hand, then re-run"
+        echo -e "${RED}./opentr.sh stop failed; not proceeding.${NC}" >&2
+        exit 3
+    fi
+    STACK_STOPPED_BY_US=true
+
+    # Verify rather than trust: `stop` returning 0 is not the same as the ports being free,
+    # and the whole reason this precondition exists is that a survivor collides with the
+    # scenarios' stock names/ports minutes later, reported as a confusing port error.
+    still_up="$( {
+        docker ps --filter "label=com.docker.compose.project=${OPENTR_STOP_PROJECT_LABEL:-opentranscribe}" --format '{{.Names}}'
+        docker ps --filter "label=com.docker.compose.project=${OPENTR_STOP_PROJECT_LABEL_ALT:-transcribe-app}" --format '{{.Names}}'
+    } | sort -u)"
+    if [[ -n "$still_up" ]]; then
+        record live-stack-stopped fail "containers survived ./opentr.sh stop" "investigate: $still_up"
+        echo -e "${RED}Still running after stop: ${still_up}${NC}" >&2
+        exit 3
+    fi
+    echo -e "${GREEN}live stack stopped${NC}" >&2
 fi
 record live-stack-stopped pass
 


### PR DESCRIPTION
## What

The rehearsal has always refused to run beside a live stack and printed two commands for the operator to run by hand — stop, rehearse, start again. Correct, and a papercut **every single release**: the same two-step dance, and the stack left down afterwards whenever anyone forgot the second half.

This automates **the dance, not the decision.**

## Approval stays human

Taking someone's deployment down remains a human call. It just stops being manual. Approval is any of:

- **`--yes`** — the pipeline's existing "I mean it" signal
- **`RELEASE_AUTO_STOP_STACK=true`**
- **an interactive prompt** — which states plainly that data is preserved, that the stack will be restarted, and that anything transcribing **will be interrupted**

With none of those **and no tty**, the original refusal stands byte for byte, exit 3 included. That combination is the one that matters: a cron or CI caller can never silently take a deployment down.

## Safety properties, and how each is pinned

| Property | Why | Test |
|---|---|---|
| Unattended + no approval → refuse | a CI caller must not stop a deployment | executes the decision with stdin closed |
| Only literal `"true"` is consent | an exported `0`/empty must not approve | control case |
| Restart survives failure/Ctrl-C | that's when the operator least expects the stack to be down | `trap ... EXIT INT TERM` |
| Never restart a stack we didn't stop | starting one the operator deliberately stopped is its own surprise | `STACK_STOPPED_BY_US` guard |
| Never `pkill`/`kill -9` | a SIGKILLed CUDA context has required a full machine restart here **twice** | executable-line scan + guard-the-guard |

The stop is **verified, not trusted** — `opentr.sh stop` returning 0 is not the same as the containers being gone, and a survivor collides with the scenarios' stock names/ports minutes later, surfacing as a confusing port error rather than the real cause.

A restart failure **warns, never fails the stage**: whether the scenarios passed is a fact about the *release*; whether this host came back up is a fact about the *host*. Conflating them would report a bad release for a local hiccup.

## One of my own tests failed first, and that's worth recording

The "never reaches for kill" scan matched the **comment explaining why those commands are forbidden**. A detector that cannot tell code from prose would have forced the explanation to be deleted to stay green — precisely backwards. It now strips comment lines, and a guard-the-guard case proves the stripped scan still fires on a real call, because a scanner that matches nothing passes everything.

## Not covered — stated rather than implied

The scenarios themselves, and the restart actually succeeding, both need Docker and a real stack. **A green unit run here is not "the rehearsal is proven."** This PR's automation gets exercised for real by the v0.5.0 rehearsal.

## Test plan

- `pytest tests/unit/test_rehearse_stack_automation.py` → 8 passed
- `bash -n` + `shellcheck -S warning` on `65-rehearse.sh` → clean
- `audit-tests` → no un-allowlisted findings