### PR TITLE
fix(docker): MinIO deleted its Docker Hub images — pull from quay.io (v0.5.0 RELEASE BLOCKER)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -375,6 +375,25 @@ A tag was either yours alone or published to the whole deployment, so giving one
 
 ### Fixed
 
+- **Fresh installs could not start: MinIO deleted its Docker Hub images.** `minio/minio`
+  and `minio/mc` no longer exist on Docker Hub — the registry API returns `object not
+  found` for the repository and for the exact tag we pin, while anonymous pull tokens are
+  still issued normally, so this is a removal rather than a rate limit. Any host without a
+  warm image cache — i.e. **every new install** — failed with `pull access denied`.
+  Existing deployments kept working only until someone pruned their images, which is why
+  nothing surfaced it until the release rehearsal's fresh-install scenario ran on a clean
+  host. The object store now pulls from **`quay.io/minio/minio`**, at the same pinned tag
+  and the same digest
+  (`sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e`) — the
+  identical artifact, not a substitute, verified by pulling both and comparing. The
+  offline-install bundle and its uninstaller were repointed too; a bundle that pre-pulls a
+  deleted image produces a tarball silently missing the object store.
+  ⚠️ **No action needed on upgrade** — compose pulls the new reference on the next
+  `./opentr.sh start`, and existing data is untouched. Note for planning: the tag we pin,
+  `RELEASE.2025-09-07T16-13-09Z`, appears to be the **final community release** — every
+  newer tag upstream is a `.hotfix.*` build — so this pin will not receive further upstream
+  updates, and an S3-compatible replacement is being evaluated for a future release.
+
 - **Summary search ignored every filter, had no ranking, and broke `result_type=all`
   pagination** (#831). The Summaries tab applied **none** of the ten filter dimensions the
   Transcripts tab honours, so one request's two legs disagreed about which files the caller had

--- a/README-OFFLINE.md
+++ b/README-OFFLINE.md
@@ -597,7 +597,7 @@ sudo rm -rf /opt/opentranscribe
 docker rmi davidamacey/opentranscribe-backend:latest
 docker rmi davidamacey/opentranscribe-frontend:latest
 docker rmi postgres:17.5-alpine redis:8.2.2-alpine3.22
-docker rmi minio/minio:RELEASE.2025-09-07T16-13-09Z
+docker rmi quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
 docker rmi opensearchproject/opensearch:3.4.0
 ```
 

--- a/backend/tests/unit/test_minio_image_registry.py
+++ b/backend/tests/unit/test_minio_image_registry.py
@@ -1,0 +1,89 @@
+"""No compose service may pull MinIO from Docker Hub — the images are gone.
+
+MinIO **removed** `minio/minio` and `minio/mc` from Docker Hub. This is not a rate
+limit and not a transient outage: the Hub API returns `object not found` for the
+repository and for our exact pinned tag, while an anonymous pull token is still
+issued normally. `docker pull minio/minio` fails with `pull access denied ...
+repository does not exist`.
+
+The blast radius is every NEW user. An existing host with a warm image cache keeps
+working — right up until someone prunes — so this is invisible in day-to-day
+development and fatal to a fresh install. The v0.5.0 release rehearsal's
+fresh-install scenario is what caught it; nothing else in the pipeline pulls.
+
+The images are on quay.io, and it is the SAME artifact rather than a substitute:
+`quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z` resolves to digest
+`sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e`,
+byte-identical to the docker.io copy cached on the build host. Verified by pulling
+both and comparing, not by assuming two registries agree.
+
+This test is deliberately OFFLINE. A test that pulls would be slow, would fail in
+CI's sandbox for the wrong reason, and would turn a registry outage into a red gate.
+What it pins is the thing under our control: nothing asks Docker Hub for MinIO.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+#: Docker resolves an unqualified `minio/...` to docker.io, where it no longer exists.
+_DOCKER_HUB_MINIO = re.compile(r"^\s*image:\s*[\"']?(minio/[^\s\"']+)")
+
+
+def _compose_files() -> list[Path]:
+    return sorted(REPO_ROOT.glob("docker-compose*.yml"))
+
+
+def test_there_are_compose_files_to_scan():
+    """GUARD THE GUARD: a glob that matches nothing would pass every test below."""
+    assert _compose_files(), f"no docker-compose*.yml found under {REPO_ROOT}"
+
+
+def test_no_compose_service_pulls_minio_from_docker_hub():
+    """THE property. An unqualified `minio/...` image is an unpullable image."""
+    offenders: list[str] = []
+    for path in _compose_files():
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if line.lstrip().startswith("#"):
+                continue  # the explanatory comment names the dead path on purpose
+            match = _DOCKER_HUB_MINIO.match(line)
+            if match:
+                offenders.append(f"{path.name}:{lineno} -> {match.group(1)}")
+
+    assert not offenders, (
+        "these resolve to docker.io, where MinIO deleted the repository — a fresh "
+        f"install cannot pull them: {offenders}. Use quay.io/minio/... instead."
+    )
+
+
+def test_the_detector_actually_fires_on_the_shape_it_guards():
+    """Without this, a typo in the regex makes the test above vacuously green."""
+    assert _DOCKER_HUB_MINIO.match("    image: minio/minio:RELEASE.2025-09-07T16-13-09Z")
+    assert _DOCKER_HUB_MINIO.match('    image: "minio/mc:latest"')
+    # quay-qualified must NOT match, or the fix could never satisfy the test
+    assert _DOCKER_HUB_MINIO.match("    image: quay.io/minio/minio:RELEASE.x") is None
+
+
+def test_the_object_store_is_still_pinned_not_floating():
+    """A registry move is not licence to drop the pin.
+
+    Re-pointing a tag while loosening it would swap one supply-chain problem for
+    another: `:latest` on a new registry is strictly worse than a dead pin, because
+    it fails silently and differently on every host.
+    """
+    compose = (REPO_ROOT / "docker-compose.yml").read_text(encoding="utf-8")
+
+    minio_images = re.findall(r"^\s*image:\s*(\S*minio/minio\S*)", compose, re.MULTILINE)
+    assert minio_images, "docker-compose.yml declares no minio image at all"
+    for image in minio_images:
+        assert ":" in image.rsplit("/", 1)[-1], f"{image} carries no tag"
+        assert not image.endswith(":latest"), (
+            f"{image} floats on :latest — pin the RELEASE tag, as every other image here is"
+        )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,18 @@ services:
 
   minio:
     container_name: opentranscribe-minio
-    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    # ⚠️ quay.io, NOT docker.io. MinIO REMOVED `minio/minio` from Docker Hub — the Hub API
+    # returns `object not found` for the repository AND for this exact tag, while an
+    # anonymous pull token is still issued normally, so it is a removal and not a rate
+    # limit. `minio/mc` is gone the same way. Anyone without a warm image cache — i.e.
+    # every NEW user running the install one-liner — got `pull access denied` and a failed
+    # install. Caught by the v0.5.0 release rehearsal; nothing else in the pipeline looks.
+    #
+    # Same artifact, not a substitute: this tag on quay.io resolves to digest
+    # sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e, byte-identical
+    # to the docker.io copy already cached on the build host, as a 3-child multi-arch list.
+    # Verified by pulling both and comparing, not by assuming the registries agree.
+    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
     restart: always
     env_file:
       - path: .env

--- a/docs-site/docs/installation/offline-installation.md
+++ b/docs-site/docs/installation/offline-installation.md
@@ -43,7 +43,7 @@ docker pull davidamacey/opentranscribe-backend:latest
 docker pull davidamacey/opentranscribe-frontend:latest
 docker pull postgres:17.5-alpine
 docker pull redis:8.2.2-alpine3.22
-docker pull minio/minio:RELEASE.2025-09-07T16-13-09Z
+docker pull quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
 docker pull opensearchproject/opensearch:3.4.0
 
 # Save images to tarball
@@ -52,7 +52,7 @@ docker save -o opentranscribe-images.tar \
   davidamacey/opentranscribe-frontend:latest \
   postgres:17.5-alpine \
   redis:8.2.2-alpine3.22 \
-  minio/minio:RELEASE.2025-09-07T16-13-09Z \
+  quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z \
   opensearchproject/opensearch:3.4.0
 ```
 

--- a/docs-site/docs/operations/backup-restore.md
+++ b/docs-site/docs/operations/backup-restore.md
@@ -454,7 +454,7 @@ MinIO stores all uploaded media files. Back up using the MinIO Client (`mc`):
 
 ```bash
 # Install mc (if not already available)
-docker run --rm -it --entrypoint /bin/sh minio/mc
+docker run --rm -it --entrypoint /bin/sh quay.io/minio/mc
 
 # Or use mc from within the MinIO container
 docker compose exec minio mc alias set local http://localhost:9000 $MINIO_ROOT_USER $MINIO_ROOT_PASSWORD

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -179,7 +179,7 @@ export HUGGINGFACE_TOKEN=your_token_here
    - `davidamacey/opentranscribe-frontend:latest` (~51MB)
    - `postgres:14-alpine` (~220MB)
    - `redis:7-alpine` (~30MB)
-   - `minio/minio:latest` (~175MB)
+   - `quay.io/minio/minio` (~175MB)
    - `opensearchproject/opensearch:3.4.0` (~800MB)
 3. **Downloads** AI models (~38GB):
    - WhisperX models (~1.5GB)

--- a/scripts/uninstall-offline-package.sh
+++ b/scripts/uninstall-offline-package.sh
@@ -266,7 +266,7 @@ remove_images() {
     echo "  - davidamacey/opentranscribe-frontend:latest (~100MB)"
     echo "  - postgres:17.5-alpine"
     echo "  - redis:8.2.2-alpine3.22"
-    echo "  - minio/minio:RELEASE.2025-09-07T16-13-09Z"
+    echo "  - quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z"
     echo "  - opensearchproject/opensearch:3.4.0"
     echo ""
     echo "Note: Removing images will require re-loading them if you reinstall"
@@ -288,7 +288,7 @@ remove_images() {
         "davidamacey/opentranscribe-docs:latest"
         "postgres:17.5-alpine"
         "redis:8.2.2-alpine3.22"
-        "minio/minio:RELEASE.2025-09-07T16-13-09Z"
+        "quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z"
         "opensearchproject/opensearch:3.4.0"
     )
 


### PR DESCRIPTION
## 🚨 Release blocker for v0.5.0 — every *new* user is broken, and no *existing* user could notice

`minio/minio` and `minio/mc` **no longer exist on Docker Hub.**

This is a **removal**, not a rate limit and not an outage — checked rather than assumed:

| Probe | Result |
|---|---|
| Anonymous pull token | ✅ issued normally |
| Hub API — repository | ❌ `object not found` |
| Hub API — our exact pinned tag | ❌ `object not found` |
| `docker pull minio/minio` | ❌ `pull access denied ... repository does not exist` |

## Why it was invisible

A host with a warm image cache keeps working **indefinitely** — right up until someone prunes. So every developer machine and every running deployment looked fine, while `./opentranscribe.sh` on a clean host could not get past pulling the object store.

The failure mode is *"new users cannot install"* — precisely the population least able to report it.

**The release rehearsal's fresh-install scenario is what caught this.** Nothing else in the pipeline pulls images onto a cold host, which is the entire argument for that scenario existing. Scenarios B and C then failed on `port 5175 already in use` — a **cascade** from A's half-started stack, not three independent bugs.

## The fix — the same artifact, not a substitute

`quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z` resolves to

```
sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
```

**byte-identical** to the docker.io copy already cached on the build host, as a 3-child multi-arch manifest list. Verified by pulling both and comparing digests — not by assuming two registries agree about a tag. The pin is unchanged, deliberately.

### Verified running, not merely pulled

- minio recreated from the quay image → **healthy**
- `/minio/health/live` → **200**
- backend `/health` → **200**
- `minio_client.list_buckets()` from inside the backend container → `['opentranscribe', 'processed-videos']`, objects readable

Existing data survives the swap.

## Scope — 7 references across 6 files

`docker-compose.yml` is the critical one. The **offline-install bundle and its uninstaller** matter more than they look: a bundle that pre-pulls a deleted image produces a tarball that silently omits the object store.

## The guard

`test_minio_image_registry.py` fails on any compose `image:` resolving to an unqualified `minio/...`, carries a guard-the-guard case so a broken regex can't pass everything, and **asserts the image stays pinned**.

That last one matters: re-pointing a tag while loosening it to `:latest` would swap one supply-chain problem for a worse one — a dead pin fails loudly and identically everywhere, a floating tag fails silently and *differently* on every host.

Deliberately **offline**. A test that pulls would be slow, would fail in CI's sandbox for the wrong reason, and would turn someone else's registry outage into our red gate. It pins the part under our control: nothing asks Docker Hub for MinIO.

**Red-checked** against `origin/master` with only the test copied in: FAILED there, passes here.